### PR TITLE
[0.18] fix(pyramid): align raw vector retrieval with HGraph

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -463,6 +463,9 @@ DatasetPtr
 InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
                                           int64_t count,
                                           uint64_t selected_data_flag) const {
+    if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U && not this->has_raw_vector_) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "has_raw_vector_ is false");
+    }
     auto* inner_ids =
         reinterpret_cast<InnerIdType*>(this->allocator_->Allocate(count * sizeof(InnerIdType)));
     {
@@ -476,9 +479,6 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
     auto dataset = Dataset::Make();
     dataset->NumElements(count)->Dim(dim_)->Owner(true, allocator_);
     if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U) {
-        if (not this->has_raw_vector_) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT, "has_raw_vector_ is false");
-        }
         auto* fp32_data = reinterpret_cast<float*>(
             this->allocator_->Allocate(count * this->dim_ * sizeof(float)));
         dataset->Float32Vectors(fp32_data);

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -214,11 +214,16 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
     const auto* data_ids = base->GetIds();
 
     resize(data_num);
-    std::memcpy(label_table_->label_table_.data(), data_ids, sizeof(LabelType) * data_num);
+    for (InnerIdType inner_id = 0; inner_id < data_num; ++inner_id) {
+        label_table_->Insert(inner_id, data_ids[inner_id]);
+    }
 
     base_codes_->BatchInsertVector(data_vectors, data_num);
     if (use_reorder_) {
         precise_codes_->BatchInsertVector(data_vectors, data_num);
+    }
+    if (create_new_raw_vector_) {
+        raw_vector_->BatchInsertVector(data_vectors, data_num);
     }
     auto codes = use_reorder_ ? precise_codes_ : base_codes_;
 
@@ -423,6 +428,9 @@ Pyramid::Serialize(StreamWriter& writer) const {
     if (use_reorder_) {
         precise_codes_->Serialize(writer);
     }
+    if (create_new_raw_vector_) {
+        raw_vector_->Serialize(writer);
+    }
     root_->Serialize(writer);
 
     // serialize footer (introduced since v0.15)
@@ -449,6 +457,9 @@ Pyramid::Deserialize(StreamReader& reader) {
     base_codes_->Deserialize(buffer_reader);
     if (use_reorder_) {
         precise_codes_->Deserialize(buffer_reader);
+    }
+    if (create_new_raw_vector_) {
+        raw_vector_->Deserialize(buffer_reader);
     }
     cur_element_count_ = base_codes_->TotalCount();
     root_->Deserialize(buffer_reader);
@@ -506,6 +517,10 @@ Pyramid::Add(const DatasetPtr& base) {
                 if (use_reorder_) {
                     precise_codes_->InsertVector(data_vectors + dim_ * i,
                                                  valid_id_count + local_cur_element_count);
+                }
+                if (create_new_raw_vector_) {
+                    raw_vector_->InsertVector(data_vectors + dim_ * i,
+                                              valid_id_count + local_cur_element_count);
                 }
                 valid_id_count++;
                 data_biases.push_back(i);
@@ -570,6 +585,9 @@ Pyramid::resize(int64_t new_max_capacity) {
     if (use_reorder_) {
         precise_codes_->Resize(new_max_capacity);
     }
+    if (create_new_raw_vector_) {
+        raw_vector_->Resize(new_max_capacity);
+    }
     points_mutex_->Resize(new_max_capacity);
     max_capacity_ = new_max_capacity;
 }
@@ -617,6 +635,13 @@ Pyramid::InitFeatures() {
         IndexFeature::SUPPORT_EXPORT_MODEL,
         IndexFeature::SUPPORT_GET_MEMORY_USAGE,
     });
+    const auto& retrieval_codes = use_reorder_ ? precise_codes_ : base_codes_;
+    const bool can_decode_exact_vector =
+        retrieval_codes->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32 &&
+        (metric_ != MetricType::METRIC_TYPE_COSINE || retrieval_codes->HoldMolds());
+    if (can_decode_exact_vector || raw_vector_ != nullptr) {
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS);
+    }
 }
 
 static const std::string HGRAPH_PARAMS_TEMPLATE =
