### PR TITLE
fix(pyramid): align raw vector retrieval on 1.0

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -614,6 +614,9 @@ DatasetPtr
 InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
                                           int64_t count,
                                           uint64_t selected_data_flag) const {
+    if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U && not this->has_raw_vector_) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "has_raw_vector_ is false");
+    }
     auto* inner_ids =
         reinterpret_cast<InnerIdType*>(this->allocator_->Allocate(count * sizeof(InnerIdType)));
     {
@@ -627,9 +630,6 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
     auto dataset = Dataset::Make();
     dataset->NumElements(count)->Dim(dim_)->Owner(true, allocator_);
     if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U) {
-        if (not this->has_raw_vector_) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT, "has_raw_vector_ is false");
-        }
         auto* fp32_data = reinterpret_cast<float*>(
             this->allocator_->Allocate(count * this->dim_ * sizeof(float)));
         dataset->Float32Vectors(fp32_data);

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -217,11 +217,16 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
     const auto* data_ids = base->GetIds();
 
     resize(data_num);
-    std::memcpy(label_table_->label_table_.data(), data_ids, sizeof(LabelType) * data_num);
+    for (InnerIdType inner_id = 0; inner_id < data_num; ++inner_id) {
+        label_table_->Insert(inner_id, data_ids[inner_id]);
+    }
 
     base_codes_->BatchInsertVector(data_vectors, data_num);
     if (use_reorder_) {
         precise_codes_->BatchInsertVector(data_vectors, data_num);
+    }
+    if (create_new_raw_vector_) {
+        raw_vector_->BatchInsertVector(data_vectors, data_num);
     }
     auto codes = use_reorder_ ? precise_codes_ : base_codes_;
 
@@ -435,6 +440,9 @@ Pyramid::Serialize(StreamWriter& writer) const {
     if (use_reorder_) {
         precise_codes_->Serialize(writer);
     }
+    if (create_new_raw_vector_) {
+        raw_vector_->Serialize(writer);
+    }
 
     auto pyramid_param = std::dynamic_pointer_cast<PyramidParameters>(create_param_ptr_);
     if (pyramid_param && pyramid_param->has_hierarchies) {
@@ -489,6 +497,13 @@ Pyramid::collect_streaming_header() const {
                                      StreamSerializationBlockCurrentVersion(tag),
                                      StreamSerializationTagCritical(tag));
     }
+    if (this->create_new_raw_vector_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::RAW_VECTOR);
+        AppendStreamingManifestBlock(manifest,
+                                     tag,
+                                     StreamSerializationBlockCurrentVersion(tag),
+                                     StreamSerializationTagCritical(tag));
+    }
     AppendStreamingManifestBlock(manifest,
                                  hierarchy_tag,
                                  StreamSerializationBlockCurrentVersion(hierarchy_tag),
@@ -532,6 +547,13 @@ Pyramid::serialize_streaming_body(StreamWriter& writer) const {
         WriteStreamingBlock(
             writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
                 this->precise_codes_->Serialize(w);
+            });
+    }
+    if (this->create_new_raw_vector_) {
+        auto tag = static_cast<uint32_t>(StreamSerializationTag::RAW_VECTOR);
+        WriteStreamingBlock(
+            writer, tag, StreamSerializationTagCritical(tag), [this](StreamWriter& w) {
+                this->raw_vector_->Serialize(w);
             });
     }
     WriteStreamingBlock(writer,
@@ -598,6 +620,7 @@ Pyramid::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) 
     bool loaded_label_table = false;
     bool loaded_base_codes = false;
     bool loaded_precise_codes = false;
+    bool loaded_raw_vector = false;
     bool loaded_hierarchies = false;
 
     while (true) {
@@ -649,6 +672,15 @@ Pyramid::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) 
                     loaded_precise_codes = true;
                 }
                 break;
+            case StreamSerializationTag::RAW_VECTOR:
+                if (this->create_new_raw_vector_) {
+                    ReadSeekableBlockPayload(
+                        block_reader, block_header, [this](StreamReader& block) {
+                            this->raw_vector_->Deserialize(block);
+                        });
+                    loaded_raw_vector = true;
+                }
+                break;
             case StreamSerializationTag::PYRAMID_HIERARCHIES:
                 ReadSeekableBlockPayload(
                     block_reader, block_header, [this, &basic_info](StreamReader& block) {
@@ -682,6 +714,10 @@ Pyramid::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) 
         throw VsagException(ErrorType::READ_ERROR,
                             "Pyramid streaming serialization precise codes block is missing");
     }
