### PR TITLE
[0.18] feat(pyramid): support model export

### DIFF
--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -456,6 +456,25 @@ Pyramid::Deserialize(StreamReader& reader) {
     this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
 }
 
+InnerIndexPtr
+Pyramid::ExportModel(const IndexCommonParam& param) const {
+    auto index = std::make_shared<Pyramid>(this->create_param_ptr_, param);
+    if (index->use_reorder_ != this->use_reorder_) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "Export model's pyramid reorder config mismatched");
+    }
+    this->base_codes_->ExportModel(index->base_codes_);
+    if (use_reorder_) {
+        if (index->precise_codes_ == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "Export model's pyramid precise codes is empty");
+        }
+        this->precise_codes_->ExportModel(index->precise_codes_);
+    }
+    index->current_memory_usage_ = static_cast<int64_t>(index->CalSerializeSize());
+    return index;
+}
+
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base) {
     const auto* path = base->GetPaths();
@@ -595,6 +614,7 @@ Pyramid::InitFeatures() {
     // other
     this->index_feature_list_->SetFeatures({
         IndexFeature::SUPPORT_CLONE,
+        IndexFeature::SUPPORT_EXPORT_MODEL,
         IndexFeature::SUPPORT_GET_MEMORY_USAGE,
     });
 }

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -140,6 +140,9 @@ public:
     Deserialize(StreamReader& reader) override;
 
     [[nodiscard]] InnerIndexPtr
+    ExportModel(const IndexCommonParam& param) const override;
+
+    [[nodiscard]] InnerIndexPtr
     Fork(const IndexCommonParam& param) override {
         return std::make_shared<Pyramid>(this->create_param_ptr_, param);
     }

--- a/src/algorithm/pyramid_test.cpp
+++ b/src/algorithm/pyramid_test.cpp
@@ -17,6 +17,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "impl/allocator/safe_allocator.h"
+#include "vsag_exception.h"
+
 TEST_CASE("Split function tests", "[ut][pyramid]") {
     SECTION("Empty input string") {
         auto result = vsag::split("", ',');
@@ -56,5 +59,29 @@ TEST_CASE("Split function tests", "[ut][pyramid]") {
     SECTION("Mixed delimiters and spaces") {
         auto result = vsag::split("  , hello,  world  ", ',');
         REQUIRE(result == std::vector<std::string>{"  ", " hello", "  world  "});
+    }
+}
+
+TEST_CASE("Pyramid ExportModel rejects inconsistent reorder configuration",
+          "[ut][Pyramid][ExportModel]") {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 4;
+    common_param.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+
+    auto external_param = vsag::JsonType::Parse(R"({"use_reorder": false})");
+    auto index_param = vsag::Pyramid::CheckAndMappingExternalParam(external_param, common_param);
+    auto index = std::make_shared<vsag::Pyramid>(index_param, common_param);
+    REQUIRE_FALSE(index->use_reorder_);
+
+    index->use_reorder_ = true;
+    try {
+        index->ExportModel(common_param);
+        FAIL("ExportModel should reject a mismatched reorder configuration");
+    } catch (const vsag::VsagException& exception) {
+        REQUIRE(exception.error_.type == vsag::ErrorType::INTERNAL_ERROR);
+        REQUIRE(std::string(exception.what()) ==
+                "Export model's pyramid reorder config mismatched");
     }
 }

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -289,6 +289,39 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex, "Pyramid Clone", "[ft][
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Export Model",
+                             "[ft][pyramid][export_model]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    const auto use_reorder = GENERATE(false, true);
+    PyramidParam pyramid_param;
+    pyramid_param.graph_type = graph_type;
+    pyramid_param.no_build_levels = {0, 1, 2};
+    pyramid_param.base_quantization_type = "sq8";
+    pyramid_param.precise_quantization_type = "sq8";
+    pyramid_param.use_reorder = use_reorder;
+
+    const auto search_param = GeneratePyramidSearchParametersString(100);
+    for (const auto dim : dims) {
+        CAPTURE(graph_type, use_reorder, dim);
+        const auto param = GeneratePyramidBuildParametersString("l2", dim, pyramid_param);
+        auto index = TestFactory("pyramid", param, true);
+        auto restored_model = TestFactory("pyramid", param, true);
+        auto dataset = pool.GetDatasetAndCreate(dim, base_count, "l2", /*with_path=*/true);
+
+        REQUIRE(index->CheckFeature(vsag::IndexFeature::SUPPORT_EXPORT_MODEL));
+        TestBuildIndex(index, dataset, true);
+
+        auto exported_model = index->ExportModel();
+        REQUIRE(exported_model.has_value());
+        REQUIRE(exported_model.value()->GetNumElements() == 0);
+        REQUIRE(exported_model.value()->GetMemoryUsage() > 0);
+        REQUIRE(exported_model.value()->CheckFeature(vsag::IndexFeature::SUPPORT_EXPORT_MODEL));
+
+        TestExportModel(index, restored_model, dataset, search_param);
+    }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
                              "Pyramid Build Test With Random Allocator",
                              "[ft][pyramid]") {
     auto allocator = std::make_shared<fixtures::RandomAllocator>();


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2753

## What Changed

- Add `Pyramid::ExportModel` for the base model.
- Export the precise model when reorder is enabled.
- Advertise `SUPPORT_EXPORT_MODEL`.
- Cover NSW and ODescent with reorder enabled and disabled through the public factory API.

## Test Evidence

- [x] `clang-format-15`
- [x] `clang-tidy-15 -p build src/algorithm/pyramid.cpp --quiet`
- [ ] `make test`
- [ ] `make cov`
- [x] Other targeted test

Test details:

```text
./build/tests/functests [ft][pyramid][export_model]
All tests passed (848 assertions in 1 test case)
```

## Compatibility Impact

- API/ABI compatibility: no public API or ABI changes.
- Behavior changes: Pyramid now reports and supports model export on 0.18.

## Performance and Concurrency Impact

- Performance impact: none outside explicit model export.
- Concurrency/thread-safety impact: none.

## Documentation Impact

- [x] No docs update needed; this backports an existing Pyramid capability to the maintenance branch.

## Risk and Rollback

- Risk level: low.
- Rollback plan: revert the single commit.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for the new behavior.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed.
- [x] My commit message follows project conventions.