@@ -672,6 +697,18 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{HOLD_MOLDS}": false
             }
         },
+        "{STORE_RAW_VECTOR_KEY}": false,
+        "{RAW_VECTOR_KEY}": {
+            "{IO_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
+            },
+            "{CODES_TYPE_KEY}": "flatten",
+            "{QUANTIZATION_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{HOLD_MOLDS}": true
+            }
+        },
         "{BUILD_THREAD_COUNT_KEY}": 1,
         "{EF_CONSTRUCTION_KEY}": 400,
         "{NO_BUILD_LEVELS}":[],
@@ -686,6 +723,7 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
         {PYRAMID_EF_CONSTRUCTION, {EF_CONSTRUCTION_KEY}},
         {PYRAMID_USE_REORDER, {USE_REORDER_KEY}},
         {PYRAMID_BASE_QUANTIZATION_TYPE, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, TYPE_KEY}},
+        {STORE_RAW_VECTOR, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, HOLD_MOLDS}},
         {PYRAMID_RABITQ_BITS_PER_DIM_BASE,
          {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, RABITQ_QUANTIZATION_BITS_PER_DIM_BASE_KEY}},
         {PYRAMID_RABITQ_BITS_PER_DIM_QUERY,
@@ -693,6 +731,8 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
         {PYRAMID_RABITQ_PCA_DIM, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, PCA_DIM_KEY}},
         {PYRAMID_RABITQ_USE_FHT, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, USE_FHT_KEY}},
         {PYRAMID_PRECISE_QUANTIZATION_TYPE, {PRECISE_CODES_KEY, QUANTIZATION_PARAMS_KEY, TYPE_KEY}},
+        {STORE_RAW_VECTOR, {PRECISE_CODES_KEY, QUANTIZATION_PARAMS_KEY, HOLD_MOLDS}},
+        {STORE_RAW_VECTOR, {STORE_RAW_VECTOR_KEY}},
         {PYRAMID_GRAPH_MAX_DEGREE, {GRAPH_KEY, GRAPH_PARAM_MAX_DEGREE_KEY}},
         {PYRAMID_BASE_IO_TYPE, {BASE_CODES_KEY, IO_PARAMS_KEY, TYPE_KEY}},
         {PYRAMID_BUILD_ALPHA, {GRAPH_KEY, ODESCENT_PARAMETER_ALPHA}},
@@ -726,6 +766,9 @@ Pyramid::Train(const DatasetPtr& base) {
     this->base_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
     if (use_reorder_) {
         this->precise_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
+    }
+    if (create_new_raw_vector_) {
+        this->raw_vector_->Train(base->GetFloat32Vectors(), base->GetNumElements());
     }
 }
 std::vector<int64_t>
@@ -915,6 +958,9 @@ Pyramid::CalcDistanceById(const float* query, int64_t id) const {
     if (use_reorder_) {
         flat = this->precise_codes_;
     }
+    if (create_new_raw_vector_) {
+        flat = this->raw_vector_;
+    }
     return InnerIndexInterface::calc_distance_by_id(query, id, flat);
 }
 
@@ -925,6 +971,52 @@ Pyramid::CalDistanceById(const float* query, const int64_t* ids, int64_t count) 
     if (use_reorder_) {
         flat = this->precise_codes_;
     }
+    if (create_new_raw_vector_) {
+        flat = this->raw_vector_;
+    }
     return InnerIndexInterface::cal_distance_by_id(query, ids, count, flat);