+    if (this->create_new_raw_vector_ && !loaded_raw_vector) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "Pyramid streaming serialization raw vector block is missing");
+    }
 
     resize(max_capacity);
     this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
@@ -705,6 +741,9 @@ Pyramid::Deserialize(StreamReader& reader) {
     base_codes_->Deserialize(buffer_reader);
     if (use_reorder_) {
         precise_codes_->Deserialize(buffer_reader);
+    }
+    if (create_new_raw_vector_) {
+        raw_vector_->Deserialize(buffer_reader);
     }
     cur_element_count_ = base_codes_->TotalCount();
 
@@ -784,6 +823,10 @@ Pyramid::Add(const DatasetPtr& base) {
                     precise_codes_->InsertVector(data_vectors + dim_ * i,
                                                  valid_id_count + local_cur_element_count);
                 }
+                if (create_new_raw_vector_) {
+                    raw_vector_->InsertVector(data_vectors + dim_ * i,
+                                              valid_id_count + local_cur_element_count);
+                }
                 valid_id_count++;
                 data_biases.push_back(i);
             } else {
@@ -815,6 +858,9 @@ Pyramid::resize(int64_t new_max_capacity) {
     base_codes_->Resize(new_max_capacity);
     if (use_reorder_) {
         precise_codes_->Resize(new_max_capacity);
+    }
+    if (create_new_raw_vector_) {
+        raw_vector_->Resize(new_max_capacity);
     }
     points_mutex_->Resize(new_max_capacity);
     max_capacity_ = new_max_capacity;
@@ -863,6 +909,14 @@ Pyramid::InitFeatures() {
         IndexFeature::SUPPORT_EXPORT_MODEL,
         IndexFeature::SUPPORT_GET_MEMORY_USAGE,
     });
+
+    const auto& retrieval_codes = use_reorder_ ? precise_codes_ : base_codes_;
+    const bool can_decode_exact_vector =
+        retrieval_codes->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32 &&
+        (metric_ != MetricType::METRIC_TYPE_COSINE || retrieval_codes->HoldMolds());
+    if (can_decode_exact_vector || raw_vector_ != nullptr) {
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS);
+    }
 
     this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_DELETE_BY_ID);
 }
@@ -921,6 +975,18 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
                 "{HOLD_MOLDS}": false
             }
         },
+        "{STORE_RAW_VECTOR_KEY}": false,
+        "{RAW_VECTOR_KEY}": {
+            "{IO_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{IO_TYPE_VALUE_BLOCK_MEMORY_IO}",
+                "{IO_FILE_PATH_KEY}": "{DEFAULT_FILE_PATH_VALUE}"
+            },
+            "{CODES_TYPE_KEY}": "flatten",
+            "{QUANTIZATION_PARAMS_KEY}": {
+                "{TYPE_KEY}": "{QUANTIZATION_TYPE_VALUE_FP32}",
+                "{HOLD_MOLDS}": true
+            }
+        },
         "{BUILD_THREAD_COUNT_KEY}": 1,
         "{EF_CONSTRUCTION_KEY}": 400,
         "{NO_BUILD_LEVELS}":[],
@@ -935,6 +1001,7 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
         {PYRAMID_EF_CONSTRUCTION, {EF_CONSTRUCTION_KEY}},
         {PYRAMID_USE_REORDER, {USE_REORDER_KEY}},
         {PYRAMID_BASE_QUANTIZATION_TYPE, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, TYPE_KEY}},
+        {STORE_RAW_VECTOR, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, HOLD_MOLDS}},
         {PYRAMID_RABITQ_BITS_PER_DIM_BASE,
          {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, RABITQ_QUANTIZATION_BITS_PER_DIM_BASE_KEY}},
         {PYRAMID_RABITQ_BITS_PER_DIM_QUERY,
@@ -942,6 +1009,8 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
         {PYRAMID_RABITQ_PCA_DIM, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, PCA_DIM_KEY}},
         {PYRAMID_RABITQ_USE_FHT, {BASE_CODES_KEY, QUANTIZATION_PARAMS_KEY, USE_FHT_KEY}},
         {PYRAMID_PRECISE_QUANTIZATION_TYPE, {PRECISE_CODES_KEY, QUANTIZATION_PARAMS_KEY, TYPE_KEY}},
