### PR TITLE
docs: align dense index lifecycle documentation

### DIFF
--- a/docs/docs/en/src/advanced/index_lifecycle.md
+++ b/docs/docs/en/src/advanced/index_lifecycle.md
@@ -8,18 +8,19 @@ produce a new index derived from it. This page documents the full lifecycle surf
 - `Clone` — produce a deep copy of an existing index.
 - `ExportModel` — extract the trained model as an empty index for reuse.
 
-Each operation is optional and is exposed only when the underlying index advertises the matching
-capability flag via `index->CheckFeature(...)`.
+Each operation is optional. For operations with a dedicated capability flag, check it through
+`index->CheckFeature(...)`; `Remove` has no dedicated flag and must be checked by index type and
+`RemoveMode`.
 
 ## Capability Flags
 
-| Operation         | Capability Flag                          | HGraph | IVF | SINDI |
-|-------------------|------------------------------------------|:------:|:---:|:-----:|
-| `Remove`          | _(no dedicated flag — see below)_        |   Yes  |  —  |   —   |
-| `UpdateVector`    | `SUPPORT_UPDATE_VECTOR_CONCURRENT`       |   Yes  |  —  |  Yes  |
-| `UpdateId`        | `SUPPORT_UPDATE_ID_CONCURRENT`           |   Yes  |  —  |  Yes  |
-| `Clone`           | `SUPPORT_CLONE`                          |   Yes  | Yes |   —   |
-| `ExportModel`     | `SUPPORT_EXPORT_MODEL`                   |   Yes  | Yes |   —   |
+| Operation | Capability Flag | HGraph | Pyramid | IVF | BruteForce | SINDI |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| `Remove` | _(no dedicated flag — see below)_ | Yes | `RemoveMode::MARK_REMOVE` only | `RemoveMode::MARK_REMOVE` only | Yes | `RemoveMode::MARK_REMOVE` only |
+| `UpdateVector` | `SUPPORT_UPDATE_VECTOR_CONCURRENT` | Yes | — | — | Yes | Yes |
+| `UpdateId` | `SUPPORT_UPDATE_ID_CONCURRENT` | Yes | — | — | — | Yes |
+| `Clone` | `SUPPORT_CLONE` | Yes | Yes | Yes | Yes | — |
+| `ExportModel` | `SUPPORT_EXPORT_MODEL` | Yes | Yes | Yes | — | — |
 
 For the flag-gated operations, check at runtime with `index->CheckFeature(vsag::SUPPORT_*)` before
 calling; unsupported indexes return `UNSUPPORTED_INDEX_OPERATION`. `Remove` does not currently
@@ -88,12 +89,22 @@ silently skipped and not counted.
 
 A runnable example is available at `examples/cpp/303_feature_remove.cpp`.
 
+### Pyramid and IVF Deletion
+
+Pyramid and IVF support `RemoveMode::MARK_REMOVE` only. The operation writes tombstones, excludes
+the ids from later searches, and does not physically reclaim vector storage. `FORCE_REMOVE` is not
+supported for either index.
+
 ### BruteForce Deletion
 
 BruteForce also supports both modes, but it does **not** use HGraph's
 `support_force_remove` setting. `MARK_REMOVE` writes a tombstone and keeps vector storage.
 `FORCE_REMOVE` needs no extra configuration: it physically removes entries, moving the final
 internal slot when necessary while keeping external ids intact.
+
+When BruteForce is not in multi-vector mode and `use_attribute_filter: true` is enabled, neither removal mode is available; rebuild the index instead if attribute-filtered data must be deleted.
+
+In multi-vector mode, BruteForce supports `RemoveMode::MARK_REMOVE` only; `FORCE_REMOVE` is not available, including when `use_attribute_filter: true` is enabled.
 
 BruteForce uses `block_memory_io` by default. Every successful force-removal batch reduces its
 logical vector and optional extra-information storage to the live entry count and releases trailing