+}
+
+void
+Pyramid::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
+    std::shared_lock<std::shared_mutex> lock(resize_mutex_);
+    auto codes = use_reorder_ ? precise_codes_ : base_codes_;
+    if (create_new_raw_vector_) {
+        codes = raw_vector_;
+    }
+    bool release = false;
+    const auto* buffer = codes->GetCodesById(inner_id, release);
+    if (buffer == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("failed to get vector by inner id {}", inner_id));
+    }
+    const bool decoded = codes->Decode(buffer, data);
+    if (release) {
+        codes->Release(buffer);
+    }
+    if (not decoded) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("failed to decode vector by inner id {}", inner_id));
+    }
+}
+
+void
+Pyramid::check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
+                                   const IndexCommonParam& common_param) {
+    if (raw_vector_param == nullptr) {
+        return;
+    }
+
+    const auto& retrieval_codes = use_reorder_ ? precise_codes_ : base_codes_;
+    const auto io_type_name = raw_vector_param->io_parameter->GetTypeName();
+    const bool is_memory_io =
+        io_type_name == IO_TYPE_VALUE_BLOCK_MEMORY_IO || io_type_name == IO_TYPE_VALUE_MEMORY_IO;
+    if (retrieval_codes->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32 && is_memory_io) {
+        raw_vector_ = retrieval_codes;
+    } else {
+        raw_vector_ = FlattenInterface::MakeInstance(raw_vector_param, common_param);
+        create_new_raw_vector_ = true;
+    }
+    has_raw_vector_ = true;
 }
 }  // namespace vsag

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -117,6 +117,7 @@ public:
                 FlattenInterface::MakeInstance(pyramid_param->precise_codes_param, common_param);
             reorder_ = std::make_shared<FlattenReorder>(precise_codes_, allocator_);
         }
+        check_and_init_raw_vector(pyramid_param->raw_vector_param, common_param);
     }
 
     explicit Pyramid(const ParamPtr& param, const IndexCommonParam& common_param)
@@ -185,7 +186,14 @@ public:
     void
     Train(const vsag::DatasetPtr& base) override;
 
+    void
+    GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
+
 private:
+    void
+    check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
+                              const IndexCommonParam& common_param);
+
     void
     resize(int64_t new_max_capacity);
 
@@ -229,6 +237,8 @@ private:
     std::shared_ptr<IndexNode> root_{nullptr};
     FlattenInterfacePtr base_codes_{nullptr};
     FlattenInterfacePtr precise_codes_{nullptr};
+    FlattenInterfacePtr raw_vector_{nullptr};
+    bool create_new_raw_vector_{false};
     std::unique_ptr<VisitedListPool> pool_ = nullptr;
 
     MutexArrayPtr points_mutex_{nullptr};

--- a/src/algorithm/pyramid_test.cpp
+++ b/src/algorithm/pyramid_test.cpp
@@ -15,7 +15,98 @@
 
 #include "algorithm/pyramid.h"
 