+        {STORE_RAW_VECTOR, {PRECISE_CODES_KEY, QUANTIZATION_PARAMS_KEY, HOLD_MOLDS}},
+        {STORE_RAW_VECTOR, {STORE_RAW_VECTOR_KEY}},
         {PYRAMID_GRAPH_MAX_DEGREE, {GRAPH_KEY, GRAPH_PARAM_MAX_DEGREE_KEY}},
         {PYRAMID_BASE_IO_TYPE, {BASE_CODES_KEY, IO_PARAMS_KEY, TYPE_KEY}},
         {PYRAMID_BUILD_ALPHA, {GRAPH_KEY, ODESCENT_PARAMETER_ALPHA}},
@@ -977,6 +1046,9 @@ Pyramid::Train(const DatasetPtr& base) {
     this->base_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
     if (use_reorder_) {
         this->precise_codes_->Train(base->GetFloat32Vectors(), base->GetNumElements());
+    }
+    if (create_new_raw_vector_) {
+        this->raw_vector_->Train(base->GetFloat32Vectors(), base->GetNumElements());
     }
 }
 std::vector<int64_t>
@@ -1285,6 +1357,9 @@ Pyramid::CalcDistanceById(const float* query, int64_t id, bool calculate_precise
     if (use_reorder_ && calculate_precise_distance) {
         flat = this->precise_codes_;
     }
+    if (create_new_raw_vector_ && calculate_precise_distance) {
+        flat = this->raw_vector_;
+    }
     return InnerIndexInterface::calc_distance_by_id(query, id, flat);
 }
 
@@ -1298,19 +1373,53 @@ Pyramid::CalDistanceById(const float* query,
     if (use_reorder_ && calculate_precise_distance) {
         flat = this->precise_codes_;
     }
+    if (create_new_raw_vector_ && calculate_precise_distance) {
+        flat = this->raw_vector_;
+    }
     return InnerIndexInterface::cal_distance_by_id(query, ids, count, flat);
 }
 
 void
 Pyramid::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
-    auto codes = (use_reorder_) ? precise_codes_ : base_codes_;
+    auto codes = use_reorder_ ? precise_codes_ : base_codes_;
+    if (create_new_raw_vector_) {
+        codes = raw_vector_;
+    }
     bool release = false;
     const auto* buffer = codes->GetCodesById(inner_id, release);
-    codes->Decode(buffer, data);
+    if (buffer == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("failed to get vector by inner id {}", inner_id));
+    }
+    const bool decoded = codes->Decode(buffer, data);
     if (release) {
         codes->Release(buffer);
     }
+    if (not decoded) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            fmt::format("failed to decode vector by inner id {}", inner_id));
+    }
+}
+
+void
+Pyramid::check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
+                                   const IndexCommonParam& common_param) {
+    if (raw_vector_param == nullptr) {
+        return;
+    }
+
+    const auto& retrieval_codes = use_reorder_ ? precise_codes_ : base_codes_;
+    const auto io_type_name = raw_vector_param->io_parameter->GetTypeName();
+    const bool is_memory_io =
+        io_type_name == IO_TYPE_VALUE_BLOCK_MEMORY_IO || io_type_name == IO_TYPE_VALUE_MEMORY_IO;
+    if (retrieval_codes->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_FP32 && is_memory_io) {
+        raw_vector_ = retrieval_codes;
+    } else {
+        raw_vector_ = FlattenInterface::MakeInstance(raw_vector_param, common_param);
+        create_new_raw_vector_ = true;
+    }
+    has_raw_vector_ = true;
 }
 
 std::string

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -167,6 +167,7 @@ public:
                 FlattenInterface::MakeInstance(pyramid_param->precise_codes_param, common_param);
             reorder_ = std::make_shared<FlattenReorder>(precise_codes_, allocator_);
         }