@@ -135,6 +146,10 @@ if (status.has_value() && *status) {
 Setting `force_update = true` skips the check and always applies the update; use with caution as
 it may degrade recall.
 
+This connectivity check applies to HGraph. BruteForce also supports `UpdateVector` for a
+same-dimension FP32 replacement, but it has no graph connectivity check and therefore does not
+give `force_update` a separate effect. Pyramid and IVF do not support `UpdateVector`.
+
 ### `UpdateId`
 
 `UpdateId(old_id, new_id)` renames an existing id without touching the underlying vector.
@@ -146,6 +161,10 @@ index->UpdateId(123, 456);
 
 A runnable example combining `UpdateVector`, `Remove`, and `Add` is available at
 `examples/cpp/305_feature_update.cpp`.
+
+`UpdateId` is implemented through a shared label-table path on several indexes, but only indexes
+that advertise `SUPPORT_UPDATE_ID_CONCURRENT` promise the corresponding concurrent-update
+semantics.
 
 ## Cloning an Index
 

--- a/docs/docs/en/src/indexes/brute_force.md
+++ b/docs/docs/en/src/indexes/brute_force.md
@@ -54,6 +54,12 @@ auto result = index->KnnSearch(query, /*topk=*/10, "{}").value();
 A full runnable program is at
 [`examples/cpp/105_index_brute_force.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/105_index_brute_force.cpp).
 
+## Input data type
+
+The public `Build`, `Add`, `KnnSearch`, `RangeSearch`, and `UpdateVector` paths accept FP32 vectors only. At runtime, supply vectors via `Dataset::Float32Vectors`. At index creation, set `dtype` to `"float32"`; `dtype: "int8"` is not supported when creating a BruteForce index.
+
+The `base_quantization_type` parameter controls the index's internal encoding and storage, not the input type. Selecting an internal `fp16`, `bf16`, or other quantizer does not enable FP16/BF16 input.
+
 ## Build parameters
 
 The minimal config consists of the three top-level fields (`dtype`, `metric_type`, `dim`).
@@ -122,6 +128,8 @@ For range search semantics, see [Range Search](../advanced/range_search.md).
 BruteForce supports both `RemoveMode::MARK_REMOVE` and `RemoveMode::FORCE_REMOVE`; neither mode
 needs an HGraph-style `support_force_remove` setting.
 
+When `use_attribute_filter: true` is enabled, neither removal mode is available. Rebuild the index instead if attribute-filtered data must be deleted.
+
 - `MARK_REMOVE` is the default. It records a tombstone, so the id is excluded from later searches
   while its vector storage remains allocated. `GetNumElements()` excludes marked ids and
   `GetNumberRemoved()` reports their count.
@@ -161,14 +169,15 @@ BruteForce advertises the following capability flags (see `BruteForce::InitFeatu
 | `SUPPORT_RANGE_SEARCH` / `SUPPORT_RANGE_SEARCH_WITH_ID_FILTER` | Available with non-training quantizers (`fp32`, `fp16`, `bf16`). |
 | `SUPPORT_DELETE_BY_ID` / `SUPPORT_DELETE_CONCURRENT` | `Remove` by id is supported. Searches and delete operations are synchronized; `FORCE_REMOVE` takes an exclusive lock. |
 | `SUPPORT_CAL_DISTANCE_BY_ID` | Distance lookup against stored vectors (non-training quantizers only). |
+| `SUPPORT_UPDATE_VECTOR_CONCURRENT` | `UpdateVector` replaces an existing FP32 vector with the same dimension. BruteForce has no graph connectivity check, so `force_update` does not change its update behavior. |
 | `SUPPORT_GET_RAW_VECTOR_BY_IDS` | Available only when `base_quantization_type` is `fp32` and either the metric is not `cosine` or the underlying quantizer holds molds (`hold_molds`). Quantized BruteForce indexes do **not** advertise this flag. |
 | `SUPPORT_CHECK_ID_EXIST` / `SUPPORT_CLONE` / `SUPPORT_ESTIMATE_MEMORY` / `SUPPORT_GET_MEMORY_USAGE` | Standard introspection and lifecycle. |
 | `SUPPORT_SERIALIZE_BINARY_SET` / `SUPPORT_SERIALIZE_FILE` / `SUPPORT_SERIALIZE_WRITE_FUNC` | Full save surface. |
 | `SUPPORT_DESERIALIZE_BINARY_SET` / `SUPPORT_DESERIALIZE_FILE` / `SUPPORT_DESERIALIZE_READER_SET` | Full load surface. (There is no `DESERIALIZE_WRITE_FUNC` counterpart — read paths use `READER_SET` instead.) |
 | `NEED_TRAIN` | Set when `base_quantization_type` is one of `sq8`, `sq4`, `sq8_uniform`, `sq4_uniform`, `pq`, `pqfs`, `rabitq`. |
 
-Notably **not** supported by BruteForce: `SUPPORT_UPDATE_VECTOR_CONCURRENT`,
-`SUPPORT_UPDATE_ID_CONCURRENT`, and `SUPPORT_EXPORT_MODEL`.
+Notably **not** supported by BruteForce: `SUPPORT_UPDATE_ID_CONCURRENT` and
+`SUPPORT_EXPORT_MODEL`.
 
 ## When to use BruteForce
 

--- a/docs/docs/en/src/indexes/ivf.md
+++ b/docs/docs/en/src/indexes/ivf.md
@@ -64,6 +64,10 @@ auto result = index->KnnSearch(
     R"({"ivf": {"scan_buckets_count": 16}})").value();
 ```
 
+## Input data type
+
+The public `Build`, `Add`, and search paths currently accept FP32 vectors supplied with `Dataset::Float32Vectors`; set `dtype` to `"float32"`. `base_quantization_type` selects internal encoding and storage and does not enable FP16/BF16 input. `dtype: "int8"` is not supported when creating an IVF index.
+
 ## Build parameters
 
 Build-time parameters live under `index_param`. See

--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -78,6 +78,10 @@ auto result = index->KnnSearch(
     R"({"pyramid": {"ef_search": 100}})").value();
 ```
 
+## Input data type
+
+The public `Build`, `Add`, and search paths currently accept FP32 vectors supplied with `Dataset::Float32Vectors`; set `dtype` to `"float32"`. `base_quantization_type` selects internal encoding and storage and does not by itself enable FP16, BF16, or INT8 input.
+
 ## Build parameters
 
 Build-time parameters live under `index_param`.

--- a/docs/docs/zh/src/advanced/index_lifecycle.md
+++ b/docs/docs/zh/src/advanced/index_lifecycle.md
@@ -8,17 +8,18 @@
 - `Clone` —— 对已有索引进行深拷贝。
 - `ExportModel` —— 将训练好的模型导出为空索引以复用。
 
-每个操作均为可选项，仅当底层索引通过 `index->CheckFeature(...)` 公布对应能力标志时才可用。
+每个操作均为可选项。带有专用能力标志的操作应通过 `index->CheckFeature(...)` 检查；`Remove`
+没有专用标志，必须按索引类型和 `RemoveMode` 判断。
 
 ## 能力标志
 
-| 操作              | 能力标志                                  | HGraph | IVF | SINDI |
-|-------------------|------------------------------------------|:------:|:---:|:-----:|
-| `Remove`          | _（暂无专用标志，参见下文）_              |   是   |  —  |   —   |
-| `UpdateVector`    | `SUPPORT_UPDATE_VECTOR_CONCURRENT`       |   是   |  —  |  是   |
-| `UpdateId`        | `SUPPORT_UPDATE_ID_CONCURRENT`           |   是   |  —  |  是   |
-| `Clone`           | `SUPPORT_CLONE`                          |   是   | 是  |   —   |
-| `ExportModel`     | `SUPPORT_EXPORT_MODEL`                   |   是   | 是  |   —   |
+| 操作 | 能力标志 | HGraph | Pyramid | IVF | BruteForce | SINDI |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| `Remove` | _（暂无专用标志，参见下文）_ | 是 | 仅 `RemoveMode::MARK_REMOVE` | 仅 `RemoveMode::MARK_REMOVE` | 是 | 仅 `RemoveMode::MARK_REMOVE` |
+| `UpdateVector` | `SUPPORT_UPDATE_VECTOR_CONCURRENT` | 是 | — | — | 是 | 是 |
+| `UpdateId` | `SUPPORT_UPDATE_ID_CONCURRENT` | 是 | — | — | — | 是 |
+| `Clone` | `SUPPORT_CLONE` | 是 | 是 | 是 | 是 | — |
+| `ExportModel` | `SUPPORT_EXPORT_MODEL` | 是 | 是 | 是 | — | — |
 
 对于带能力标志的操作，请在调用前通过 `index->CheckFeature(vsag::SUPPORT_*)` 在运行时进行检查；
 不支持的索引会返回 `UNSUPPORTED_INDEX_OPERATION`。`Remove` 目前未提供专用能力标志，是否可用
@@ -83,11 +84,20 @@ index->Remove(std::vector<int64_t>{id1, id2, id3});
 
 可运行示例：`examples/cpp/303_feature_remove.cpp`。
 
+### Pyramid 与 IVF 删除
+
+Pyramid 和 IVF 都只支持 `RemoveMode::MARK_REMOVE`：操作写入墓碑、让后续检索排除对应 id，但不会
+物理回收向量存储。两者均不支持 `FORCE_REMOVE`。
+
 ### BruteForce 删除
 
 BruteForce 也支持这两种模式，但它**不使用** HGraph 的 `support_force_remove` 配置。
 `MARK_REMOVE` 会写入墓碑并保留向量存储。`FORCE_REMOVE` 不需要额外配置：它会物理删除条目，必要时
 移动最后一个内部槽位，同时保持外部 id 不变。
+
+BruteForce 处于非 multi-vector 模式且启用 `use_attribute_filter: true` 时，不支持任一种删除模式；如需删除属性过滤数据，请重建索引。
+
+在 multi-vector 模式下，BruteForce 仅支持 `RemoveMode::MARK_REMOVE`，不支持 `FORCE_REMOVE`；即使启用 `use_attribute_filter: true` 也是如此。
 
 BruteForce 默认使用 `block_memory_io`。每个成功的物理删除批次都会将逻辑向量和可选额外信息存储收缩到
 存活条目数，并释放末尾完整的块；最后一个未填满的块会保留。标签表会在存活条目数不超过当前容量一半时
@@ -123,6 +133,9 @@ if (status.has_value() && *status) {
 
 将 `force_update` 置为 `true` 会跳过检查并强制更新；请谨慎使用，可能损失召回率。
 
+上述连通性检查适用于 HGraph。BruteForce 也支持使用维度相同的 FP32 向量进行 `UpdateVector`，但它
+没有图连通性检查，因此 `force_update` 不会改变更新行为。Pyramid 和 IVF 不支持 `UpdateVector`。
+
 ### `UpdateId`
 
 `UpdateId(old_id, new_id)` 重命名已有 id 而不动底层向量。成功返回 `true`，若 `old_id` 不存在
@@ -133,6 +146,9 @@ index->UpdateId(123, 456);
 ```
 
 结合 `UpdateVector`、`Remove`、`Add` 的可运行示例：`examples/cpp/305_feature_update.cpp`。
+
+多个索引可经共享的 label table 路径调用 `UpdateId`，但只有声明
+`SUPPORT_UPDATE_ID_CONCURRENT` 的索引承诺对应的并发更新语义。
 
 ## 克隆索引
 

--- a/docs/docs/zh/src/indexes/brute_force.md
+++ b/docs/docs/zh/src/indexes/brute_force.md
@@ -50,6 +50,12 @@ auto result = index->KnnSearch(query, /*topk=*/10, "{}").value();
 完整可运行示例见
 [`examples/cpp/105_index_brute_force.cpp`](https://github.com/antgroup/vsag/blob/main/examples/cpp/105_index_brute_force.cpp)。
 
+## 支持的输入数据类型
+
+当前公开的 `Build`、`Add`、`KnnSearch`、`RangeSearch` 与 `UpdateVector` 路径仅接受 FP32 向量。运行时通过 `Dataset::Float32Vectors` 传入向量；创建索引时 `dtype` 应设为 `"float32"`，不支持 `dtype: "int8"`。
+
+`base_quantization_type` 描述的是索引内部编码和存储，而非输入类型。选择内部 `fp16`、`bf16` 等量化器不会使 API 接受 FP16/BF16 输入。
+
 ## 构建参数
 
 最简配置只需要三个顶层字段（`dtype`、`metric_type`、`dim`）。大多数场景下不需要
@@ -115,6 +121,8 @@ auto r3 = index->RangeSearch(query, radius, R"({"parallelism": 8})").value();
 BruteForce 同时支持 `RemoveMode::MARK_REMOVE` 与 `RemoveMode::FORCE_REMOVE`；两种模式都不需要
 配置 HGraph 专用的 `support_force_remove`。
 
+启用 `use_attribute_filter: true` 时，BruteForce 不支持任一种删除模式；如需删除属性过滤数据，请重建索引。
+
 - `MARK_REMOVE` 是默认模式。它只写入墓碑标记，后续搜索会过滤该 id，但向量存储仍保持已分配状态。
   `GetNumElements()` 不计已标记的 id，`GetNumberRemoved()` 返回其数量。
 - `FORCE_REMOVE` 会物理删除请求的每条向量。必要时它用最后一个内部槽位覆盖被删除槽位，并保留被移动
@@ -147,14 +155,14 @@ BruteForce 声明的能力标志如下（参见 `BruteForce::InitFeatures`，
 | `SUPPORT_RANGE_SEARCH` / `SUPPORT_RANGE_SEARCH_WITH_ID_FILTER` | 仅在非训练型量化器（`fp32`、`fp16`、`bf16`）下可用。 |
 | `SUPPORT_DELETE_BY_ID` / `SUPPORT_DELETE_CONCURRENT` | 支持按 id 删除。查询和删除操作会同步；`FORCE_REMOVE` 会获取独占锁。 |
 | `SUPPORT_CAL_DISTANCE_BY_ID` | 与已存储向量计算距离（仅非训练型量化器）。 |
+| `SUPPORT_UPDATE_VECTOR_CONCURRENT` | 支持 `UpdateVector`：以维度相同的 FP32 向量替换已有向量。BruteForce 没有图连通性检查，因此 `force_update` 不改变更新行为。 |
 | `SUPPORT_GET_RAW_VECTOR_BY_IDS` | 仅当 `base_quantization_type = fp32`，且度量不是 `cosine` 或底层量化器持有向量范数（`hold_molds`）时才声明。量化的 BruteForce 索引**不会**声明该能力。 |
 | `SUPPORT_CHECK_ID_EXIST` / `SUPPORT_CLONE` / `SUPPORT_ESTIMATE_MEMORY` / `SUPPORT_GET_MEMORY_USAGE` | 标准的内省与生命周期接口。 |
 | `SUPPORT_SERIALIZE_BINARY_SET` / `SUPPORT_SERIALIZE_FILE` / `SUPPORT_SERIALIZE_WRITE_FUNC` | 完整的保存能力。 |
 | `SUPPORT_DESERIALIZE_BINARY_SET` / `SUPPORT_DESERIALIZE_FILE` / `SUPPORT_DESERIALIZE_READER_SET` | 完整的加载能力。（没有对应的 `DESERIALIZE_WRITE_FUNC`，读路径使用 `READER_SET` 形式。） |
 | `NEED_TRAIN` | 当 `base_quantization_type` 是 `sq8`、`sq4`、`sq8_uniform`、`sq4_uniform`、`pq`、`pqfs`、`rabitq` 之一时声明。 |
 
-BruteForce **不支持** 的能力包括：`SUPPORT_UPDATE_VECTOR_CONCURRENT`、
-`SUPPORT_UPDATE_ID_CONCURRENT`、`SUPPORT_EXPORT_MODEL`。
+BruteForce **不支持** 的能力包括：`SUPPORT_UPDATE_ID_CONCURRENT`、`SUPPORT_EXPORT_MODEL`。
 
 ## 适用场景
 

--- a/docs/docs/zh/src/indexes/ivf.md
+++ b/docs/docs/zh/src/indexes/ivf.md
@@ -59,6 +59,10 @@ auto result = index->KnnSearch(
     R"({"ivf": {"scan_buckets_count": 16}})").value();
 ```
 
+## 支持的输入数据类型
+
+当前公开的 `Build`、`Add` 和检索路径接收通过 `Dataset::Float32Vectors` 提供的 FP32 向量，`dtype` 应设为 `"float32"`。`base_quantization_type` 选择的是内部编码和存储，不会使 API 接受 FP16/BF16 输入。创建 IVF 索引时不支持 `dtype: "int8"`。
+
 ## 构建参数
 
 构建参数放在 `index_param` 下。完整列表请见 [索引参数](../resources/index_parameters.md)。

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -73,6 +73,10 @@ auto result = index->KnnSearch(
     R"({"pyramid": {"ef_search": 100}})").value();
 ```
 
+## 支持的输入数据类型
+
+当前公开的 `Build`、`Add` 和检索路径接收通过 `Dataset::Float32Vectors` 提供的 FP32 向量，`dtype` 应设为 `"float32"`。`base_quantization_type` 选择的是内部编码和存储，本身不会使 API 接受 FP16、BF16 或 INT8 输入。
+
 ## 构建参数
 
 构建参数放在 `index_param` 下。


### PR DESCRIPTION
## Summary

Align dense-index lifecycle and input-type documentation with the current implementation.

## Changes

- Document BruteForce `UpdateVector` support and its FP32 input contract.
- Document FP32 input boundaries for Pyramid, IVF, and BruteForce.
- Correct lifecycle coverage for Pyramid and IVF `MARK_REMOVE` support.
- Document BruteForce deletion restrictions with attribute filtering and multi-vector mode.

## Validation

- Ran `git diff --check`.
- Checked the corrected capability statements and the Chinese/English document pairs.
- No C++ code or tests changed.

## Related

- Related to #2761