+#include <array>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include "impl/allocator/safe_allocator.h"
+#include "index/index_impl.h"
+
+namespace {
+
+constexpr int64_t PYRAMID_RAW_VECTOR_TEST_DIM = 4;
+
+std::shared_ptr<vsag::Index>
+MakePyramidRawVectorTestIndex(const std::string& graph_type,
+                              bool use_reorder,
+                              vsag::MetricType metric,
+                              const std::string& base_quantization_type = "fp32",
+                              const std::string& precise_quantization_type = "fp32",
+                              bool store_raw_vector = false) {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = PYRAMID_RAW_VECTOR_TEST_DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = metric;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+
+    auto external_param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "precise_quantization_type": "fp32",
+        "use_reorder": false,
+        "max_degree": 4,
+        "ef_construction": 8,
+        "graph_type": "nsw",
+        "no_build_levels": [0, 1],
+        "index_min_size": 0,
+        "store_raw_vector": false
+    })");
+    external_param[vsag::PYRAMID_GRAPH_TYPE].SetString(graph_type);
+    external_param[vsag::PYRAMID_USE_REORDER].SetBool(use_reorder);
+    external_param[vsag::PYRAMID_BASE_QUANTIZATION_TYPE].SetString(base_quantization_type);
+    external_param[vsag::PYRAMID_PRECISE_QUANTIZATION_TYPE].SetString(precise_quantization_type);
+    external_param[vsag::STORE_RAW_VECTOR].SetBool(store_raw_vector);
+    return std::make_shared<vsag::IndexImpl<vsag::Pyramid>>(external_param, common_param);
+}
+
+vsag::DatasetPtr
+MakePyramidRawVectorTestDataset(const float* vectors,
+                                const int64_t* ids,
+                                const std::string* paths,
+                                int64_t count) {
+    return vsag::Dataset::Make()
+        ->NumElements(count)
+        ->Dim(PYRAMID_RAW_VECTOR_TEST_DIM)
+        ->Float32Vectors(vectors)
+        ->Ids(ids)
+        ->Paths(paths)
+        ->Owner(false);
+}
+
+void
+RequireRawVectors(const vsag::IndexPtr& index,
+                  const int64_t* ids,
+                  int64_t count,
+                  const float* expected) {
+    auto result = index->GetRawVectorByIds(ids, count);
+    REQUIRE(result.has_value());
+    REQUIRE(std::equal(result.value()->GetFloat32Vectors(),
+                       result.value()->GetFloat32Vectors() + count * PYRAMID_RAW_VECTOR_TEST_DIM,
+                       expected));
+}
+
+void
+RequireStoredRawVectors(const vsag::IndexPtr& index,
+                        const int64_t* ids,
+                        int64_t count,
+                        const float* expected) {
+    auto data_result = index->GetDataByIds(ids, count);
+    REQUIRE(data_result.has_value());
+    REQUIRE(std::equal(data_result.value()->GetIds(), data_result.value()->GetIds() + count, ids));
+    REQUIRE(
+        std::equal(data_result.value()->GetFloat32Vectors(),
+                   data_result.value()->GetFloat32Vectors() + count * PYRAMID_RAW_VECTOR_TEST_DIM,
+                   expected));
+
+    auto flagged_result =
+        index->GetDataByIdsWithFlag(ids, count, DATA_FLAG_ID | DATA_FLAG_FLOAT32_VECTOR);
+    REQUIRE(flagged_result.has_value());
+    REQUIRE(std::equal(
+        flagged_result.value()->GetFloat32Vectors(),
+        flagged_result.value()->GetFloat32Vectors() + count * PYRAMID_RAW_VECTOR_TEST_DIM,
+        expected));
+}
+
+}  // namespace
 
 #include "impl/allocator/safe_allocator.h"
 #include "vsag_exception.h"
@@ -84,4 +175,142 @@ TEST_CASE("Pyramid ExportModel rejects inconsistent reorder configuration",
         REQUIRE(std::string(exception.what()) ==
                 "Export model's pyramid reorder config mismatched");
     }