+        check_and_init_raw_vector(pyramid_param->raw_vector_param, common_param);
     }
 
     explicit Pyramid(const ParamPtr& param, const IndexCommonParam& common_param)
@@ -255,6 +256,10 @@ public:
     friend class PyramidAnalyzer;
 
 private:
+    void
+    check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
+                              const IndexCommonParam& common_param);
+
     MetadataPtr
     collect_streaming_header() const override;
 
@@ -358,6 +363,8 @@ private:
     UnorderedMap<std::string, std::unique_ptr<Hierarchy>> hierarchies_;  // named hierarchies
     FlattenInterfacePtr base_codes_{nullptr};          // coarse codes for graph build/search
     FlattenInterfacePtr precise_codes_{nullptr};       // precise codes for reorder (if enabled)
+    FlattenInterfacePtr raw_vector_{nullptr};          // exact vectors when explicitly stored
+    bool create_new_raw_vector_{false};                // owns separate raw-vector storage
     std::unique_ptr<VisitedListPool> pool_ = nullptr;  // pool of visited-lists for search
 
     MutexArrayPtr points_mutex_{nullptr};                // per-point locks for concurrent access

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -15,7 +15,98 @@
 
 #include "pyramid.h"
 
+#include <array>
+#include <catch2/generators/catch_generators.hpp>
+
+#include "impl/allocator/safe_allocator.h"
+#include "index/index_impl.h"
 #include "unittest.h"
