### PR TITLE
perf(hgraph): parallelize cold build encoding

### DIFF
--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -444,8 +444,10 @@ private:
     [[nodiscard]] bool
     need_temporary_sq8_build_data_for_add() const;
 
-    void
-    prepare_build_codes(const DatasetPtr& data, const Vector<AddRow>& rows);
+    [[nodiscard]] bool
+    prepare_build_codes(const DatasetPtr& data,
+                        const Vector<AddRow>& rows,
+                        const AddContext& context);
 
     [[nodiscard]] bool
     should_insert_codes_before_probe(bool use_dedup_storage) const;
@@ -489,7 +491,10 @@ private:
     graph_read_codes_is_temporary(const AddContext& context) const;
 
     bool
-    insert_one_logical_point(const void* data, const AddRow& row, const AddContext& context);
+    insert_one_logical_point(const void* data,
+                             const AddRow& row,
+                             const AddContext& context,
+                             bool persistent_codes_prepared);
 
     void
     prepare_codes_before_probe_if_needed(const void* data,

--- a/src/algorithm/hgraph/hgraph_add_test.cpp
+++ b/src/algorithm/hgraph/hgraph_add_test.cpp
@@ -1242,6 +1242,49 @@ TEST_CASE("HGraph deduplicate_storage rejects unsupported graph type",
     REQUIRE_THROWS(MakeHGraphIndex(hgraph_json, common_param));
 }
 
+TEST_CASE("HGraph parallel cold build keeps RaBitQ and SQ8 codes searchable",
+          "[ut][hgraph][parallel][build]") {
+    constexpr int64_t dim = 32;
+    constexpr int64_t count = 2048;
+    constexpr uint64_t build_threads = 8;
+
+    auto hgraph_json = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "rabitq",
+        "precise_quantization_type": "sq8",
+        "rabitq_bits_per_dim_base": 3,
+        "use_reorder": true,
+        "build_by_base": false,
+        "max_degree": 8,
+        "ef_construction": 32,
+        "build_thread_count": 8
+    })");
+    auto index = MakeHGraphIndex(hgraph_json, MakeCommonParam(dim, build_threads));
+
+    std::vector<float> vectors(dim * count);
+    std::vector<int64_t> ids(count);
+    for (int64_t i = 0; i < count; ++i) {
+        ids[i] = i;
+        for (int64_t d = 0; d < dim; ++d) {
+            const int64_t value =
+                ((i + 1) * (d + 3) * 7919 + i * i * 104729 + d * d * 1543) % 1000003;
+            vectors[i * dim + d] = static_cast<float>(value) / 1000003.0F;
+        }
+    }
+
+    auto base = MakeFloatDataset(vectors, ids, dim, count);
+    auto build_result = index->Build(base);
+    REQUIRE(build_result.has_value());
+    REQUIRE(build_result.value().empty());
+
+    for (int64_t i = 0; i < count; i += 257) {
+        std::vector<float> query_vector(vectors.begin() + i * dim, vectors.begin() + (i + 1) * dim);
+        auto result = index->KnnSearch(
+            MakeFloatQuery(query_vector, dim), 1, R"({"hgraph": {"ef_search": 128}})");
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetIds()[0] == ids[i]);
+    }
+}
+
 TEST_CASE("HGraph optimized build accepts MRLE RaBitQ split with raw-vector storage",
           "[ut][hgraph][optimized_build][MRLE]") {
     constexpr int64_t dim = 64;

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -465,7 +465,7 @@ HGraph::insert_add_batch(const DatasetPtr& data, const AddContext& context, cons
     std::vector<std::future<void>> futures;
     HGraphBuildTaskGuard future_guard(
         futures, context.use_parallel_add ? static_cast<uint64_t>(batch.rows.size()) : 0);
-    this->prepare_build_codes(data, batch.rows);
+    const bool persistent_codes_prepared = this->prepare_build_codes(data, batch.rows, context);
 
     const auto* extra_infos = data->GetExtraInfos();
     const auto* attr_sets = data->GetAttributeSets();
@@ -480,7 +480,7 @@ HGraph::insert_add_batch(const DatasetPtr& data, const AddContext& context, cons
         if (attrs != nullptr and this->use_attribute_filter_) {
             this->attr_filter_index_->Insert(*attrs, row.inner_id);
         }
-        this->insert_one_logical_point(vector_data, row, context);
+        this->insert_one_logical_point(vector_data, row, context, persistent_codes_prepared);
     };
 
     for (const auto& row : batch.rows) {
@@ -547,10 +547,15 @@ HGraph::insert_persistent_codes_to_slot(const void* data, CodeSlotIdType code_sl
 // the probe result by binding deduplicated storage, updating duplicate tracking, or inserting a
 // unique point into the graph.
 bool
-HGraph::insert_one_logical_point(const void* data, const AddRow& row, const AddContext& context) {
+HGraph::insert_one_logical_point(const void* data,
+                                 const AddRow& row,
+                                 const AddContext& context,
+                                 bool persistent_codes_prepared) {
     const auto inner_id = row.inner_id;
     const auto level = row.level;
-    this->prepare_codes_before_probe_if_needed(data, inner_id, context);
+    if (not persistent_codes_prepared) {
+        this->prepare_codes_before_probe_if_needed(data, inner_id, context);
+    }
 
     auto make_search_param = [&]() {
         InnerSearchParam param;

--- a/src/algorithm/hgraph/hgraph_fast_build.cpp
+++ b/src/algorithm/hgraph/hgraph_fast_build.cpp
@@ -131,33 +131,69 @@ HGraph::need_temporary_sq8_build_data_for_add() const {
            this->basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_RABITQ;
 }
 
-void
-HGraph::prepare_build_codes(const DatasetPtr& data, const Vector<AddRow>& rows) {
-    if (this->optimized_build_codes_ == nullptr) {
-        return;
-    }
-
-    if (this->thread_pool_ == nullptr) {
-        for (const auto& row : rows) {
-            this->insert_persistent_codes(get_data(data, row.input_idx), row.inner_id);
+bool
+HGraph::prepare_build_codes(const DatasetPtr& data,
+                            const Vector<AddRow>& rows,
+                            const AddContext& context) {
+    if (this->optimized_build_codes_ != nullptr) {
+        if (this->thread_pool_ == nullptr) {
+            for (const auto& row : rows) {
+                this->insert_persistent_codes(get_data(data, row.input_idx), row.inner_id);
+            }
+            return true;
         }
-        return;
+
+        std::vector<std::future<void>> futures;
+        HGraphBuildTaskGuard task_guard(futures, static_cast<uint64_t>(rows.size()));
+        // Parallel graph insertion may probe rows from the same batch. Make every scalar code
+        // visible before any of those probes starts.
+        for (const auto& row : rows) {
+            const auto inner_id = row.inner_id;
+            const auto input_idx = row.input_idx;
+            futures.emplace_back(
+                this->thread_pool_->GeneralEnqueue([this, data, inner_id, input_idx]() {
+                    this->insert_persistent_codes(get_data(data, input_idx), inner_id);
+                }));
+        }
+        wait_all_futures(futures);
+        futures.clear();
+        return true;
     }
 
+    const auto row_count = static_cast<uint64_t>(rows.size());
+    const bool use_parallel_encode =
+        context.first_empty_add && not context.use_dedup_storage &&
+        not this->support_force_remove() && this->thread_pool_ != nullptr &&
+        this->build_thread_count_ > 1 && row_count > 1 && this->has_precise_reorder() &&
+        not this->build_by_base_ && not this->create_new_raw_vector_ &&
+        this->basic_flatten_codes_->InMemory() && this->high_precise_codes_->InMemory() &&
+        this->basic_flatten_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_RABITQ &&
+        this->high_precise_codes_->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_SQ8;
+    if (not use_parallel_encode) {
+        return false;
+    }
+
+    const uint64_t worker_count = std::min(this->build_thread_count_, row_count);
+    const uint64_t block_size = (row_count + worker_count - 1) / worker_count;
     std::vector<std::future<void>> futures;
-    HGraphBuildTaskGuard task_guard(futures, static_cast<uint64_t>(rows.size()));
-    // Parallel graph insertion may probe rows from the same batch. Make every scalar code
-    // visible before any of those probes starts.
-    for (const auto& row : rows) {
-        const auto inner_id = row.inner_id;
-        const auto input_idx = row.input_idx;
-        futures.emplace_back(
-            this->thread_pool_->GeneralEnqueue([this, data, inner_id, input_idx]() {
-                this->insert_persistent_codes(get_data(data, input_idx), inner_id);
-            }));
+    HGraphBuildTaskGuard task_guard(futures, worker_count);
+
+    // prepare_add_batch() already resized both layouts. The workers only encode disjoint IDs;
+    // these outer locks keep storage stable until every worker finishes.
+    std::shared_lock<std::shared_mutex> add_lock(this->add_mutex_);
+    std::unique_lock<std::shared_mutex> codes_lock(this->persistent_codes_mutex_);
+    for (uint64_t begin = 0; begin < row_count; begin += block_size) {
+        const uint64_t end = std::min(begin + block_size, row_count);
+        futures.emplace_back(this->thread_pool_->GeneralEnqueue([this, data, &rows, begin, end]() {
+            for (uint64_t offset = begin; offset < end; ++offset) {
+                const auto& row = rows[offset];
+                this->insert_persistent_codes_unlocked(get_data(data, row.input_idx), row.inner_id);
+            }
+        }));
     }
     wait_all_futures(futures);
     futures.clear();
+    return true;
 }
 
 bool


### PR DESCRIPTION
## Summary

- Pre-encode persistent RaBitQ base and SQ8 precise codes before parallel NSW graph insertion.
- Use a fixed number of contiguous worker blocks instead of per-vector encoding tasks.
- Skip the per-row pre-probe code insertion after the batch has been prepared.
- Preserve the existing path for incremental Add, deduplicated storage, force-remove, raw-vector, non-memory, and other quantization configurations.

## Why

The reference SIFT1M build configured 96 threads but averaged 41.452 active cores. Profiling and ablation identified cold-build RaBitQ/SQ8 encoding as a material serialized stage before graph insertion.

## Benchmark

Reference configuration: SIFT1M, L2, RaBitQ 3-bit base + SQ8 precise reorder, NSW, flat graph storage, `max_degree=64`, `ef_construction=400`, `alpha=1.0`, 96 pinned build threads.

| Metric | Upstream baseline | Parallel pre-encoding ablation |
| --- | ---: | ---: |
| Build wall | 64.457 s (3-run mean) | 39.204 s (confirmation run) |
| Average active cores | 41.452 | 89.158 |
| Whole-machine CPU utilization | 43.180% | 92.873% |
| Throughput | 15,515 vec/s | 25,508 vec/s |
| Memory | 0.582 GiB | 0.582 GiB |
| Recall@10 | 0.980 | 0.981 |
| Self-nearest checks | passed | 10/10 |

The confirmation run reduces wall time by 39.2% with unchanged reported memory and recall within 0.001. It is reported as a single retained-optimization ablation rather than a three-run mean.

## Validation

- `clang-format-15 --dry-run --Werror` on all changed C++ files
- `clang-tidy-15 -p build --quiet` on `hgraph_build.cpp` and `hgraph_fast_build.cpp`
- `build/tests/unittests "[ut][hgraph]" -r compact`: 41 cases, 389 assertions passed
- New RaBitQ 3-bit + SQ8 parallel cold-build regression: 1 case, 18 assertions passed
- Existing MRLE optimized-build regression passed
- `git diff --check`

## Scope and compatibility

No public API, serialization format, search path, Pyramid code, or third-party dependency changes. Unsupported configurations retain the existing encoding/insertion behavior.

Closes: #2749