+}
+
+TEST_CASE("Pyramid raw-vector capability does not imply stored raw data",
+          "[ut][pyramid][raw_vector]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    const auto use_reorder = GENERATE(false, true);
+    const auto metric =
+        GENERATE(vsag::MetricType::METRIC_TYPE_L2SQR, vsag::MetricType::METRIC_TYPE_IP);
+    CAPTURE(graph_type, use_reorder, metric);
+
+    const auto base_quantization_type = use_reorder ? "sq8" : "fp32";
+    auto index =
+        MakePyramidRawVectorTestIndex(graph_type, use_reorder, metric, base_quantization_type);
+    REQUIRE(index->CheckFeature(vsag::IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS));
+
+    constexpr int64_t count = 3;
+    std::array<float, count* PYRAMID_RAW_VECTOR_TEST_DIM> vectors = {
+        0.125F, 0.25F, 0.5F, 1.0F, 1.0F, 2.0F, 3.0F, 4.0F, 4.0F, 3.0F, 2.0F, 1.0F};
+    std::array<int64_t, count> ids = {10, 42, 1001};
+    std::array<std::string, count> paths = {"tenant/a", "tenant/b", "tenant/c"};
+    auto dataset = MakePyramidRawVectorTestDataset(vectors.data(), ids.data(), paths.data(), count);
+    auto build_result = index->Build(dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(build_result.value().empty());
+
+    std::array<int64_t, 2> requested_ids = {1001, 10};
+    std::array<float, 2 * PYRAMID_RAW_VECTOR_TEST_DIM> requested_vectors = {
+        4.0F, 3.0F, 2.0F, 1.0F, 0.125F, 0.25F, 0.5F, 1.0F};
+    RequireRawVectors(index, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+
+    auto data_result = index->GetDataByIds(requested_ids.data(), requested_ids.size());
+    REQUIRE(data_result.has_value());
+    REQUIRE(std::equal(data_result.value()->GetIds(),
+                       data_result.value()->GetIds() + requested_ids.size(),
+                       requested_ids.begin()));
+    REQUIRE(data_result.value()->GetFloat32Vectors() == nullptr);
+    REQUIRE_FALSE(index
+                      ->GetDataByIdsWithFlag(requested_ids.data(),
+                                             requested_ids.size(),
+                                             DATA_FLAG_ID | DATA_FLAG_FLOAT32_VECTOR)
+                      .has_value());
+
+    std::array<float, PYRAMID_RAW_VECTOR_TEST_DIM> added_vector = {8.0F, 6.0F, 4.0F, 2.0F};
+    std::array<int64_t, 1> added_id = {77};
+    std::array<std::string, 1> added_path = {"tenant/d"};
+    auto add_result = index->Add(MakePyramidRawVectorTestDataset(
+        added_vector.data(), added_id.data(), added_path.data(), added_id.size()));
+    REQUIRE(add_result.has_value());
+    REQUIRE(add_result.value().empty());
+    RequireRawVectors(index, added_id.data(), added_id.size(), added_vector.data());
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto restored =
+        MakePyramidRawVectorTestIndex(graph_type, use_reorder, metric, base_quantization_type);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    RequireRawVectors(restored, added_id.data(), added_id.size(), added_vector.data());
+    auto restored_data = restored->GetDataByIds(added_id.data(), added_id.size());
+    REQUIRE(restored_data.has_value());
+    REQUIRE(restored_data.value()->GetFloat32Vectors() == nullptr);
+}
+
+TEST_CASE("Pyramid stores exact raw vectors when requested", "[ut][pyramid][raw_vector]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    const auto use_reorder = GENERATE(false, true);
+    const auto metric =
+        GENERATE(vsag::MetricType::METRIC_TYPE_L2SQR, vsag::MetricType::METRIC_TYPE_COSINE);
+    const auto base_quantization_type = GENERATE(std::string("fp32"), std::string("sq8"));
+    CAPTURE(graph_type, use_reorder, metric, base_quantization_type);
+
+    auto index = MakePyramidRawVectorTestIndex(
+        graph_type, use_reorder, metric, base_quantization_type, "fp32", true);
+    REQUIRE(index->CheckFeature(vsag::IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS));
+
+    constexpr int64_t count = 3;
+    std::array<float, count* PYRAMID_RAW_VECTOR_TEST_DIM> vectors = {
+        0.125F, 0.25F, 0.5F, 1.0F, 1.0F, 2.0F, 3.0F, 4.0F, 4.0F, 3.0F, 2.0F, 1.0F};
+    std::array<int64_t, count> ids = {10, 42, 1001};
+    std::array<std::string, count> paths = {"tenant/a", "tenant/b", "tenant/c"};
+    auto dataset = MakePyramidRawVectorTestDataset(vectors.data(), ids.data(), paths.data(), count);
+    auto build_result = index->Build(dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(build_result.value().empty());
+
+    std::array<int64_t, 2> requested_ids = {1001, 10};
+    std::array<float, 2 * PYRAMID_RAW_VECTOR_TEST_DIM> requested_vectors = {
+        4.0F, 3.0F, 2.0F, 1.0F, 0.125F, 0.25F, 0.5F, 1.0F};
+    RequireRawVectors(index, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+    RequireStoredRawVectors(
+        index, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+
+    std::array<float, PYRAMID_RAW_VECTOR_TEST_DIM> added_vector = {8.0F, 6.0F, 4.0F, 2.0F};
+    std::array<int64_t, 1> added_id = {77};
+    std::array<std::string, 1> added_path = {"tenant/d"};
+    auto add_result = index->Add(MakePyramidRawVectorTestDataset(
+        added_vector.data(), added_id.data(), added_path.data(), added_id.size()));
+    REQUIRE(add_result.has_value());
+    REQUIRE(add_result.value().empty());
+    RequireRawVectors(index, added_id.data(), added_id.size(), added_vector.data());
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto restored = MakePyramidRawVectorTestIndex(
+        graph_type, use_reorder, metric, base_quantization_type, "fp32", true);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    RequireRawVectors(
+        restored, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+    RequireStoredRawVectors(
+        restored, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+
+    const int64_t missing_id = -1;
+    REQUIRE_FALSE(index->GetRawVectorByIds(&missing_id, 1).has_value());
+}
+
+TEST_CASE("Pyramid does not advertise unavailable raw vectors", "[ut][pyramid][raw_vector]") {
+    const auto unsupported_index = GENERATE_COPY(
+        MakePyramidRawVectorTestIndex("nsw", false, vsag::MetricType::METRIC_TYPE_L2SQR, "sq8"),
+        MakePyramidRawVectorTestIndex("nsw", false, vsag::MetricType::METRIC_TYPE_COSINE, "fp32"));
+
+    REQUIRE_FALSE(
+        unsupported_index->CheckFeature(vsag::IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS));
+    const int64_t id = 1;
+    REQUIRE_FALSE(unsupported_index->GetRawVectorByIds(&id, 1).has_value());
+}
+
+TEST_CASE("Pyramid ODescent build registers non-contiguous external ids",
+          "[ut][pyramid][raw_vector]") {
+    auto index = MakePyramidRawVectorTestIndex(
+        "odescent", false, vsag::MetricType::METRIC_TYPE_L2SQR, "sq8", "fp32", true);
+    std::array<float, 2 * PYRAMID_RAW_VECTOR_TEST_DIM> vectors = {
+        0.0F, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F};
+    std::array<int64_t, 2> ids = {42, 1001};
+    std::array<std::string, 2> paths = {"tenant/a", "tenant/b"};
+
+    auto build_result = index->Build(
+        MakePyramidRawVectorTestDataset(vectors.data(), ids.data(), paths.data(), ids.size()));
+    REQUIRE(build_result.has_value());
+    RequireRawVectors(index, ids.data(), ids.size(), vectors.data());
 }

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
@@ -28,6 +29,7 @@ struct PyramidParam {
     std::string graph_type = "nsw";
     bool use_reorder = false;
     bool support_duplicate = false;
+    bool store_raw_vector = false;
 };
 
 namespace fixtures {
@@ -83,7 +85,8 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
             "precise_quantization_type": "{}",
             "use_reorder": {},
             "index_min_size": 28,
-            "support_duplicate": {}
+            "support_duplicate": {},
+            "store_raw_vector": {}
         }}
     }}
     )";
@@ -95,7 +98,8 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
                                             param.base_quantization_type,
                                             param.precise_quantization_type,
                                             param.use_reorder,
-                                            param.support_duplicate);
+                                            param.support_duplicate,
+                                            param.store_raw_vector);
     return build_parameters_str;
 }
 