+
+namespace {
+
+constexpr int64_t PYRAMID_RAW_VECTOR_TEST_DIM = 4;
+
+std::shared_ptr<vsag::Index>
+MakePyramidRawVectorTestIndex(const std::string& graph_type,
+                              bool use_reorder,
+                              vsag::MetricType metric,
+                              const std::string& base_quantization_type = "fp32",
+                              const std::string& precise_quantization_type = "fp32",
+                              bool store_raw_vector = false) {
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = PYRAMID_RAW_VECTOR_TEST_DIM;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+    common_param.metric_ = metric;
+    common_param.allocator_ = vsag::SafeAllocator::FactoryDefaultAllocator();
+
+    auto external_param = vsag::JsonType::Parse(R"({
+        "base_quantization_type": "fp32",
+        "precise_quantization_type": "fp32",
+        "use_reorder": false,
+        "max_degree": 4,
+        "ef_construction": 8,
+        "graph_type": "nsw",
+        "no_build_levels": [0, 1],
+        "index_min_size": 0,
+        "store_raw_vector": false
+    })");
+    external_param[vsag::PYRAMID_GRAPH_TYPE].SetString(graph_type);
+    external_param[vsag::PYRAMID_USE_REORDER].SetBool(use_reorder);
+    external_param[vsag::PYRAMID_BASE_QUANTIZATION_TYPE].SetString(base_quantization_type);
+    external_param[vsag::PYRAMID_PRECISE_QUANTIZATION_TYPE].SetString(precise_quantization_type);
+    external_param[vsag::STORE_RAW_VECTOR].SetBool(store_raw_vector);
+    return std::make_shared<vsag::IndexImpl<vsag::Pyramid>>(external_param, common_param);
+}
+
+vsag::DatasetPtr
+MakePyramidRawVectorTestDataset(const float* vectors,
+                                const int64_t* ids,
+                                const std::string* paths,
+                                int64_t count) {
+    return vsag::Dataset::Make()
+        ->NumElements(count)
+        ->Dim(PYRAMID_RAW_VECTOR_TEST_DIM)
+        ->Float32Vectors(vectors)
+        ->Ids(ids)
+        ->Paths(paths)
+        ->Owner(false);
+}
+
+void
+RequireRawVectors(const vsag::IndexPtr& index,
+                  const int64_t* ids,
+                  int64_t count,
+                  const float* expected) {
+    auto result = index->GetRawVectorByIds(ids, count);
+    REQUIRE(result.has_value());
+    REQUIRE(std::equal(result.value()->GetFloat32Vectors(),
+                       result.value()->GetFloat32Vectors() + count * PYRAMID_RAW_VECTOR_TEST_DIM,
+                       expected));
+}
+
+void
+RequireStoredRawVectors(const vsag::IndexPtr& index,
+                        const int64_t* ids,
+                        int64_t count,
+                        const float* expected) {
+    auto data_result = index->GetDataByIds(ids, count);
+    REQUIRE(data_result.has_value());
+    REQUIRE(std::equal(data_result.value()->GetIds(), data_result.value()->GetIds() + count, ids));
+    REQUIRE(
+        std::equal(data_result.value()->GetFloat32Vectors(),
+                   data_result.value()->GetFloat32Vectors() + count * PYRAMID_RAW_VECTOR_TEST_DIM,
+                   expected));
+
+    auto flagged_result =
+        index->GetDataByIdsWithFlag(ids, count, DATA_FLAG_ID | DATA_FLAG_FLOAT32_VECTOR);
+    REQUIRE(flagged_result.has_value());
+    REQUIRE(std::equal(
+        flagged_result.value()->GetFloat32Vectors(),
+        flagged_result.value()->GetFloat32Vectors() + count * PYRAMID_RAW_VECTOR_TEST_DIM,
+        expected));
+}
+
+}  // namespace
 
 TEST_CASE("Split function tests", "[ut][pyramid]") {
     SECTION("Empty input string") {
@@ -57,4 +148,139 @@ TEST_CASE("Split function tests", "[ut][pyramid]") {
         auto result = vsag::split("  , hello,  world  ", ',');
         REQUIRE(result == std::vector<std::string>{"  ", " hello", "  world  "});
     }
+}
+
+TEST_CASE("Pyramid raw-vector capability does not imply stored raw data",
+          "[ut][pyramid][raw_vector]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    const auto use_reorder = GENERATE(false, true);
+    const auto metric =
+        GENERATE(vsag::MetricType::METRIC_TYPE_L2SQR, vsag::MetricType::METRIC_TYPE_IP);
+    CAPTURE(graph_type, use_reorder, metric);
+
+    const auto base_quantization_type = use_reorder ? "sq8" : "fp32";
+    auto index =
+        MakePyramidRawVectorTestIndex(graph_type, use_reorder, metric, base_quantization_type);
+    REQUIRE(index->CheckFeature(vsag::IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS));
+
+    constexpr int64_t count = 3;
+    std::array<float, count* PYRAMID_RAW_VECTOR_TEST_DIM> vectors = {
+        0.125F, 0.25F, 0.5F, 1.0F, 1.0F, 2.0F, 3.0F, 4.0F, 4.0F, 3.0F, 2.0F, 1.0F};
+    std::array<int64_t, count> ids = {10, 42, 1001};
+    std::array<std::string, count> paths = {"tenant/a", "tenant/b", "tenant/c"};
+    auto dataset = MakePyramidRawVectorTestDataset(vectors.data(), ids.data(), paths.data(), count);
+    auto build_result = index->Build(dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(build_result.value().empty());
+
+    std::array<int64_t, 2> requested_ids = {1001, 10};
+    std::array<float, 2 * PYRAMID_RAW_VECTOR_TEST_DIM> requested_vectors = {
+        4.0F, 3.0F, 2.0F, 1.0F, 0.125F, 0.25F, 0.5F, 1.0F};
+    RequireRawVectors(index, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+
+    auto data_result = index->GetDataByIds(requested_ids.data(), requested_ids.size());
+    REQUIRE(data_result.has_value());
+    REQUIRE(data_result.value()->GetFloat32Vectors() == nullptr);
+    REQUIRE_FALSE(index
+                      ->GetDataByIdsWithFlag(requested_ids.data(),
+                                             requested_ids.size(),
+                                             DATA_FLAG_ID | DATA_FLAG_FLOAT32_VECTOR)
+                      .has_value());
+
+    std::array<float, PYRAMID_RAW_VECTOR_TEST_DIM> added_vector = {8.0F, 6.0F, 4.0F, 2.0F};
+    std::array<int64_t, 1> added_id = {77};
+    std::array<std::string, 1> added_path = {"tenant/d"};
+    auto add_result = index->Add(MakePyramidRawVectorTestDataset(
+        added_vector.data(), added_id.data(), added_path.data(), added_id.size()));
+    REQUIRE(add_result.has_value());
+    REQUIRE(add_result.value().empty());
+    RequireRawVectors(index, added_id.data(), added_id.size(), added_vector.data());
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto restored =
+        MakePyramidRawVectorTestIndex(graph_type, use_reorder, metric, base_quantization_type);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    RequireRawVectors(restored, added_id.data(), added_id.size(), added_vector.data());
+    auto restored_data = restored->GetDataByIds(added_id.data(), added_id.size());
+    REQUIRE(restored_data.has_value());
+    REQUIRE(restored_data.value()->GetFloat32Vectors() == nullptr);
+}
+
+TEST_CASE("Pyramid stores exact raw vectors when requested", "[ut][pyramid][raw_vector]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    const auto use_reorder = GENERATE(false, true);
+    const auto metric =
+        GENERATE(vsag::MetricType::METRIC_TYPE_L2SQR, vsag::MetricType::METRIC_TYPE_COSINE);
+    const auto base_quantization_type = GENERATE(std::string("fp32"), std::string("sq8"));
+    CAPTURE(graph_type, use_reorder, metric, base_quantization_type);
+
+    auto index = MakePyramidRawVectorTestIndex(
+        graph_type, use_reorder, metric, base_quantization_type, "fp32", true);
+    REQUIRE(index->CheckFeature(vsag::IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS));
+
+    constexpr int64_t count = 3;
+    std::array<float, count* PYRAMID_RAW_VECTOR_TEST_DIM> vectors = {
+        0.125F, 0.25F, 0.5F, 1.0F, 1.0F, 2.0F, 3.0F, 4.0F, 4.0F, 3.0F, 2.0F, 1.0F};
+    std::array<int64_t, count> ids = {10, 42, 1001};
+    std::array<std::string, count> paths = {"tenant/a", "tenant/b", "tenant/c"};
+    auto dataset = MakePyramidRawVectorTestDataset(vectors.data(), ids.data(), paths.data(), count);
+    auto build_result = index->Build(dataset);
+    REQUIRE(build_result.has_value());
+    REQUIRE(build_result.value().empty());
+
+    std::array<int64_t, 2> requested_ids = {1001, 10};
+    std::array<float, 2 * PYRAMID_RAW_VECTOR_TEST_DIM> requested_vectors = {
+        4.0F, 3.0F, 2.0F, 1.0F, 0.125F, 0.25F, 0.5F, 1.0F};
+    RequireRawVectors(index, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+    RequireStoredRawVectors(
+        index, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+
+    std::array<float, PYRAMID_RAW_VECTOR_TEST_DIM> added_vector = {8.0F, 6.0F, 4.0F, 2.0F};
+    std::array<int64_t, 1> added_id = {77};
+    std::array<std::string, 1> added_path = {"tenant/d"};
+    auto add_result = index->Add(MakePyramidRawVectorTestDataset(
+        added_vector.data(), added_id.data(), added_path.data(), added_id.size()));
+    REQUIRE(add_result.has_value());
+    REQUIRE(add_result.value().empty());
+    RequireRawVectors(index, added_id.data(), added_id.size(), added_vector.data());
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto restored = MakePyramidRawVectorTestIndex(
+        graph_type, use_reorder, metric, base_quantization_type, "fp32", true);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    RequireRawVectors(
+        restored, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+    RequireStoredRawVectors(
+        restored, requested_ids.data(), requested_ids.size(), requested_vectors.data());
+
+    const int64_t missing_id = -1;
+    REQUIRE_FALSE(index->GetRawVectorByIds(&missing_id, 1).has_value());
+}
+
+TEST_CASE("Pyramid does not advertise unavailable raw vectors", "[ut][pyramid][raw_vector]") {
+    const auto unsupported_index = GENERATE_COPY(
+        MakePyramidRawVectorTestIndex("nsw", false, vsag::MetricType::METRIC_TYPE_L2SQR, "sq8"),
+        MakePyramidRawVectorTestIndex("nsw", false, vsag::MetricType::METRIC_TYPE_COSINE, "fp32"));
+
+    REQUIRE_FALSE(
+        unsupported_index->CheckFeature(vsag::IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS));
+    const int64_t id = 1;
+    REQUIRE_FALSE(unsupported_index->GetRawVectorByIds(&id, 1).has_value());
+}
+
+TEST_CASE("Pyramid ODescent build registers non-contiguous external ids",
+          "[ut][pyramid][raw_vector]") {
+    auto index = MakePyramidRawVectorTestIndex(
+        "odescent", false, vsag::MetricType::METRIC_TYPE_L2SQR, "sq8", "fp32", true);
+    std::array<float, 2 * PYRAMID_RAW_VECTOR_TEST_DIM> vectors = {
+        0.0F, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F};
+    std::array<int64_t, 2> ids = {42, 1001};
+    std::array<std::string, 2> paths = {"tenant/a", "tenant/b"};
+
+    auto build_result = index->Build(
+        MakePyramidRawVectorTestDataset(vectors.data(), ids.data(), paths.data(), ids.size()));
+    REQUIRE(build_result.has_value());
+    RequireRawVectors(index, ids.data(), ids.size(), vectors.data());
 }

--- a/src/algorithm/pyramid/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters.cpp
@@ -295,6 +295,10 @@ PyramidParameters::CheckCompatibility(const ParamPtr& other) const {
     if (this->use_reorder) {
         CHECK_SUB_PARAM(*this, *p, precise_codes_param);
     }
+    CHECK_FIELD_EQ(*this, *p, store_raw_vector);
+    if (this->store_raw_vector) {
+        CHECK_SUB_PARAM(*this, *p, raw_vector_param);
+    }
     CHECK_FIELD_EQ(*this, *p, index_min_size);
     CHECK_FIELD_EQ(*this, *p, support_duplicate);
     return true;

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -41,6 +41,8 @@ struct PyramidDefaultParam {
     std::string base_file_path = "base_path";
     std::string precise_io_type = "block_memory_io";
     std::string precise_file_path = "precise_path";
+    bool store_raw_vector = false;
+    std::string raw_quantization_type = "fp32";
     uint32_t index_min_size = 1000;
     bool support_duplicate = false;
 };
@@ -100,6 +102,16 @@ generate_pyramid(const PyramidDefaultParam& param) {
                     "type": "{}"
                 }}
             }},
+            "raw_vector": {{
+                "codes_type": "flatten",
+                "io_params": {{
+                    "type": "block_memory_io"
+                }},
+                "quantization_params": {{
+                    "type": "{}"
+                }}
+            }},
+            "store_raw_vector": {},
             "type": "pyramid",
             "use_reorder": {},
             "index_min_size": {},
@@ -121,6 +133,8 @@ generate_pyramid(const PyramidDefaultParam& param) {
                        param.precise_file_path,
                        param.precise_io_type,
                        param.precise_quantization_type,
+                       param.raw_quantization_type,
+                       param.store_raw_vector,
                        param.use_reorder,
                        param.index_min_size,
                        param.support_duplicate);
@@ -281,6 +295,21 @@ TEST_CASE("Pyramid Parameters CheckCompatibility", "[ut][PyramidParameter][Check
         "different precise quantization type", precise_quantization_type, "fp32", "fp16", false);
     TEST_COMPATIBILITY_CASE("different index min size", index_min_size, 500, 1500, false);
     TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, false, true, false);
+    TEST_COMPATIBILITY_CASE("different store raw vector", store_raw_vector, false, true, false);
+
+    SECTION("different raw vector parameters") {
+        PyramidDefaultParam param1;
+        PyramidDefaultParam param2;
+        param1.store_raw_vector = true;
+        param2.store_raw_vector = true;
+        param2.raw_quantization_type = "fp16";
+        auto pyramid_param1 = std::make_shared<vsag::PyramidParameters>();
+        auto pyramid_param2 = std::make_shared<vsag::PyramidParameters>();
+        pyramid_param1->FromString(generate_pyramid(param1));
+        pyramid_param2->FromString(generate_pyramid(param2));
+
+        REQUIRE_FALSE(pyramid_param1->CheckCompatibility(pyramid_param2));
+    }
 
     SECTION("same hierarchies in different order") {
         auto param1 = ParsePyramidWithHierarchies(

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -38,6 +38,7 @@ struct PyramidParam {
     std::string graph_type = "nsw";
     bool use_reorder = false;
     bool support_duplicate = false;
+    bool store_raw_vector = false;
 };
 
 namespace fixtures {
@@ -93,7 +94,8 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
             "precise_quantization_type": "{}",
             "use_reorder": {},
             "index_min_size": 28,
-            "support_duplicate": {}
+            "support_duplicate": {},
+            "store_raw_vector": {}
         }}
     }}
     )";
@@ -105,7 +107,8 @@ PyramidTestIndex::GeneratePyramidBuildParametersString(const std::string& metric
                                             param.base_quantization_type,
                                             param.precise_quantization_type,
                                             param.use_reorder,
-                                            param.support_duplicate);
+                                            param.support_duplicate,
+                                            param.store_raw_vector);
     return build_parameters_str;
 }
 