@@ -162,6 +166,44 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Add Test", "[f
         TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
         TestCalcDistanceById(index, dataset, 1e-5, true);
     }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Raw Vector Retrieval",
+                             "[ft][pyramid][raw_vector]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    const auto use_reorder = GENERATE(false, true);
+    PyramidParam pyramid_param;
+    pyramid_param.graph_type = graph_type;
+    pyramid_param.use_reorder = use_reorder;
+    pyramid_param.store_raw_vector = true;
+    pyramid_param.base_quantization_type = "sq8";
+    if (use_reorder) {
+        pyramid_param.base_quantization_type = "rabitq";
+        pyramid_param.precise_quantization_type = "fp32";
+    }
+
+    const auto param = GeneratePyramidBuildParametersString("l2", dims.front(), pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+    auto restored = TestFactory("pyramid", param, true);
+    auto dataset = pool.GetDatasetAndCreate(dims.front(), base_count, "l2", /*with_path=*/true);
+
+    TestBuildIndex(index, dataset, true);
+    TestGetRawVectorByIds(index, dataset, true);
+    TestSerializeFile(index, restored, dataset, GeneratePyramidSearchParametersString(100), true);
+    TestGetRawVectorByIds(restored, dataset, true);
+
+    std::array<int64_t, 2> requested_ids = {dataset->base_->GetIds()[base_count - 1],
+                                            dataset->base_->GetIds()[0]};
+    auto data_result = index->GetDataByIds(requested_ids.data(), requested_ids.size());
+    REQUIRE(data_result.has_value());
+    REQUIRE(data_result.value()->GetFloat32Vectors() != nullptr);
+    REQUIRE(std::equal(data_result.value()->GetFloat32Vectors(),
+                       data_result.value()->GetFloat32Vectors() + dims.front(),
+                       dataset->base_->GetFloat32Vectors() + (base_count - 1) * dims.front()));
+    REQUIRE(std::equal(data_result.value()->GetFloat32Vectors() + dims.front(),
+                       data_result.value()->GetFloat32Vectors() + 2 * dims.front(),
+                       dataset->base_->GetFloat32Vectors()));
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2755
- Fixes: #2756

## What Changed

- Separate raw-vector retrieval capability from the `store_raw_vector` data-retention flag, matching HGraph semantics.
- Reuse the selected in-memory FP32 codes when possible; otherwise maintain dedicated FP32 raw storage across train, build, add, resize, distance-by-ID, serialization, and deserialization.
- Advertise `SUPPORT_GET_RAW_VECTOR_BY_IDS` only when the selected retrieval codes can decode exact vectors or raw storage is configured.
- Register ODescent labels through `LabelTable::Insert` so reverse lookups and counts remain consistent.
- Validate unsupported float-vector flags before allocating the temporary inner-ID buffer.

## Test Evidence

- [x] `clang-format-15`
- [x] `clang-tidy-15 -p build src/algorithm/pyramid.cpp src/algorithm/inner_index_interface.cpp --quiet`
- [ ] `make test`
- [ ] `make cov`
- [x] Other targeted and component tests

Test details:

```text
./build/tests/unittests [ut][pyramid]
All tests passed (551 assertions in 5 test cases)

./build/tests/functests [ft][pyramid]
All tests passed (128300 assertions in 12 test cases)
```

## Compatibility Impact

- API/ABI compatibility: no public API or ABI changes.
- Behavior changes: FP32-backed Pyramid indexes can expose `GetRawVectorByIds` without opting into stored raw data; `GetDataByIds` includes vectors only when `store_raw_vector` is enabled. Existing serialization remains unchanged when dedicated raw storage is not required.

## Performance and Concurrency Impact

- Performance impact: no extra storage for reusable in-memory FP32 codes; compressed-only configurations allocate raw FP32 storage only when explicitly requested.
- Concurrency/thread-safety impact: none; raw-vector access follows the existing resize lock.

## Documentation Impact

- [x] No docs update needed; this restores existing HGraph-compatible behavior on the maintenance branch.

## Risk and Rollback

- Risk level: medium.
- Rollback plan: revert the single commit.

## Checklist

- [x] I have linked the relevant issues.
- [x] I have added/updated tests for the behavior and bug fix.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed.
- [x] My commit message follows project conventions.