@@ -238,6 +241,55 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
         TestRangeSearch(index, dataset, search_param, 0.94, 10, true);
         TestRangeSearch(index, dataset, search_param, 0.49, 5, true);
     }
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,
+                             "Pyramid Raw Vector Retrieval",
+                             "[ft][pyramid][raw_vector]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    const auto use_reorder = GENERATE(false, true);
+    const auto metric_type = GENERATE(std::string("l2"), std::string("cosine"));
+    PyramidParam pyramid_param;
+    pyramid_param.graph_type = graph_type;
+    pyramid_param.use_reorder = use_reorder;
+    pyramid_param.store_raw_vector = true;
+    pyramid_param.base_quantization_type = "sq8";
+    if (use_reorder) {
+        pyramid_param.base_quantization_type = "rabitq";
+        pyramid_param.precise_quantization_type = "fp32";
+    }
+
+    const auto dim = dims.front();
+    const auto param = GeneratePyramidBuildParametersString(metric_type, dim, pyramid_param);
+    auto index = TestFactory("pyramid", param, true);
+    auto restored = TestFactory("pyramid", param, true);
+    auto dataset = pool.GetDatasetAndCreate(dim, base_count, metric_type, /*with_path=*/true);
+
+    TestBuildIndex(index, dataset, true);
+    TestGetRawVectorByIds(index, dataset, true);
+    TestSerializeFile(index, restored, dataset, GeneratePyramidSearchParametersString(100), true);
+    TestGetRawVectorByIds(restored, dataset, true);
+
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+
+    std::stringstream load_stream(bytes);
+    auto loaded = vsag::Index::Load(load_stream, "{}");
+    REQUIRE(loaded.has_value());
+    TestGetRawVectorByIds(loaded.value(), dataset, true);
+
+    std::array<int64_t, 2> requested_ids = {dataset->base_->GetIds()[base_count - 1],
+                                            dataset->base_->GetIds()[0]};
+    auto data_result = index->GetDataByIds(requested_ids.data(), requested_ids.size());
+    REQUIRE(data_result.has_value());
+    REQUIRE(data_result.value()->GetFloat32Vectors() != nullptr);
+    REQUIRE(std::equal(data_result.value()->GetFloat32Vectors(),
+                       data_result.value()->GetFloat32Vectors() + dim,
+                       dataset->base_->GetFloat32Vectors() + (base_count - 1) * dim));
+    REQUIRE(std::equal(data_result.value()->GetFloat32Vectors() + dim,
+                       data_result.value()->GetFloat32Vectors() + 2 * dim,
+                       dataset->base_->GetFloat32Vectors()));
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::PyramidTestIndex,


### PR DESCRIPTION
## Summary

- expose raw-vector retrieval when the selected FP32 codes can decode exact vectors, while keeping default `GetDataByIds` vector output gated by `store_raw_vector`
- reuse selected in-memory FP32 codes or persist dedicated FP32 raw storage for compressed sources across build, add, native serialization, and streaming load
- register ODescent labels through `LabelTable::Insert` so non-contiguous external IDs resolve correctly

## Testing

- `./build/tests/unittests [ut][pyramid][raw_vector]`
- `./build/tests/unittests [ut][pyramid]`
- `./build/tests/unittests [ut][PyramidParameter]`
- `./build/tests/functests [ft][pyramid][raw_vector]`
- `./build/tests/functests [ft][pyramid]`
- `clang-format-15 --dry-run --Werror ...`
- `clang-tidy-15 -p build ...`

Fixes #2755
Fixes #2756