### PR TITLE
chore: enforce CamelCase struct names

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -50,7 +50,7 @@ AnalyzeTemporaryDtors: true
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,               value: lower_case }
   - { key: readability-identifier-naming.ClassCase,                   value: CamelCase  }
-  - { key: readability-identifier-naming.StructCase,                  value: lower_case }
+  - { key: readability-identifier-naming.StructCase,                  value: CamelCase  }
   - { key: readability-identifier-naming.TypeTemplateParameterCase,   value: CamelCase  }
   - { key: readability-identifier-naming.ValueTemplateParameterCase,  value: lower_case }
   - { key: readability-identifier-naming.FunctionCase,                value: lower_case } # c-style function

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ cov:                     ## Build unit tests with code coverage enabled.
 
 .PHONEY: lint
 lint:                    ## Check coding styles defined in `.clang-tidy`.
+	@./scripts/linters/check-struct-names.py
 	@./scripts/linters/run-clang-tidy-15.sh -p build-release/ -use-color -source-filter '^.*vsag\/src.*(?<!_test)\.cpp$$' -j ${COMPILE_JOBS}
 
 .PHONEY: fix-lint

--- a/scripts/linters/check-struct-names.py
+++ b/scripts/linters/check-struct-names.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+"""Check named struct definitions in tracked project C/C++ files."""
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+CPP_SUFFIXES = {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx", ".inl"}
+CAMEL_CASE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+EXCLUDED_PREFIXES = ("extern/", "vendor/", "third_party/", "build/", "build-")
+EXCLUDED_PARTS = {"generated", "hnsw", "diskann"}
+EXCLUDED_FILES = {"include/vsag/expected.hpp"}
+TOKEN = re.compile(
+    r"""(?P<space>\s+)|(?P<line_comment>//[^\n]*)|(?P<block_comment>/\*.*?\*/)|
+        (?P<raw_string>R\"(?P<delimiter>[^ ()\\\t\r\n]{0,16})\(.*?\)(?P=delimiter)\")|
+        (?P<string>\"(?:\\.|[^\"\\])*\")|(?P<char>'(?:\\.|[^'\\])*')|
+        (?P<identifier>[A-Za-z_][A-Za-z0-9_]*)|(?P<symbol>\[\[|\]\]|\#\#|::|.)""",
+    re.DOTALL | re.VERBOSE,
+)
+
+
+@dataclass(frozen=True)
+class Token:
+    text: str
+    line: int
+    identifier: bool
+
+
+def tokenize(source: str) -> list[Token]:
+    tokens = []
+    line = 1
+    for match in TOKEN.finditer(source):
+        text = match.group(0)
+        kind = match.lastgroup
+        if kind not in {"space", "line_comment", "block_comment", "raw_string", "string", "char"}:
+            tokens.append(Token(text, line, kind == "identifier"))
+        line += text.count("\n")
+    return tokens
+
+
+def skip_balanced(tokens: list[Token], index: int, opening: str, closing: str) -> int:
+    depth = 0
+    while index < len(tokens):
+        if tokens[index].text == opening:
+            depth += 1
+        elif tokens[index].text == closing:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    return index
+
+
+def struct_definitions(source: str) -> list[tuple[str, int]]:
+    tokens = tokenize(source)
+    definitions = []
+    index = 0
+    while index < len(tokens):
+        if tokens[index].text != "struct":
+            index += 1
+            continue
+
+        cursor = index + 1
+        while cursor < len(tokens):
+            if tokens[cursor].text in {"alignas", "__attribute__"} and cursor + 1 < len(tokens):
+                cursor = skip_balanced(tokens, cursor + 1, "(", ")")
+                continue
+            if tokens[cursor].text == "[[":
+                cursor = skip_balanced(tokens, cursor, "[[", "]]")
+                continue
+            break
+        if cursor >= len(tokens) or not tokens[cursor].identifier:
+            index += 1
+            continue
+
+        name = tokens[cursor]
+        cursor += 1
+        if cursor < len(tokens) and tokens[cursor].text == "##":
+            name_parts = [name.text]
+            while (
+                cursor + 1 < len(tokens)
+                and tokens[cursor].text == "##"
+                and tokens[cursor + 1].identifier
+            ):
+                name_parts.append(tokens[cursor + 1].text)
+                cursor += 2
+            name = Token("".join(name_parts), name.line, True)
+        elif cursor < len(tokens) and tokens[cursor].text == "<":
+            cursor = skip_balanced(tokens, cursor, "<", ">")
+        elif cursor < len(tokens) and tokens[cursor].identifier and tokens[cursor].text != "final":
+            index += 1
+            continue
+
+        while cursor < len(tokens) and tokens[cursor].text not in {"{", ";"}:
+            cursor += 1
+        if cursor < len(tokens) and tokens[cursor].text == "{":
+            definitions.append((name.text, name.line))
+        index += 1
+    return definitions
+
+
+def is_project_file(path: str) -> bool:
+    if Path(path).suffix not in CPP_SUFFIXES or path in EXCLUDED_FILES:
+        return False
+    if path.startswith(EXCLUDED_PREFIXES):
+        return False
+    return not any(part.lower() in EXCLUDED_PARTS for part in Path(path).parts)
+
+
+def tracked_files(root: Path) -> list[str]:
+    output = subprocess.check_output(["git", "ls-files"], cwd=root, text=True)
+    return [path for path in output.splitlines() if is_project_file(path)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*", help="files to check instead of the tracked project scope")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    root = args.root.resolve()
+    files = args.files or tracked_files(root)
+    failures = []
+    for filename in files:
+        path = Path(filename)
+        if not path.is_absolute():
+            path = root / path
+        for name, line in struct_definitions(path.read_text(errors="surrogateescape")):
+            if not CAMEL_CASE.fullmatch(name):
+                failures.append(f"{path.relative_to(root)}:{line}: struct '{name}' is not CamelCase")
+    if failures:
+        print("\n".join(failures))
+        return 1
+    print(f"Checked {len(files)} C/C++ files: all named struct definitions use CamelCase.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -819,9 +819,9 @@ HGraph::ensure_physical_code_capacity(CodeSlotIdType required_capacity) {
         return;
     }
     this->physical_code_resize_pending_.store(true, std::memory_order_release);
-    struct pending_reset_guard {
+    struct PendingResetGuard {
         std::atomic<bool>& pending;
-        ~pending_reset_guard() {
+        ~PendingResetGuard() {
             pending.store(false, std::memory_order_release);
         }
     } pending_reset{this->physical_code_resize_pending_};

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -541,7 +541,7 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         return make_empty_dataset_with_stats();
     }
 
-    struct visited_list_guard {
+    struct HGraphVisitedListGuard {
         std::shared_ptr<VisitedListPool> pool;
         VisitedListPtr visited_list;
 
@@ -553,11 +553,11 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
             }
         }
 
-        ~visited_list_guard() {
+        ~HGraphVisitedListGuard() {
             Release();
         }
     };
-    visited_list_guard vt_guard{this->pool_, this->pool_->TakeOne()};
+    HGraphVisitedListGuard vt_guard{this->pool_, this->pool_->TakeOne()};
     auto& vt = vt_guard.visited_list;
 
     const auto* raw_query = use_custom_distance ? nullptr : get_data(query);

--- a/src/algorithm/ivf/gno_imi_partition.cpp
+++ b/src/algorithm/ivf/gno_imi_partition.cpp
@@ -332,7 +332,7 @@ GNOIMIPartition::Serialize(StreamWriter& writer) {
     StreamWriter::WriteVector(writer, this->precomputed_terms_st_);
 }
 void
-GNOIMIPartition::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+GNOIMIPartition::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     IVFPartitionStrategy::Deserialize(reader);
     StreamReader::ReadObj<BucketIdType>(reader, this->bucket_count_s_);
     StreamReader::ReadObj<BucketIdType>(reader, this->bucket_count_t_);

--- a/src/algorithm/ivf/gno_imi_partition.h
+++ b/src/algorithm/ivf/gno_imi_partition.h
@@ -52,7 +52,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
 public:
     IVFNearestPartitionTrainerType trainer_type_{IVFNearestPartitionTrainerType::KMeansTrainer};

--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -152,7 +152,7 @@ IVFNearestPartition::Serialize(StreamWriter& writer) {
     this->route_index_ptr_->Serialize(writer);
 }
 void
-IVFNearestPartition::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+IVFNearestPartition::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     IVFPartitionStrategy::Deserialize(reader);
     this->route_index_ptr_->Deserialize(reader);
 }

--- a/src/algorithm/ivf/ivf_nearest_partition.h
+++ b/src/algorithm/ivf/ivf_nearest_partition.h
@@ -45,7 +45,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
     [[nodiscard]] uint64_t
     GetMemoryUsage() const override;

--- a/src/algorithm/ivf/ivf_partition_strategy.h
+++ b/src/algorithm/ivf/ivf_partition_strategy.h
@@ -80,7 +80,7 @@ public:
     }
 
     virtual void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) {
         StreamReader::ReadObj(reader, this->is_trained_);
         StreamReader::ReadObj(reader, this->bucket_count_);
         StreamReader::ReadObj(reader, this->dim_);

--- a/src/algorithm/mci/mci_mce.h
+++ b/src/algorithm/mci/mci_mce.h
@@ -8,7 +8,7 @@
 
 namespace vsag::mci {
 
-struct mce_stats {
+struct MceStats {
     uint64_t roots_seen = 0;
     uint64_t roots_skipped_by_degree = 0;
     uint64_t roots_skipped_no_must = 0;
@@ -21,11 +21,11 @@ struct mce_stats {
 
     void
     reset() {
-        *this = mce_stats{};
+        *this = MceStats{};
     }
 
     void
-    add(const mce_stats& other) {
+    add(const MceStats& other) {
         roots_seen += other.roots_seen;
         roots_skipped_by_degree += other.roots_skipped_by_degree;
         roots_skipped_no_must += other.roots_skipped_no_must;
@@ -139,7 +139,7 @@ public:
     std::vector<uint32_t> nxt_c;
     void
     reserve(uint32_t sz);
-    mce_stats stats;
+    MceStats stats;
     uint32_t max_clique_cnt_limit = std::numeric_limits<uint32_t>::max();
     uint32_t remaining_must_count = 0;
     bool stop_search = false;

--- a/src/algorithm/mci/mci_runner.h
+++ b/src/algorithm/mci/mci_runner.h
@@ -19,7 +19,7 @@ public:
     std::vector<bool> must_contain_nodes;
     // graph_mce g;
     mce mce_;
-    mce_stats last_stats;
+    MceStats last_stats;
 
     void
     re_id_and_build_csr_graph(std::vector<edge_type>& edge) {

--- a/src/algorithm/simq/simq.cpp
+++ b/src/algorithm/simq/simq.cpp
@@ -50,7 +50,7 @@ wait_all_futures(std::vector<std::future<void>>& futures);
 
 namespace {
 
-struct cluster_member_entry {
+struct ClusterMemberEntry {
     InnerIdType vec_id;
     float distance;
 };
@@ -142,7 +142,7 @@ public:
     Fit(const float* vecs, int64_t num_vecs, int64_t dim);
 
     std::vector<int> cluster_centers_;
-    std::unordered_map<int, std::vector<cluster_member_entry>> clusters_;
+    std::unordered_map<int, std::vector<ClusterMemberEntry>> clusters_;
     std::vector<int> vec_to_cluster_;
 
 private:
@@ -156,7 +156,7 @@ private:
     ip_distance(int v1, int v2) const;
 
     static void
-    sorted_insert(std::vector<cluster_member_entry>& members, InnerIdType vec_id, float dist);
+    sorted_insert(std::vector<ClusterMemberEntry>& members, InnerIdType vec_id, float dist);
 
     void
     split_cluster(int old_center_id, int64_t dim);
@@ -243,11 +243,11 @@ HGraphDynamicClustering::ip_distance(int v1, int v2) const {
 }
 
 void
-HGraphDynamicClustering::sorted_insert(std::vector<cluster_member_entry>& members,
+HGraphDynamicClustering::sorted_insert(std::vector<ClusterMemberEntry>& members,
                                        InnerIdType vec_id,
                                        float dist) {
     auto it = std::lower_bound(
-        members.begin(), members.end(), dist, [](const cluster_member_entry& e, float val) {
+        members.begin(), members.end(), dist, [](const ClusterMemberEntry& e, float val) {
             return e.distance < val;
         });
     members.insert(it, {vec_id, dist});
@@ -272,10 +272,10 @@ HGraphDynamicClustering::split_cluster(int old_center_id, int64_t /*dim*/) {
     }
 
     auto split_it = cluster.begin() + (split_start_idx_ - 1);
-    std::vector<cluster_member_entry> to_move(split_it, cluster.end());
+    std::vector<ClusterMemberEntry> to_move(split_it, cluster.end());
     cluster.erase(split_it, cluster.end());
 
-    std::vector<cluster_member_entry> new_cluster;
+    std::vector<ClusterMemberEntry> new_cluster;
     new_cluster.push_back({static_cast<InnerIdType>(new_center_id), 0.0F});
     vec_to_cluster_[new_center_id] = new_center_id;
 
@@ -755,7 +755,7 @@ SIMQ::Add(const DatasetPtr& data) {
     // cross-thread data race on the per-token vectors).
     // Cluster-level structures (cluster_lists_, cluster_token_counts_) are
     // collected per-thread and merged in Phase 4.
-    struct per_thread_cluster_data {
+    struct PerThreadClusterData {
         // cluster_idx → list of inner_ids that touch it (unique per thread)
         std::unordered_map<InnerIdType, std::vector<InnerIdType>> cluster_docs;
         // cluster_idx → token count contribution
@@ -772,7 +772,7 @@ SIMQ::Add(const DatasetPtr& data) {
     last_reported_pct_ = -1;
 
     if (use_parallel) {
-        Vector<per_thread_cluster_data> per_thread(num_docs, allocator_);
+        Vector<PerThreadClusterData> per_thread(num_docs, allocator_);
         std::vector<std::future<void>> futures;
         futures.reserve(num_docs);
 
@@ -1250,12 +1250,12 @@ SIMQ::coarse_search(const float* query_tokens,
 
     // Each query token's search is independent. We do all KnnSearch calls in
     // parallel, then sequentially propagate scores (which is fast O(k) per token).
-    struct token_search_result {
+    struct TokenSearchResult {
         std::vector<std::pair<float, InnerIdType>> cscores;
         int64_t actual_coarse_k{0};
         uint64_t dist_cmp{0};
     };
-    std::vector<token_search_result> token_results(query_token_count);
+    std::vector<TokenSearchResult> token_results(query_token_count);
 
     if (this->thread_pool_ && query_token_count > 1) {
         std::vector<std::future<void>> futures;

--- a/src/algorithm/sindi_v2/sindi_v2.cpp
+++ b/src/algorithm/sindi_v2/sindi_v2.cpp
@@ -264,7 +264,7 @@ make_top_terms_signature_key(const SparseVector& vector, uint32_t top_terms) {
     return {signature.begin(), signature.end()};
 }
 
-struct rerank_layout_record {
+struct RerankLayoutRecord {
     const SparseVector* vector{nullptr};
     InnerIdType inner_id{0};
     std::vector<uint64_t> signature;
@@ -272,7 +272,7 @@ struct rerank_layout_record {
 
 void
 write_rerank_flat_with_layout(const FlattenInterfacePtr& rerank_flat,
-                              std::vector<rerank_layout_record>& records,
+                              std::vector<RerankLayoutRecord>& records,
                               uint32_t rerank_layout) {
     if (rerank_layout > 0) {
         for (auto& record : records) {
@@ -520,7 +520,7 @@ SINDIV2::Add(const DatasetPtr& base) {
     if (use_reorder_ && rerank_type_ == SPARSE_RERANK_TYPE_DMQ8) {
         dmq_rerank_vectors.reserve(data_num);
     }
-    std::vector<rerank_layout_record> rerank_layout_records;
+    std::vector<RerankLayoutRecord> rerank_layout_records;
     if (use_reorder_ && rerank_layout_ > 0) {
         rerank_layout_records.reserve(data_num);
     }
@@ -654,7 +654,7 @@ SINDIV2::build_immutable(const DatasetPtr& base) {
     if (use_reorder_ && rerank_type_ == SPARSE_RERANK_TYPE_DMQ8) {
         dmq_rerank_vectors.reserve(data_num);
     }
-    std::vector<rerank_layout_record> rerank_layout_records;
+    std::vector<RerankLayoutRecord> rerank_layout_records;
     if (use_reorder_ && rerank_layout_ > 0) {
         rerank_layout_records.reserve(data_num);
     }

--- a/src/analyzer/sindi_analyzer.cpp
+++ b/src/analyzer/sindi_analyzer.cpp
@@ -43,7 +43,7 @@ is_sq8_value_quantization(SparseValueQuantizationType type) {
     return type == SparseValueQuantizationType::SQ8;
 }
 
-struct analyze_options {
+struct AnalyzeOptions {
     std::string base_path;
     std::string groundtruth_path;
     std::string save_groundtruth_path;
@@ -534,9 +534,9 @@ parse_sindi_search_json(const std::string& params_str) {
     return json;
 }
 
-analyze_options
+AnalyzeOptions
 parse_analyze_options(const JsonType& json) {
-    analyze_options options;
+    AnalyzeOptions options;
     if (not json.Contains("analyze")) {
         return options;
     }

--- a/src/attr/attr_type_schema.cpp
+++ b/src/attr/attr_type_schema.cpp
@@ -47,7 +47,7 @@ AttrTypeSchema::Serialize(StreamWriter& writer) {
 }
 
 void
-AttrTypeSchema::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+AttrTypeSchema::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     uint64_t size;
     StreamReader::ReadObj(reader, size);
     this->schema_.reserve(size);

--- a/src/attr/attr_type_schema.h
+++ b/src/attr/attr_type_schema.h
@@ -38,7 +38,7 @@ public:
     Serialize(StreamWriter& writer);
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader);
+    Deserialize(LvalueOrRvalue<StreamReader> reader);
 
 private:
     UnorderedMap<std::string, AttrValueType> schema_;

--- a/src/attr/multi_bitset_manager.cpp
+++ b/src/attr/multi_bitset_manager.cpp
@@ -90,7 +90,7 @@ MultiBitsetManager::Serialize(StreamWriter& writer) {
 }
 
 void
-MultiBitsetManager::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+MultiBitsetManager::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     StreamReader::ReadObj(reader, count_);
     this->bitset_map_.resize(count_, -1);
     for (uint64_t i = 0; i < count_; i++) {

--- a/src/attr/multi_bitset_manager.h
+++ b/src/attr/multi_bitset_manager.h
@@ -105,7 +105,7 @@ public:
      * @param reader The StreamReader to deserialize the MultiBitsetManager from.
      */
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader);
+    Deserialize(LvalueOrRvalue<StreamReader> reader);
 
     /**
      * @brief Retrieves the type of ComputableBitset instances managed by this object.

--- a/src/datacell/attribute_bucket_inverted_datacell.cpp
+++ b/src/datacell/attribute_bucket_inverted_datacell.cpp
@@ -200,7 +200,7 @@ AttributeBucketInvertedDataCell::Serialize(StreamWriter& writer) {
 }
 
 void
-AttributeBucketInvertedDataCell::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+AttributeBucketInvertedDataCell::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     AttributeInvertedInterface::Deserialize(reader);
     uint64_t size;
     StreamReader::ReadObj(reader, size);

--- a/src/datacell/attribute_bucket_inverted_datacell.h
+++ b/src/datacell/attribute_bucket_inverted_datacell.h
@@ -53,7 +53,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
     void
     GetAttribute(BucketIdType bucket_id, InnerIdType inner_id, AttributeSet* attr) override;

--- a/src/datacell/attribute_inverted_interface.h
+++ b/src/datacell/attribute_inverted_interface.h
@@ -74,7 +74,7 @@ public:
     }
 
     virtual void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) {
         this->field_type_map_.Deserialize(reader);
     }
 

--- a/src/datacell/bucket_datacell.h
+++ b/src/datacell/bucket_datacell.h
@@ -153,7 +153,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
     void
     InitIO(const IOParamPtr& io_param) override {
@@ -905,7 +905,7 @@ BucketDataCell<QuantTmpl, IOTmpl>::Serialize(StreamWriter& writer) {
 
 template <typename QuantTmpl, typename IOTmpl>
 void
-BucketDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+BucketDataCell<QuantTmpl, IOTmpl>::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     BucketInterface::Deserialize(reader);
     quantizer_->Deserialize(reader);
     this->backend_ =

--- a/src/datacell/bucket_interface.h
+++ b/src/datacell/bucket_interface.h
@@ -143,7 +143,7 @@ public:
     }
 
     virtual void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) {
         StreamReader::ReadObj(reader, this->bucket_count_);
         StreamReader::ReadObj(reader, this->code_size_);
     }

--- a/src/datacell/code_slot_flatten_adapter.cpp
+++ b/src/datacell/code_slot_flatten_adapter.cpp
@@ -231,7 +231,7 @@ public:
     }
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override {
         base_->Deserialize(std::move(reader));
         this->refresh_metadata();
     }

--- a/src/datacell/disk_sindi_term_datacell.cpp
+++ b/src/datacell/disk_sindi_term_datacell.cpp
@@ -291,12 +291,12 @@ DiskSindiTermDataCell<IOTmpl>::LoadQueryTermBuffers(const Vector<uint32_t>& quer
         return query_term_buffers;
     }
 
-    struct query_term_read_plan {
+    struct QueryTermReadPlan {
         uint32_t term_id{0};
         DiskTermEntry entry{};
     };
 
-    Vector<query_term_read_plan> read_plans(allocator);
+    Vector<QueryTermReadPlan> read_plans(allocator);
     UnorderedSet<uint32_t> planned_terms(allocator);
     read_plans.reserve(query_term_ids.size());
     planned_terms.reserve(query_term_ids.size());
@@ -328,7 +328,7 @@ DiskSindiTermDataCell<IOTmpl>::LoadQueryTermBuffers(const Vector<uint32_t>& quer
         }
     }
 
-    const auto validate_entry = [payload_size](const query_term_read_plan& plan) {
+    const auto validate_entry = [payload_size](const QueryTermReadPlan& plan) {
         const auto& entry = plan.entry;
         const bool valid_entry =
             entry.posting_payload_offset <= payload_size &&

--- a/src/datacell/flatten_datacell.h
+++ b/src/datacell/flatten_datacell.h
@@ -173,7 +173,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
     inline void
     SetQuantizer(std::shared_ptr<Quantizer<QuantTmpl>> quantizer) {
@@ -487,7 +487,7 @@ FlattenDataCell<QuantTmpl, LayoutTmpl>::Serialize(StreamWriter& writer) {
 
 template <typename QuantTmpl, typename LayoutTmpl>
 void
-FlattenDataCell<QuantTmpl, LayoutTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+FlattenDataCell<QuantTmpl, LayoutTmpl>::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     FlattenInterface::Deserialize(reader);
     this->layout_->SetCodeSize(this->code_size_);
     this->layout_->Deserialize(reader);

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -267,7 +267,7 @@ public:
     }
 
     virtual void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) {
         StreamReader::ReadObj(reader, this->total_count_);
         StreamReader::ReadObj(reader, this->max_capacity_);
         StreamReader::ReadObj(reader, this->code_size_);

--- a/src/datacell/multi_vector_datacell.h
+++ b/src/datacell/multi_vector_datacell.h
@@ -114,7 +114,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
     uint64_t
     GetMemoryUsage() const override;

--- a/src/datacell/multi_vector_datacell.inl
+++ b/src/datacell/multi_vector_datacell.inl
@@ -219,7 +219,7 @@ MultiVectorDataCell<QuantTmpl, IOTmpl>::Serialize(StreamWriter& writer) {
 
 template <typename QuantTmpl, typename IOTmpl>
 void
-MultiVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+MultiVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     FlattenInterface::Deserialize(reader);
     StreamReader::ReadObj(reader, multi_vector_dim_);
     uint64_t current_offset = 0;

--- a/src/datacell/rabitq_split_datacell.h
+++ b/src/datacell/rabitq_split_datacell.h
@@ -867,7 +867,7 @@ public:
     }
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override {
         FlattenInterface::Deserialize(reader);
         this->DeserializeSupplementIOType(reader);
         this->x_bit_layout_->Deserialize(reader);

--- a/src/datacell/sparse_dmq_datacell.cpp
+++ b/src/datacell/sparse_dmq_datacell.cpp
@@ -227,7 +227,7 @@ SparseDmqDataCell::Serialize(StreamWriter& writer) {
 }
 
 void
-SparseDmqDataCell::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+SparseDmqDataCell::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     std::unique_lock lock(this->mutex_);
     uint32_t magic = 0;
     StreamReader::ReadObj(reader, magic);

--- a/src/datacell/sparse_dmq_datacell.h
+++ b/src/datacell/sparse_dmq_datacell.h
@@ -91,7 +91,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
     [[nodiscard]] uint64_t
     GetMemoryUsage() const override;

--- a/src/datacell/sparse_vector_datacell.h
+++ b/src/datacell/sparse_vector_datacell.h
@@ -149,7 +149,7 @@ public:
     Serialize(StreamWriter& writer) override;
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) override;
+    Deserialize(LvalueOrRvalue<StreamReader> reader) override;
 
     inline void
     SetQuantizer(std::shared_ptr<Quantizer<QuantTmpl>> quantizer) {

--- a/src/datacell/sparse_vector_datacell.inl
+++ b/src/datacell/sparse_vector_datacell.inl
@@ -162,7 +162,7 @@ SparseVectorDataCell<QuantTmpl, IOTmpl>::query(float* result_dists,
 }
 template <typename QuantTmpl, typename IOTmpl>
 void
-SparseVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+SparseVectorDataCell<QuantTmpl, IOTmpl>::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     FlattenInterface::Deserialize(reader);
 
     uint32_t maybe_sentinel = 0;

--- a/src/factory/factory.cpp
+++ b/src/factory/factory.cpp
@@ -224,13 +224,13 @@ apply_ivf_streaming_load_parameters(JsonType& index_param, const LoadParameters&
     }
 }
 
-struct streaming_index_load_target {
+struct StreamingIndexLoadTarget {
     IndexPtr index;
     InnerIndexPtr inner_index;
 };
 
 template <typename IndexT, typename ParamT>
-streaming_index_load_target
+StreamingIndexLoadTarget
 create_streaming_index(const JsonType& index_param, const IndexCommonParam& common_param) {
     auto param = std::make_shared<ParamT>();
     param->FromJson(index_param);
@@ -238,7 +238,7 @@ create_streaming_index(const JsonType& index_param, const IndexCommonParam& comm
     return {std::make_shared<IndexImpl<IndexT>>(inner_index, common_param), inner_index};
 }
 
-tl::expected<streaming_index_load_target, Error>
+tl::expected<StreamingIndexLoadTarget, Error>
 create_streaming_index_from_metadata(const MetadataPtr& metadata,
                                      const LoadParameters& parameters,
                                      Allocator* allocator) {
@@ -326,7 +326,7 @@ Index::GetStreamingMetadata(std::istream& in_stream) {
             StreamingIndexMetadata result;
             result.metadata_json = std::move(stream_header.metadata_string);
 
-            struct manifest_block {
+            struct ManifestBlock {
                 std::string name;
                 uint32_t tag{0};
                 uint32_t version{0};
@@ -334,13 +334,13 @@ Index::GetStreamingMetadata(std::istream& in_stream) {
                 uint64_t payload_size{0};
                 bool has_payload_size{false};
             };
-            std::vector<manifest_block> manifest_blocks;
+            std::vector<ManifestBlock> manifest_blocks;
             auto manifest = stream_header.metadata->Get("block_manifest");
             if (manifest.IsArray()) {
                 const auto* manifest_json = manifest.GetInnerJson();
                 manifest_blocks.reserve(manifest_json->size());
                 for (const auto& block_json : *manifest_json) {
-                    manifest_block block;
+                    ManifestBlock block;
                     block.name = block_json.value("name", std::string{});
                     block.tag = block_json.value("tag", 0U);
                     block.version = block_json.value("version", 0U);

--- a/src/impl/allocator/allocator_wrapper.h
+++ b/src/impl/allocator/allocator_wrapper.h
@@ -74,9 +74,12 @@ public:
     }
 
     template <class U>
-    struct rebind {
+    struct Rebind {
         using other = AllocatorWrapper<U>;
     };
+
+    template <class U>
+    using rebind = Rebind<U>;
 
     Allocator* allocator_{};
 };

--- a/src/impl/label_table/label_table.h
+++ b/src/impl/label_table/label_table.h
@@ -183,7 +183,7 @@ public:
     }
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) {
         StreamReader::ReadVector(reader, label_table_);
         if (use_reverse_map_) {
             this->label_remap_.Clear();

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -33,7 +33,7 @@ GENERATE_HAS_STATIC_CLASS_FUNCTION(CheckAndMappingExternalParam,
 template <class T>
 class IndexImpl : public Index {
     static_assert(std::is_base_of<InnerIndexInterface, T>::value);
-    static_assert(has_static_CheckAndMappingExternalParam<T>::value);
+    static_assert(HasStaticCheckAndMappingExternalParam<T>::value);
 
 public:
     IndexImpl(const JsonType& external_param, const IndexCommonParam& common_param)

--- a/src/io/common/basic_io.h
+++ b/src/io/common/basic_io.h
@@ -92,7 +92,7 @@ public:
      */
     inline void
     Write(const uint8_t* data, uint64_t size, uint64_t offset) {
-        static_assert(has_WriteImpl<IOTmpl>::value);
+        static_assert(HasWriteImpl<IOTmpl>::value);
         cast().WriteImpl(data, size, offset);
         if constexpr (not InMemory) {
             InvalidateCacheRange(size, offset);
@@ -112,7 +112,7 @@ public:
      */
     inline bool
     Read(uint64_t size, uint64_t offset, uint8_t* data) const {
-        static_assert(has_ReadImpl<IOTmpl>::value);
+        static_assert(HasReadImpl<IOTmpl>::value);
         if constexpr (not InMemory) {
             const auto cache = GetReadCacheSnapshot();
             if (cache.cache != nullptr) {
@@ -135,7 +135,7 @@ public:
      */
     [[nodiscard]] inline const uint8_t*
     Read(uint64_t size, uint64_t offset, bool& need_release) const {
-        static_assert(has_DirectReadImpl<IOTmpl>::value);
+        static_assert(HasDirectReadImpl<IOTmpl>::value);
         if constexpr (not InMemory) {
             const auto cache = GetReadCacheSnapshot();
             if (cache.cache != nullptr) {
@@ -180,7 +180,7 @@ public:
      */
     inline bool
     MultiRead(uint8_t* datas, uint64_t* sizes, uint64_t* offsets, uint64_t count) const {
-        static_assert(has_MultiReadImpl<IOTmpl>::value);
+        static_assert(HasMultiReadImpl<IOTmpl>::value);
         if constexpr (not InMemory) {
             const auto cache = GetReadCacheSnapshot();
             if (cache.cache != nullptr) {
@@ -295,7 +295,7 @@ public:
      */
     inline void
     Prefetch(uint64_t offset, uint64_t cache_line = 64) {
-        if constexpr (has_PrefetchImpl<IOTmpl>::value) {
+        if constexpr (HasPrefetchImpl<IOTmpl>::value) {
             return cast().PrefetchImpl(offset, cache_line);
         }
     }
@@ -336,7 +336,7 @@ public:
         } else {
             // Reset the logical and physical extent so a shorter deserialization
             // cannot retain stale bytes from a previously opened file.
-            if constexpr (has_ResizeImpl<IOTmpl>::value) {
+            if constexpr (HasResizeImpl<IOTmpl>::value) {
                 if (size > 0 or SupportsZeroSizeResize<IOTmpl>::value) {
                     Resize(size);
                 } else {
@@ -378,7 +378,7 @@ public:
                 return;
             }
         }
-        if constexpr (has_ReleaseImpl<IOTmpl>::value) {
+        if constexpr (HasReleaseImpl<IOTmpl>::value) {
             return cast().ReleaseImpl(data);
         }
     }
@@ -404,14 +404,14 @@ public:
                 ClearCache();
             }
         }
-        if constexpr (has_InitIOImpl<IOTmpl>::value) {
+        if constexpr (HasInitIOImpl<IOTmpl>::value) {
             return cast().InitIOImpl(io_param);
         }
     }
 
     inline void
     Resize(uint64_t size) {
-        if constexpr (has_ResizeImpl<IOTmpl>::value) {
+        if constexpr (HasResizeImpl<IOTmpl>::value) {
             cast().ResizeImpl(size);
         } else {
             const auto current_size = this->size_.load(std::memory_order_acquire);
@@ -434,7 +434,7 @@ public:
 
     inline void
     Shrink(uint64_t size) {
-        if constexpr (has_ShrinkImpl<IOTmpl>::value) {
+        if constexpr (HasShrinkImpl<IOTmpl>::value) {
             cast().ShrinkImpl(size);
         } else {
             if (size <= this->size_.load(std::memory_order_acquire)) {
@@ -448,7 +448,7 @@ public:
 
     inline int64_t
     GetMemoryUsage() const {
-        if constexpr (has_GetMemoryUsageImpl<IOTmpl>::value) {
+        if constexpr (HasGetMemoryUsageImpl<IOTmpl>::value) {
             return cast().GetMemoryUsageImpl();
         }
         return this->size_.load(std::memory_order_acquire);

--- a/src/layout/byte_range_layout.h
+++ b/src/layout/byte_range_layout.h
@@ -126,7 +126,7 @@ public:
     }
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) {
         io_->Deserialize(reader);
     }
 

--- a/src/layout/fixed_layout.h
+++ b/src/layout/fixed_layout.h
@@ -158,7 +158,7 @@ public:
     }
 
     void
-    Deserialize(lvalue_or_rvalue<StreamReader> reader) {
+    Deserialize(LvalueOrRvalue<StreamReader> reader) {
         io_->Deserialize(reader);
     }
 

--- a/src/quantization/quantizer.h
+++ b/src/quantization/quantizer.h
@@ -196,7 +196,7 @@ public:
                              const uint8_t* codes,
                              float threshold,
                              float* dists) const {
-        if constexpr (has_ComputeDistWithThresholdImpl<QuantT>::value) {
+        if constexpr (HasComputeDistWithThresholdImpl<QuantT>::value) {
             return cast().ComputeDistWithThresholdImpl(computer, codes, threshold, dists);
         } else {
             cast().ComputeDistImpl(computer, codes, dists);
@@ -209,7 +209,7 @@ public:
                               const uint8_t* codes,
                               float* dists,
                               float* lower_bound) const {
-        if constexpr (has_ComputeDistWithLowerBoundImpl<QuantT>::value) {
+        if constexpr (HasComputeDistWithLowerBoundImpl<QuantT>::value) {
             return cast().ComputeDistWithLowerBoundImpl(computer, codes, dists, lower_bound);
         } else {
             cast().ComputeDistImpl(computer, codes, dists);
@@ -256,7 +256,7 @@ public:
                        float& dists2,
                        float& dists3,
                        float& dists4) const {
-        if constexpr (has_ComputeDistsBatch4Impl<QuantT>::value) {
+        if constexpr (HasComputeDistsBatch4Impl<QuantT>::value) {
             cast().ComputeDistsBatch4Impl(
                 computer, codes1, codes2, codes3, codes4, dists1, dists2, dists3, dists4);
         } else {

--- a/src/simd/avx.cpp
+++ b/src/simd/avx.cpp
@@ -79,7 +79,7 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_AVX)
-    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::AVX_Tag>>(
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::AvxTag>>(
         single_dim_centers, single_dim_val, result, &sse::PQDistanceFloat256);
 #else
     return sse::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
@@ -106,7 +106,7 @@ __inline __m256i __attribute__((__always_inline__)) load_8_char_and_convert(cons
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::ComputeIPImpl<simd::SimdTraits<simd::AVX_Tag>>(
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::AvxTag>>(
         query, codes, dim, &sse::FP32ComputeIP);
 #else
     return sse::FP32ComputeIP(query, codes, dim);
@@ -116,7 +116,7 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::AVX_Tag>>(
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::AvxTag>>(
         query, codes, dim, &sse::FP32ComputeL2Sqr);
 #else
     return sse::FP32ComputeL2Sqr(query, codes, dim);
@@ -163,7 +163,7 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_AVX)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX_Tag>, simd::Batch4Kind::IP>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AvxTag>, simd::Batch4Kind::IP>(
         query,
         dim,
         codes1,
@@ -193,7 +193,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_AVX)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX_Tag>, simd::Batch4Kind::L2>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AvxTag>, simd::Batch4Kind::L2>(
         query,
         dim,
         codes1,
@@ -214,7 +214,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Sub>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AvxTag>, simd::BinaryOp::Sub>(
         x, y, z, dim, &sse::FP32Sub);
 #else
     sse::FP32Sub(x, y, z, dim);
@@ -224,7 +224,7 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Add>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AvxTag>, simd::BinaryOp::Add>(
         x, y, z, dim, &sse::FP32Add);
 #else
     sse::FP32Add(x, y, z, dim);
@@ -234,7 +234,7 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Mul>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AvxTag>, simd::BinaryOp::Mul>(
         x, y, z, dim, &sse::FP32Mul);
 #else
     sse::FP32Mul(x, y, z, dim);
@@ -244,7 +244,7 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX_Tag>, simd::BinaryOp::Div>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::AvxTag>, simd::BinaryOp::Div>(
         x, y, z, dim, &sse::FP32Div);
 #else
     sse::FP32Div(x, y, z, dim);
@@ -280,7 +280,7 @@ __inline __m256i __attribute__((__always_inline__)) load_8_short(const uint16_t*
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::AVX_BF16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::AvxBF16Tag>>(
         query, codes, dim, &sse::BF16ComputeIP);
 #else
     return sse::BF16ComputeIP(query, codes, dim);
@@ -290,7 +290,7 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::AVX_BF16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::AvxBF16Tag>>(
         query, codes, dim, &sse::BF16ComputeL2Sqr);
 #else
     return sse::BF16ComputeL2Sqr(query, codes, dim);
@@ -300,7 +300,7 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::AVX_FP16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::AvxFP16Tag>>(
         query, codes, dim, &sse::FP16ComputeIP);
 #else
     return sse::FP16ComputeIP(query, codes, dim);
@@ -310,7 +310,7 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::AVX_FP16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::AvxFP16Tag>>(
         query, codes, dim, &sse::FP16ComputeL2Sqr);
 #else
     return sse::FP16ComputeL2Sqr(query, codes, dim);
@@ -372,7 +372,7 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::AvxSQ8Tag>>(
         query, codes, lower_bound, diff, dim, &sse::SQ8ComputeIP);
 #else
     return sse::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
@@ -386,7 +386,7 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::AvxSQ8Tag>>(
         query, codes, lower_bound, diff, dim, &sse::SQ8ComputeL2Sqr);
 #else
     return sse::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -400,7 +400,7 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::AvxSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &sse::SQ8ComputeCodesIP);
 #else
     return sse::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -414,7 +414,7 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::AVX_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::AvxSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &sse::SQ8ComputeCodesL2Sqr);
 #else
     return sse::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -518,7 +518,7 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::AvxSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &sse::SQ4ComputeIP);
 #else
     return sse::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
@@ -532,7 +532,7 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::AvxSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &sse::SQ4ComputeL2Sqr);
 #else
     return sse::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -546,7 +546,7 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::AvxSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesIP);
 #else
     return sse::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -560,7 +560,7 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::AVX_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::AvxSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesL2Sqr);
 #else
     return sse::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -604,7 +604,7 @@ SQ8UniformComputeCodesIPBatch(const uint8_t* RESTRICT query,
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_AVX)
-    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::AVX_RaBitQ_Tag>>(
+    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::AvxRaBitQTag>>(
         vector, bits, dim, inv_sqrt_d, &sse::RaBitQFloatBinaryIP);
 #else
     return sse::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
@@ -621,7 +621,7 @@ RaBitQFloatBinaryIPBatch4(const float* vector,
                           float inv_sqrt_d,
                           float* results) {
 #if defined(ENABLE_AVX)
-    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::AVX_RaBitQ_Tag>>(
+    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::AvxRaBitQTag>>(
         vector,
         bits1,
         bits2,
@@ -656,7 +656,7 @@ RaBitQFloatSplitCodeIP(const float* vector,
                        uint64_t dim,
                        uint32_t supplement_bits) {
 #if defined(ENABLE_AVX)
-    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::AVX_RaBitQ_Tag>>(
+    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::AvxRaBitQTag>>(
         vector, one_bit_code, supplement_code, dim, supplement_bits);
 #else
     return sse::RaBitQFloatSplitCodeIP(vector, one_bit_code, supplement_code, dim, supplement_bits);
@@ -674,7 +674,7 @@ RaBitQFloatSupplementCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX)
-    simd::DivScalarImpl<simd::SimdTraits<simd::AVX_Tag>>(from, to, dim, scalar, &sse::DivScalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::AvxTag>>(from, to, dim, scalar, &sse::DivScalar);
 #else
     sse::DivScalar(from, to, dim, scalar);
 #endif
@@ -702,7 +702,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    simd::BitAndImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, y, num_byte, result, &sse::BitAnd);
+    simd::BitAndImpl<simd::BitTraits<simd::AvxBitTag>>(x, y, num_byte, result, &sse::BitAnd);
 #else
     return sse::BitAnd(x, y, num_byte, result);
 #endif
@@ -711,7 +711,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    simd::BitOrImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, y, num_byte, result, &sse::BitOr);
+    simd::BitOrImpl<simd::BitTraits<simd::AvxBitTag>>(x, y, num_byte, result, &sse::BitOr);
 #else
     return sse::BitOr(x, y, num_byte, result);
 #endif
@@ -720,7 +720,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    simd::BitXorImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, y, num_byte, result, &sse::BitXor);
+    simd::BitXorImpl<simd::BitTraits<simd::AvxBitTag>>(x, y, num_byte, result, &sse::BitXor);
 #else
     return sse::BitXor(x, y, num_byte, result);
 #endif
@@ -729,7 +729,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX)
-    simd::BitNotImpl<simd::BitTraits<simd::AVX_Bit_Tag>>(x, num_byte, result, &sse::BitNot);
+    simd::BitNotImpl<simd::BitTraits<simd::AvxBitTag>>(x, num_byte, result, &sse::BitNot);
 #else
     return sse::BitNot(x, num_byte, result);
 #endif
@@ -737,7 +737,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX)
-    simd::VecRescaleImpl<simd::SimdTraits<simd::AVX_Tag>>(data, dim, val, &sse::VecRescale);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::AvxTag>>(data, dim, val, &sse::VecRescale);
 #else
     sse::VecRescale(data, dim, val);
 #endif
@@ -746,7 +746,7 @@ VecRescale(float* data, uint64_t dim, float val) {
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_AVX)
-    simd::RotateOpImpl<simd::SimdTraits<simd::AVX_Tag>>(data, idx, dim_, step);
+    simd::RotateOpImpl<simd::SimdTraits<simd::AvxTag>>(data, idx, dim_, step);
 #else
     sse::RotateOp(data, idx, dim_, step);
 #endif
@@ -775,7 +775,7 @@ FHTRotate(float* data, uint64_t dim_) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX)
-    simd::KacsWalkImpl<simd::SimdTraits<simd::AVX_Tag>>(data, len, &sse::KacsWalk);
+    simd::KacsWalkImpl<simd::SimdTraits<simd::AvxTag>>(data, len, &sse::KacsWalk);
 #else
     sse::KacsWalk(data, len);
 #endif
@@ -784,7 +784,7 @@ KacsWalk(float* data, uint64_t len) {
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_AVX)
-    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX_Tag>>(
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::AvxTag>>(
         from, centroid, to, dim, &sse::NormalizeWithCentroid);
 #else
     return sse::NormalizeWithCentroid(from, centroid, to, dim);
@@ -795,7 +795,7 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_AVX)
-    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX_Tag>>(
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::AvxTag>>(
         from, centroid, to, dim, norm, &sse::InverseNormalizeWithCentroid);
 #else
     sse::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);

--- a/src/simd/avx2.cpp
+++ b/src/simd/avx2.cpp
@@ -83,7 +83,7 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_AVX2)
-    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::AVX2_Tag>>(
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::Avx2Tag>>(
         single_dim_centers, single_dim_val, result, &avx::PQDistanceFloat256);
 #else
     return avx::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
@@ -104,7 +104,7 @@ __inline __m128i __attribute__((__always_inline__)) load_8_char(const uint8_t* d
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::ComputeIPImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::Avx2Tag>>(
         query, codes, dim, &sse::FP32ComputeIP);
 #else
     return avx::FP32ComputeIP(query, codes, dim);
@@ -114,7 +114,7 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::Avx2Tag>>(
         query, codes, dim, &sse::FP32ComputeL2Sqr);
 #else
     return avx::FP32ComputeL2Sqr(query, codes, dim);
@@ -167,7 +167,7 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_AVX2)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX2_Tag>, simd::Batch4Kind::IP>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Avx2Tag>, simd::Batch4Kind::IP>(
         query,
         dim,
         codes1,
@@ -197,7 +197,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_AVX2)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX2_Tag>, simd::Batch4Kind::L2>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Avx2Tag>, simd::Batch4Kind::L2>(
         query,
         dim,
         codes1,
@@ -218,7 +218,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Sub>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx2Tag>, simd::BinaryOp::Sub>(
         x, y, z, dim, &sse::FP32Sub);
 #else
     return sse::FP32Sub(x, y, z, dim);
@@ -228,7 +228,7 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Add>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx2Tag>, simd::BinaryOp::Add>(
         x, y, z, dim, &sse::FP32Add);
 #else
     return sse::FP32Add(x, y, z, dim);
@@ -238,7 +238,7 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Mul>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx2Tag>, simd::BinaryOp::Mul>(
         x, y, z, dim, &sse::FP32Mul);
 #else
     return sse::FP32Mul(x, y, z, dim);
@@ -248,7 +248,7 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX2_Tag>, simd::BinaryOp::Div>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx2Tag>, simd::BinaryOp::Div>(
         x, y, z, dim, &sse::FP32Div);
 #else
     return sse::FP32Div(x, y, z, dim);
@@ -257,7 +257,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::ReduceAddImpl<simd::SimdTraits<simd::AVX2_Tag>>(x, dim, &sse::FP32ReduceAdd);
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::Avx2Tag>>(x, dim, &sse::FP32ReduceAdd);
 #else
     return sse::FP32ReduceAdd(x, dim);
 #endif
@@ -274,7 +274,7 @@ __inline __m256i __attribute__((__always_inline__)) load_8_short(const uint16_t*
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::AVX2_BF16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::Avx2BF16Tag>>(
         query, codes, dim, &avx::BF16ComputeIP);
 #else
     return avx::BF16ComputeIP(query, codes, dim);
@@ -284,7 +284,7 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::AVX2_BF16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::Avx2BF16Tag>>(
         query, codes, dim, &avx::BF16ComputeL2Sqr);
 #else
     return avx::BF16ComputeL2Sqr(query, codes, dim);
@@ -294,7 +294,7 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::AVX2_FP16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::Avx2FP16Tag>>(
         query, codes, dim, &avx::FP16ComputeIP);
 #else
     return avx::FP16ComputeIP(query, codes, dim);
@@ -304,7 +304,7 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::AVX2_FP16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::Avx2FP16Tag>>(
         query, codes, dim, &avx::FP16ComputeL2Sqr);
 #else
     return avx::FP16ComputeL2Sqr(query, codes, dim);
@@ -349,7 +349,7 @@ FP16SparseAccumulate(float* RESTRICT dists,
 float
 INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::AVX2_Int8_Tag>>(
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::Avx2Int8Tag>>(
         query, codes, dim, &avx::INT8ComputeL2Sqr);
 #else
     return sse::INT8ComputeL2Sqr(query, codes, dim);
@@ -359,7 +359,7 @@ INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uin
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::AVX2_Int8_Tag>>(
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::Avx2Int8Tag>>(
         query, codes, dim, &avx::INT8ComputeIP);
 #else
     return sse::INT8ComputeIP(query, codes, dim);
@@ -373,7 +373,7 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::Avx2SQ8Tag>>(
         query, codes, lower_bound, diff, dim, &avx::SQ8ComputeIP);
 #else
     return avx::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
@@ -387,7 +387,7 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::Avx2SQ8Tag>>(
         query, codes, lower_bound, diff, dim, &avx::SQ8ComputeL2Sqr);
 #else
     return avx::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -401,7 +401,7 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::Avx2SQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &avx::SQ8ComputeCodesIP);
 #else
     return avx::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -415,7 +415,7 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::Avx2SQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &avx::SQ8ComputeCodesL2Sqr);
 #else
     return avx::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -523,7 +523,7 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::Avx2SQ4Tag>>(
         query, codes, lower_bound, diff, dim, &sse::SQ4ComputeIP);
 #else
     return sse::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
@@ -537,7 +537,7 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::Avx2SQ4Tag>>(
         query, codes, lower_bound, diff, dim, &sse::SQ4ComputeL2Sqr);
 #else
     return sse::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -551,7 +551,7 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::Avx2SQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesIP);
 #else
     return sse::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -565,7 +565,7 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::AVX2_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::Avx2SQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &sse::SQ4ComputeCodesL2Sqr);
 #else
     return sse::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -577,7 +577,7 @@ SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX2_Uniform_Tag>>(
+    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::Avx2UniformTag>>(
         codes1, codes2, dim, &avx::SQ4UniformComputeCodesIP);
 #else
     return avx::SQ4UniformComputeCodesIP(codes1, codes2, dim);
@@ -589,7 +589,7 @@ SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX2_Uniform_Tag>>(
+    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::Avx2UniformTag>>(
         codes1, codes2, dim, &avx::SQ8UniformComputeCodesIP);
 #else
     return avx::SQ8UniformComputeCodesIP(codes1, codes2, dim);
@@ -611,7 +611,7 @@ SQ8UniformComputeCodesIPBatch(const uint8_t* RESTRICT query,
 float
 RaBitQFloatSQIP(const float* vector, const uint8_t* codes, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::RaBitQFloatScalarIPImpl<simd::SQ8Traits<simd::AVX2_SQ8_Tag>>(
+    return simd::RaBitQFloatScalarIPImpl<simd::SQ8Traits<simd::Avx2SQ8Tag>>(
         vector, codes, dim, &generic::RaBitQFloatSQIP);
 #else
     return generic::RaBitQFloatSQIP(vector, codes, dim);
@@ -621,7 +621,7 @@ RaBitQFloatSQIP(const float* vector, const uint8_t* codes, uint64_t dim) {
 uint64_t
 RaBitQCodeCodeIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::RaBitQScalarCodesIPImpl<simd::UniformCodeTraits<simd::AVX2_Uniform_Tag>>(
+    return simd::RaBitQScalarCodesIPImpl<simd::UniformCodeTraits<simd::Avx2UniformTag>>(
         codes1, codes2, dim, &generic::RaBitQCodeCodeIP);
 #else
     return generic::RaBitQCodeCodeIP(codes1, codes2, dim);
@@ -667,7 +667,7 @@ RaBitQPackScalarToSplitPlanes(const uint8_t* scalar_codes,
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_AVX2)
-    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::Avx2RaBitQTag>>(
         vector, bits, dim, inv_sqrt_d, &avx::RaBitQFloatBinaryIP);
 #else
     return avx::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
@@ -684,7 +684,7 @@ RaBitQFloatBinaryIPBatch4(const float* vector,
                           float inv_sqrt_d,
                           float* results) {
 #if defined(ENABLE_AVX2)
-    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::Avx2RaBitQTag>>(
         vector,
         bits1,
         bits2,
@@ -783,7 +783,7 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
 float
 RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::RaBitQFloatTwoBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+    return simd::RaBitQFloatTwoBitCenteredIPImpl<simd::RaBitQTraits<simd::Avx2RaBitQTag>>(
         vector, bits, dim, &generic::RaBitQFloatTwoBitCenteredIP);
 #else
     return generic::RaBitQFloatTwoBitCenteredIP(vector, bits, dim);
@@ -799,7 +799,7 @@ RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
                                   uint64_t dim,
                                   float* results) {
 #if defined(ENABLE_AVX2)
-    simd::RaBitQFloatTwoBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+    simd::RaBitQFloatTwoBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::Avx2RaBitQTag>>(
         vector,
         bits1,
         bits2,
@@ -816,7 +816,7 @@ RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
 float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+    return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::Avx2RaBitQTag>>(
         vector, bits, dim, &generic::RaBitQFloatThreeBitCenteredIP);
 #else
     return generic::RaBitQFloatThreeBitCenteredIP(vector, bits, dim);
@@ -832,7 +832,7 @@ RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
                                     uint64_t dim,
                                     float* results) {
 #if defined(ENABLE_AVX2)
-    simd::RaBitQFloatThreeBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+    simd::RaBitQFloatThreeBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::Avx2RaBitQTag>>(
         vector,
         bits1,
         bits2,
@@ -973,7 +973,7 @@ RaBitQFloatSplitCodeIP(const float* vector,
                        uint64_t dim,
                        uint32_t supplement_bits) {
 #if defined(ENABLE_AVX2)
-    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::AVX2_RaBitQ_Tag>>(
+    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::Avx2RaBitQTag>>(
         vector, one_bit_code, supplement_code, dim, supplement_bits);
 #else
     return avx::RaBitQFloatSplitCodeIP(vector, one_bit_code, supplement_code, dim, supplement_bits);
@@ -1039,7 +1039,7 @@ RaBitQFloatSupplementCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX2)
-    simd::DivScalarImpl<simd::SimdTraits<simd::AVX2_Tag>>(from, to, dim, scalar, &avx::DivScalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::Avx2Tag>>(from, to, dim, scalar, &avx::DivScalar);
 #else
     sse::DivScalar(from, to, dim, scalar);
 #endif
@@ -1113,7 +1113,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    simd::BitAndImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, y, num_byte, result, &sse::BitAnd);
+    simd::BitAndImpl<simd::BitTraits<simd::Avx2BitTag>>(x, y, num_byte, result, &sse::BitAnd);
 #else
     return sse::BitAnd(x, y, num_byte, result);
 #endif
@@ -1122,7 +1122,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    simd::BitOrImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, y, num_byte, result, &sse::BitOr);
+    simd::BitOrImpl<simd::BitTraits<simd::Avx2BitTag>>(x, y, num_byte, result, &sse::BitOr);
 #else
     return sse::BitOr(x, y, num_byte, result);
 #endif
@@ -1131,7 +1131,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    simd::BitXorImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, y, num_byte, result, &sse::BitXor);
+    simd::BitXorImpl<simd::BitTraits<simd::Avx2BitTag>>(x, y, num_byte, result, &sse::BitXor);
 #else
     return sse::BitXor(x, y, num_byte, result);
 #endif
@@ -1140,7 +1140,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX2)
-    simd::BitNotImpl<simd::BitTraits<simd::AVX2_Bit_Tag>>(x, num_byte, result, &sse::BitNot);
+    simd::BitNotImpl<simd::BitTraits<simd::Avx2BitTag>>(x, num_byte, result, &sse::BitNot);
 #else
     return sse::BitNot(x, num_byte, result);
 #endif
@@ -1149,7 +1149,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX2)
-    simd::VecRescaleImpl<simd::SimdTraits<simd::AVX2_Tag>>(data, dim, val, &sse::VecRescale);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::Avx2Tag>>(data, dim, val, &sse::VecRescale);
 #else
     sse::VecRescale(data, dim, val);
 #endif
@@ -1158,7 +1158,7 @@ VecRescale(float* data, uint64_t dim, float val) {
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_AVX2)
-    simd::RotateOpImpl<simd::SimdTraits<simd::AVX2_Tag>>(data, idx, dim_, step);
+    simd::RotateOpImpl<simd::SimdTraits<simd::Avx2Tag>>(data, idx, dim_, step);
 #else
     avx::RotateOp(data, idx, dim_, step);
 #endif
@@ -1187,7 +1187,7 @@ FHTRotate(float* data, uint64_t dim_) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX2)
-    simd::KacsWalkImpl<simd::SimdTraits<simd::AVX2_Tag>>(data, len, &avx::KacsWalk);
+    simd::KacsWalkImpl<simd::SimdTraits<simd::Avx2Tag>>(data, len, &avx::KacsWalk);
 #else
     avx::KacsWalk(data, len);
 #endif
@@ -1196,7 +1196,7 @@ KacsWalk(float* data, uint64_t len) {
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_AVX2)
-    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::Avx2Tag>>(
         from, centroid, to, dim, &avx::NormalizeWithCentroid);
 #else
     return sse::NormalizeWithCentroid(from, centroid, to, dim);
@@ -1207,7 +1207,7 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_AVX2)
-    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX2_Tag>>(
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::Avx2Tag>>(
         from, centroid, to, dim, norm, &avx::InverseNormalizeWithCentroid);
 #else
     sse::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);

--- a/src/simd/avx512.cpp
+++ b/src/simd/avx512.cpp
@@ -71,7 +71,7 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_AVX512)
-    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::AVX512_Tag>>(
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::Avx512Tag>>(
         single_dim_centers, single_dim_val, result, &avx2::PQDistanceFloat256);
 #else
     return avx2::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
@@ -86,7 +86,7 @@ Prefetch(const void* data) {
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::ComputeIPImpl<simd::SimdTraits<simd::AVX512_Tag>, /*Unroll=*/4>(
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::Avx512Tag>, /*Unroll=*/4>(
         query, codes, dim, &avx2::FP32ComputeIP);
 #else
     return avx2::FP32ComputeIP(query, codes, dim);
@@ -96,7 +96,7 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::AVX512_Tag>, /*Unroll=*/4>(
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::Avx512Tag>, /*Unroll=*/4>(
         query, codes, dim, &avx2::FP32ComputeL2Sqr);
 #else
     return avx2::FP32ComputeL2Sqr(query, codes, dim);
@@ -173,7 +173,7 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_AVX512)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX512_Tag>, simd::Batch4Kind::IP>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Avx512Tag>, simd::Batch4Kind::IP>(
         query,
         dim,
         codes1,
@@ -203,7 +203,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_AVX512)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::AVX512_Tag>, simd::Batch4Kind::L2>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Avx512Tag>, simd::Batch4Kind::L2>(
         query,
         dim,
         codes1,
@@ -224,7 +224,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Sub>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx512Tag>, simd::BinaryOp::Sub>(
         x, y, z, dim, &avx2::FP32Sub);
 #else
     return avx2::FP32Sub(x, y, z, dim);
@@ -234,7 +234,7 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Add>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx512Tag>, simd::BinaryOp::Add>(
         x, y, z, dim, &avx2::FP32Add);
 #else
     return avx2::FP32Add(x, y, z, dim);
@@ -244,7 +244,7 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Mul>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx512Tag>, simd::BinaryOp::Mul>(
         x, y, z, dim, &avx2::FP32Mul);
 #else
     return avx2::FP32Mul(x, y, z, dim);
@@ -254,7 +254,7 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::AVX512_Tag>, simd::BinaryOp::Div>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::Avx512Tag>, simd::BinaryOp::Div>(
         x, y, z, dim, &avx2::FP32Div);
 #else
     return avx2::FP32Div(x, y, z, dim);
@@ -264,7 +264,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::ReduceAddImpl<simd::SimdTraits<simd::AVX512_Tag>>(x, dim, &avx2::FP32ReduceAdd);
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::Avx512Tag>>(x, dim, &avx2::FP32ReduceAdd);
 #else
     return sse::FP32ReduceAdd(x, dim);
 #endif
@@ -281,7 +281,7 @@ __inline __m512i __attribute__((__always_inline__)) load_16_short(const uint16_t
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::AVX512_Int8_Tag>>(
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::Avx512Int8Tag>>(
         query, codes, dim, &avx2::INT8ComputeIP);
 #else
     return avx2::INT8ComputeIP(query, codes, dim);
@@ -291,7 +291,7 @@ INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, ui
 float
 INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::AVX512_Int8_Tag>>(
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::Avx512Int8Tag>>(
         query, codes, dim, &avx2::INT8ComputeL2Sqr);
 #else
     return avx2::INT8ComputeL2Sqr(query, codes, dim);
@@ -301,7 +301,7 @@ INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uin
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::AVX512_BF16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::Avx512BF16Tag>>(
         query, codes, dim, &avx2::BF16ComputeIP);
 #else
     return avx2::BF16ComputeIP(query, codes, dim);
@@ -311,7 +311,7 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::AVX512_BF16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::Avx512BF16Tag>>(
         query, codes, dim, &avx2::BF16ComputeL2Sqr);
 #else
     return avx2::BF16ComputeL2Sqr(query, codes, dim);
@@ -321,7 +321,7 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::AVX512_FP16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::Avx512FP16Tag>>(
         query, codes, dim, &avx2::FP16ComputeIP);
 #else
     return avx2::FP16ComputeIP(query, codes, dim);
@@ -331,7 +331,7 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::AVX512_FP16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::Avx512FP16Tag>>(
         query, codes, dim, &avx2::FP16ComputeL2Sqr);
 #else
     return avx2::FP16ComputeL2Sqr(query, codes, dim);
@@ -406,7 +406,7 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::Avx512SQ8Tag>>(
         query, codes, lower_bound, diff, dim, &avx2::SQ8ComputeIP);
 #else
     return avx2::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
@@ -420,7 +420,7 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::Avx512SQ8Tag>>(
         query, codes, lower_bound, diff, dim, &avx2::SQ8ComputeL2Sqr);
 #else
     return avx2::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -434,7 +434,7 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::Avx512SQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &avx2::SQ8ComputeCodesIP);
 #else
     return avx2::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -448,7 +448,7 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::Avx512SQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &avx2::SQ8ComputeCodesL2Sqr);
 #else
     return avx2::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -551,7 +551,7 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::Avx512SQ4Tag>>(
         query, codes, lower_bound, diff, dim, &avx2::SQ4ComputeIP);
 #else
     return avx2::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
@@ -565,7 +565,7 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::Avx512SQ4Tag>>(
         query, codes, lower_bound, diff, dim, &avx2::SQ4ComputeL2Sqr);
 #else
     return avx2::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -579,7 +579,7 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::Avx512SQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &avx2::SQ4ComputeCodesIP);
 #else
     return avx2::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -593,7 +593,7 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::AVX512_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::Avx512SQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &avx2::SQ4ComputeCodesL2Sqr);
 #else
     return avx2::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -605,7 +605,7 @@ SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX512_Uniform_Tag>>(
+    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::Avx512UniformTag>>(
         codes1, codes2, dim, &avx2::SQ4UniformComputeCodesIP);
 #else
     return avx2::SQ4UniformComputeCodesIP(codes1, codes2, dim);
@@ -617,7 +617,7 @@ SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::AVX512_Uniform_Tag>>(
+    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::Avx512UniformTag>>(
         codes1, codes2, dim, &avx2::SQ8UniformComputeCodesIP);
 #else
     return avx2::SQ8UniformComputeCodesIP(codes1, codes2, dim);
@@ -639,7 +639,7 @@ SQ8UniformComputeCodesIPBatch(const uint8_t* RESTRICT query,
 float
 RaBitQFloatSQIP(const float* vector, const uint8_t* codes, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::RaBitQFloatScalarIPImpl<simd::SQ8Traits<simd::AVX512_SQ8_Tag>>(
+    return simd::RaBitQFloatScalarIPImpl<simd::SQ8Traits<simd::Avx512SQ8Tag>>(
         vector, codes, dim, &avx2::RaBitQFloatSQIP);
 #else
     return avx2::RaBitQFloatSQIP(vector, codes, dim);
@@ -649,7 +649,7 @@ RaBitQFloatSQIP(const float* vector, const uint8_t* codes, uint64_t dim) {
 uint64_t
 RaBitQCodeCodeIP(const uint8_t* codes1, const uint8_t* codes2, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::RaBitQScalarCodesIPImpl<simd::UniformCodeTraits<simd::AVX512_Uniform_Tag>>(
+    return simd::RaBitQScalarCodesIPImpl<simd::UniformCodeTraits<simd::Avx512UniformTag>>(
         codes1, codes2, dim, &avx2::RaBitQCodeCodeIP);
 #else
     return avx2::RaBitQCodeCodeIP(codes1, codes2, dim);
@@ -690,7 +690,7 @@ RaBitQPackScalarToSplitPlanes(const uint8_t* scalar_codes,
 float
 RaBitQFloatBinaryIP(const float* vector, const uint8_t* bits, uint64_t dim, float inv_sqrt_d) {
 #if defined(ENABLE_AVX512)
-    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+    return simd::RaBitQFloatBinaryIPImpl<simd::RaBitQTraits<simd::Avx512RaBitQTag>>(
         vector, bits, dim, inv_sqrt_d, &avx2::RaBitQFloatBinaryIP);
 #else
     return avx2::RaBitQFloatBinaryIP(vector, bits, dim, inv_sqrt_d);
@@ -707,7 +707,7 @@ RaBitQFloatBinaryIPBatch4(const float* vector,
                           float inv_sqrt_d,
                           float* results) {
 #if defined(ENABLE_AVX512)
-    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+    simd::RaBitQFloatBinaryIPBatch4Impl<simd::RaBitQTraits<simd::Avx512RaBitQTag>>(
         vector,
         bits1,
         bits2,
@@ -738,7 +738,7 @@ RaBitQFloatThreeBitIPBatch4(const float* vector,
 float
 RaBitQFloatTwoBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::RaBitQFloatTwoBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+    return simd::RaBitQFloatTwoBitCenteredIPImpl<simd::RaBitQTraits<simd::Avx512RaBitQTag>>(
         vector, bits, dim, &generic::RaBitQFloatTwoBitCenteredIP);
 #else
     return avx2::RaBitQFloatTwoBitCenteredIP(vector, bits, dim);
@@ -754,7 +754,7 @@ RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
                                   uint64_t dim,
                                   float* results) {
 #if defined(ENABLE_AVX512)
-    simd::RaBitQFloatTwoBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+    simd::RaBitQFloatTwoBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::Avx512RaBitQTag>>(
         vector,
         bits1,
         bits2,
@@ -771,7 +771,7 @@ RaBitQFloatTwoBitCenteredIPBatch4(const float* vector,
 float
 RaBitQFloatThreeBitCenteredIP(const float* vector, const uint8_t* bits, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+    return simd::RaBitQFloatThreeBitCenteredIPImpl<simd::RaBitQTraits<simd::Avx512RaBitQTag>>(
         vector, bits, dim, &generic::RaBitQFloatThreeBitCenteredIP);
 #else
     return avx2::RaBitQFloatThreeBitCenteredIP(vector, bits, dim);
@@ -787,7 +787,7 @@ RaBitQFloatThreeBitCenteredIPBatch4(const float* vector,
                                     uint64_t dim,
                                     float* results) {
 #if defined(ENABLE_AVX512)
-    simd::RaBitQFloatThreeBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+    simd::RaBitQFloatThreeBitCenteredIPBatch4Impl<simd::RaBitQTraits<simd::Avx512RaBitQTag>>(
         vector,
         bits1,
         bits2,
@@ -928,7 +928,7 @@ RaBitQFloatSplitCodeIP(const float* vector,
                        uint64_t dim,
                        uint32_t supplement_bits) {
 #if defined(ENABLE_AVX512)
-    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::AVX512_RaBitQ_Tag>>(
+    return simd::RaBitQFloatSplitCodeIPImpl<simd::RaBitQTraits<simd::Avx512RaBitQTag>>(
         vector, one_bit_code, supplement_code, dim, supplement_bits);
 #else
     return avx2::RaBitQFloatSplitCodeIP(
@@ -1021,8 +1021,7 @@ RaBitQFloatSupplementCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_AVX512)
-    simd::DivScalarImpl<simd::SimdTraits<simd::AVX512_Tag>>(
-        from, to, dim, scalar, &avx2::DivScalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::Avx512Tag>>(from, to, dim, scalar, &avx2::DivScalar);
 #else
     avx2::DivScalar(from, to, dim, scalar);
 #endif
@@ -1096,7 +1095,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    simd::BitAndImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, y, num_byte, result, &avx2::BitAnd);
+    simd::BitAndImpl<simd::BitTraits<simd::Avx512BitTag>>(x, y, num_byte, result, &avx2::BitAnd);
 #else
     return avx2::BitAnd(x, y, num_byte, result);
 #endif
@@ -1105,7 +1104,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    simd::BitOrImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, y, num_byte, result, &avx2::BitOr);
+    simd::BitOrImpl<simd::BitTraits<simd::Avx512BitTag>>(x, y, num_byte, result, &avx2::BitOr);
 #else
     return avx2::BitOr(x, y, num_byte, result);
 #endif
@@ -1114,7 +1113,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    simd::BitXorImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, y, num_byte, result, &avx2::BitXor);
+    simd::BitXorImpl<simd::BitTraits<simd::Avx512BitTag>>(x, y, num_byte, result, &avx2::BitXor);
 #else
     return avx2::BitXor(x, y, num_byte, result);
 #endif
@@ -1123,7 +1122,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_AVX512)
-    simd::BitNotImpl<simd::BitTraits<simd::AVX512_Bit_Tag>>(x, num_byte, result, &avx2::BitNot);
+    simd::BitNotImpl<simd::BitTraits<simd::Avx512BitTag>>(x, num_byte, result, &avx2::BitNot);
 #else
     return avx2::BitNot(x, num_byte, result);
 #endif
@@ -1132,7 +1131,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_AVX512)
-    simd::KacsWalkImpl<simd::SimdTraits<simd::AVX512_Tag>>(data, len, &avx2::KacsWalk);
+    simd::KacsWalkImpl<simd::SimdTraits<simd::Avx512Tag>>(data, len, &avx2::KacsWalk);
 #else
     avx2::KacsWalk(data, len);
 #endif
@@ -1188,7 +1187,7 @@ FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_AVX512)
-    simd::VecRescaleImpl<simd::SimdTraits<simd::AVX512_Tag>>(data, dim, val, &avx2::VecRescale);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::Avx512Tag>>(data, dim, val, &avx2::VecRescale);
 #else
     avx2::VecRescale(data, dim, val);
 #endif
@@ -1197,7 +1196,7 @@ VecRescale(float* data, uint64_t dim, float val) {
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_AVX512)
-    simd::RotateOpImpl<simd::SimdTraits<simd::AVX512_Tag>>(data, idx, dim_, step);
+    simd::RotateOpImpl<simd::SimdTraits<simd::Avx512Tag>>(data, idx, dim_, step);
 #else
     avx2::RotateOp(data, idx, dim_, step);
 #endif
@@ -1228,7 +1227,7 @@ FHTRotate(float* data, uint64_t dim_) {
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_AVX512)
-    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX512_Tag>>(
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::Avx512Tag>>(
         from, centroid, to, dim, &avx2::NormalizeWithCentroid);
 #else
     return avx2::NormalizeWithCentroid(from, centroid, to, dim);
@@ -1239,7 +1238,7 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_AVX512)
-    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::AVX512_Tag>>(
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::Avx512Tag>>(
         from, centroid, to, dim, norm, &avx2::InverseNormalizeWithCentroid);
 #else
     avx2::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);

--- a/src/simd/generic.cpp
+++ b/src/simd/generic.cpp
@@ -98,12 +98,12 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
-    return simd::ComputeIPImpl<simd::SimdTraits<simd::Generic_Tag>>(query, codes, dim);
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::GenericTag>>(query, codes, dim);
 }
 
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
-    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::Generic_Tag>>(query, codes, dim);
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::GenericTag>>(query, codes, dim);
 }
 
 void
@@ -128,7 +128,7 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result2,
                     float& result3,
                     float& result4) {
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Generic_Tag>, simd::Batch4Kind::IP>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::GenericTag>, simd::Batch4Kind::IP>(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
 }
 
@@ -143,33 +143,33 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result2,
                        float& result3,
                        float& result4) {
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::Generic_Tag>, simd::Batch4Kind::L2>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::GenericTag>, simd::Batch4Kind::L2>(
         query, dim, codes1, codes2, codes3, codes4, result1, result2, result3, result4);
 }
 
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
-    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Sub>(x, y, z, dim);
+    simd::BinaryOpImpl<simd::SimdTraits<simd::GenericTag>, simd::BinaryOp::Sub>(x, y, z, dim);
 }
 
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
-    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Add>(x, y, z, dim);
+    simd::BinaryOpImpl<simd::SimdTraits<simd::GenericTag>, simd::BinaryOp::Add>(x, y, z, dim);
 }
 
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
-    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Mul>(x, y, z, dim);
+    simd::BinaryOpImpl<simd::SimdTraits<simd::GenericTag>, simd::BinaryOp::Mul>(x, y, z, dim);
 }
 
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
-    simd::BinaryOpImpl<simd::SimdTraits<simd::Generic_Tag>, simd::BinaryOp::Div>(x, y, z, dim);
+    simd::BinaryOpImpl<simd::SimdTraits<simd::GenericTag>, simd::BinaryOp::Div>(x, y, z, dim);
 }
 
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
-    return simd::ReduceAddImpl<simd::SimdTraits<simd::Generic_Tag>>(x, dim);
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::GenericTag>>(x, dim);
 }
 
 union FP32Struct {
@@ -179,12 +179,12 @@ union FP32Struct {
 
 float
 INT8ComputeL2Sqr(const int8_t* query, const int8_t* codes, uint64_t dim) {
-    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::Generic_Int8_Tag>>(query, codes, dim);
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::GenericInt8Tag>>(query, codes, dim);
 }
 
 float
 INT8ComputeIP(const int8_t* query, const int8_t* codes, uint64_t dim) {
-    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::Generic_Int8_Tag>>(query, codes, dim);
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::GenericInt8Tag>>(query, codes, dim);
 }
 
 float
@@ -229,25 +229,25 @@ FloatToFP16(const float fp32_value) {
 
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::Generic_BF16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::GenericBF16Tag>>(
         query, codes, dim, nullptr);
 }
 
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::Generic_BF16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::GenericBF16Tag>>(
         query, codes, dim, nullptr);
 }
 
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::Generic_FP16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::GenericFP16Tag>>(
         query, codes, dim, nullptr);
 }
 
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
-    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::Generic_FP16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::GenericFP16Tag>>(
         query, codes, dim, nullptr);
 }
 
@@ -268,7 +268,7 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT lower_bound,
              const float* RESTRICT diff,
              uint64_t dim) {
-    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::GenericSQ8Tag>>(
         query, codes, lower_bound, diff, dim);
 }
 
@@ -278,7 +278,7 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT lower_bound,
                 const float* RESTRICT diff,
                 uint64_t dim) {
-    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::GenericSQ8Tag>>(
         query, codes, lower_bound, diff, dim);
 }
 
@@ -288,7 +288,7 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT lower_bound,
                   const float* RESTRICT diff,
                   uint64_t dim) {
-    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::GenericSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim);
 }
 
@@ -298,7 +298,7 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT lower_bound,
                      const float* RESTRICT diff,
                      uint64_t dim) {
-    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::Generic_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::GenericSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim);
 }
 
@@ -369,7 +369,7 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT lower_bound,
              const float* RESTRICT diff,
              uint64_t dim) {
-    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::GenericSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &SQ4ScalarIP);
 }
 
@@ -379,7 +379,7 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT lower_bound,
                 const float* RESTRICT diff,
                 uint64_t dim) {
-    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::GenericSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &SQ4ScalarL2);
 }
 
@@ -389,7 +389,7 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT lower_bound,
                   const float* RESTRICT diff,
                   uint64_t dim) {
-    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::GenericSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &SQ4ScalarCodesIP);
 }
 
@@ -399,7 +399,7 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT lower_bound,
                      const float* RESTRICT diff,
                      uint64_t dim) {
-    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::Generic_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::GenericSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &SQ4ScalarCodesL2);
 }
 
@@ -880,20 +880,20 @@ Normalize(const float* from, float* to, uint64_t dim) {
 
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
-    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::Generic_Tag>>(
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::GenericTag>>(
         from, centroid, to, dim);
 }
 
 void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
-    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::Generic_Tag>>(
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::GenericTag>>(
         from, centroid, to, dim, norm);
 }
 
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
-    simd::DivScalarImpl<simd::SimdTraits<simd::Generic_Tag>>(from, to, dim, scalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::GenericTag>>(from, to, dim, scalar);
 }
 
 void
@@ -951,7 +951,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 
 void
 KacsWalk(float* data, uint64_t len) {
-    simd::KacsWalkImpl<simd::SimdTraits<simd::Generic_Tag>>(data, len);
+    simd::KacsWalkImpl<simd::SimdTraits<simd::GenericTag>>(data, len);
 }
 
 void
@@ -966,12 +966,12 @@ FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 
 void
 VecRescale(float* data, uint64_t dim, float val) {
-    simd::VecRescaleImpl<simd::SimdTraits<simd::Generic_Tag>>(data, dim, val);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::GenericTag>>(data, dim, val);
 }
 
 void
 RotateOp(float* data, int idx, int dim_, int step) {
-    simd::RotateOpImpl<simd::SimdTraits<simd::Generic_Tag>>(data, idx, dim_, step);
+    simd::RotateOpImpl<simd::SimdTraits<simd::GenericTag>>(data, idx, dim_, step);
 }
 
 void

--- a/src/simd/neon.cpp
+++ b/src/simd/neon.cpp
@@ -111,7 +111,7 @@ __inline float32x4_t __attribute__((__always_inline__)) vcvt_f32_half(const uint
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_NEON)
-    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::NEON_Tag>>(
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::NeonTag>>(
         single_dim_centers, single_dim_val, result, &generic::PQDistanceFloat256);
 #else
     return generic::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
@@ -121,7 +121,7 @@ PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* r
 float
 FP32ComputeIP(const float* query, const float* codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::ComputeIPImpl<simd::SimdTraits<simd::NEON_Tag>>(
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::NeonTag>>(
         query, codes, dim, &generic::FP32ComputeIP);
 #else
     return generic::FP32ComputeIP(query, codes, dim);
@@ -131,7 +131,7 @@ FP32ComputeIP(const float* query, const float* codes, uint64_t dim) {
 float
 FP32ComputeL2Sqr(const float* query, const float* codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::NEON_Tag>>(
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::NeonTag>>(
         query, codes, dim, &generic::FP32ComputeL2Sqr);
 #else
     return vsag::generic::FP32ComputeL2Sqr(query, codes, dim);
@@ -159,7 +159,7 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_NEON)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::NEON_Tag>, simd::Batch4Kind::IP>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::NeonTag>, simd::Batch4Kind::IP>(
         query,
         dim,
         codes1,
@@ -189,7 +189,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_NEON)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::NEON_Tag>, simd::Batch4Kind::L2>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::NeonTag>, simd::Batch4Kind::L2>(
         query,
         dim,
         codes1,
@@ -210,7 +210,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Sub>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NeonTag>, simd::BinaryOp::Sub>(
         x, y, z, dim, &generic::FP32Sub);
 #else
     return generic::FP32Sub(x, y, z, dim);
@@ -220,7 +220,7 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Add>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NeonTag>, simd::BinaryOp::Add>(
         x, y, z, dim, &generic::FP32Add);
 #else
     return generic::FP32Add(x, y, z, dim);
@@ -230,7 +230,7 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Mul>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NeonTag>, simd::BinaryOp::Mul>(
         x, y, z, dim, &generic::FP32Mul);
 #else
     return generic::FP32Mul(x, y, z, dim);
@@ -240,7 +240,7 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::NEON_Tag>, simd::BinaryOp::Div>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::NeonTag>, simd::BinaryOp::Div>(
         x, y, z, dim, &generic::FP32Div);
 #else
     return generic::FP32Div(x, y, z, dim);
@@ -250,7 +250,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::ReduceAddImpl<simd::SimdTraits<simd::NEON_Tag>>(x, dim, &generic::FP32ReduceAdd);
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::NeonTag>>(x, dim, &generic::FP32ReduceAdd);
 #else
     return generic::FP32ReduceAdd(x, dim);
 #endif
@@ -266,7 +266,7 @@ __inline uint16x8_t __attribute__((__always_inline__)) load_4_short(const uint16
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::NEON_BF16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::NeonBF16Tag>>(
         query, codes, dim, &generic::BF16ComputeIP);
 #else
     return generic::BF16ComputeIP(query, codes, dim);
@@ -276,7 +276,7 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::NEON_BF16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::NeonBF16Tag>>(
         query, codes, dim, &generic::BF16ComputeL2Sqr);
 #else
     return generic::BF16ComputeL2Sqr(query, codes, dim);
@@ -286,7 +286,7 @@ BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, u
 float
 FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::NEON_FP16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::FP16Traits<simd::NeonFP16Tag>>(
         query, codes, dim, &generic::FP16ComputeIP);
 #else
     return generic::FP16ComputeIP(query, codes, dim);
@@ -296,7 +296,7 @@ FP16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 FP16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::NEON_FP16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::FP16Traits<simd::NeonFP16Tag>>(
         query, codes, dim, &generic::FP16ComputeL2Sqr);
 #else
     return generic::FP16ComputeL2Sqr(query, codes, dim);
@@ -364,7 +364,7 @@ load_12_uint8_to_float(const uint8_t* data, float32x4_t& f0, float32x4_t& f1, fl
 float
 INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::NEON_Int8_Tag>>(
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::NeonInt8Tag>>(
         query, codes, dim, &generic::INT8ComputeL2Sqr);
 #else
     return generic::INT8ComputeL2Sqr(query, codes, dim);
@@ -374,7 +374,7 @@ INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uin
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::NEON_Int8_Tag>>(
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::NeonInt8Tag>>(
         query, codes, dim, &generic::INT8ComputeIP);
 #else
     return generic::INT8ComputeIP(query, codes, dim);
@@ -388,7 +388,7 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::NeonSQ8Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ8ComputeIP);
 #else
     return generic::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
@@ -402,7 +402,7 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::NeonSQ8Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ8ComputeL2Sqr);
 #else
     return generic::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -416,7 +416,7 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::NeonSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesIP);
 #else
     return generic::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -430,7 +430,7 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::NeonSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesL2Sqr);
 #else
     return generic::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -453,7 +453,7 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::NeonSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ4ComputeIP);
 #else
     return generic::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
@@ -467,7 +467,7 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::NeonSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ4ComputeL2Sqr);
 #else
     return generic::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -481,7 +481,7 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::NeonSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesIP);
 #else
     return generic::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -495,7 +495,7 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::NEON_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::NeonSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesL2Sqr);
 #else
     return generic::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -717,7 +717,7 @@ extract_4_bits_to_mask(const uint8_t* bits, uint64_t bit_offset) {
 float
 RaBitQFloatSQIP(const float* vector, const uint8_t* codes, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::RaBitQFloatScalarIPImpl<simd::SQ8Traits<simd::NEON_SQ8_Tag>>(
+    return simd::RaBitQFloatScalarIPImpl<simd::SQ8Traits<simd::NeonSQ8Tag>>(
         vector, codes, dim, &generic::RaBitQFloatSQIP);
 #else
     return generic::RaBitQFloatSQIP(vector, codes, dim);
@@ -976,7 +976,7 @@ RaBitQFloatSupplementCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_NEON)
-    simd::DivScalarImpl<simd::SimdTraits<simd::NEON_Tag>>(
+    simd::DivScalarImpl<simd::SimdTraits<simd::NeonTag>>(
         from, to, dim, scalar, &generic::DivScalar);
 #else
     generic::DivScalar(from, to, dim, scalar);
@@ -1064,7 +1064,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    simd::BitAndImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, y, num_byte, result, &generic::BitAnd);
+    simd::BitAndImpl<simd::BitTraits<simd::NeonBitTag>>(x, y, num_byte, result, &generic::BitAnd);
 #else
     return generic::BitAnd(x, y, num_byte, result);
 #endif
@@ -1073,7 +1073,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    simd::BitOrImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, y, num_byte, result, &generic::BitOr);
+    simd::BitOrImpl<simd::BitTraits<simd::NeonBitTag>>(x, y, num_byte, result, &generic::BitOr);
 #else
     return generic::BitOr(x, y, num_byte, result);
 #endif
@@ -1082,7 +1082,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    simd::BitXorImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, y, num_byte, result, &generic::BitXor);
+    simd::BitXorImpl<simd::BitTraits<simd::NeonBitTag>>(x, y, num_byte, result, &generic::BitXor);
 #else
     return generic::BitXor(x, y, num_byte, result);
 #endif
@@ -1091,7 +1091,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_NEON)
-    simd::BitNotImpl<simd::BitTraits<simd::NEON_Bit_Tag>>(x, num_byte, result, &generic::BitNot);
+    simd::BitNotImpl<simd::BitTraits<simd::NeonBitTag>>(x, num_byte, result, &generic::BitNot);
 #else
     return generic::BitNot(x, num_byte, result);
 #endif
@@ -1099,7 +1099,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_NEON)
-    simd::KacsWalkImpl<simd::SimdTraits<simd::NEON_Tag>>(data, len, &generic::KacsWalk);
+    simd::KacsWalkImpl<simd::SimdTraits<simd::NeonTag>>(data, len, &generic::KacsWalk);
 #else
     generic::KacsWalk(data, len);
 #endif
@@ -1144,7 +1144,7 @@ FlipSign(const uint8_t* flip, float* data, uint64_t dim) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_NEON)
-    simd::VecRescaleImpl<simd::SimdTraits<simd::NEON_Tag>>(data, dim, val, &generic::VecRescale);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::NeonTag>>(data, dim, val, &generic::VecRescale);
 #else
     generic::VecRescale(data, dim, val);
 #endif
@@ -1153,7 +1153,7 @@ VecRescale(float* data, uint64_t dim, float val) {
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_NEON)
-    simd::RotateOpImpl<simd::SimdTraits<simd::NEON_Tag>>(data, idx, dim_, step);
+    simd::RotateOpImpl<simd::SimdTraits<simd::NeonTag>>(data, idx, dim_, step);
 #else
     generic::RotateOp(data, idx, dim_, step);
 #endif
@@ -1180,7 +1180,7 @@ FHTRotate(float* data, uint64_t dim_) {
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_NEON)
-    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::NEON_Tag>>(
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::NeonTag>>(
         from, centroid, to, dim, &generic::NormalizeWithCentroid);
 #else
     return generic::NormalizeWithCentroid(from, centroid, to, dim);
@@ -1191,7 +1191,7 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_NEON)
-    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::NEON_Tag>>(
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::NeonTag>>(
         from, centroid, to, dim, norm, &generic::InverseNormalizeWithCentroid);
 #else
     generic::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);

--- a/src/simd/sse.cpp
+++ b/src/simd/sse.cpp
@@ -75,7 +75,7 @@ INT8InnerProductDistance(const void* pVect1v, const void* pVect2v, const void* q
 void
 PQDistanceFloat256(const void* single_dim_centers, float single_dim_val, void* result) {
 #if defined(ENABLE_SSE)
-    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::SSE_Tag>>(
+    simd::PQDistanceFloat256Impl<simd::SimdTraits<simd::SseTag>>(
         single_dim_centers, single_dim_val, result, &generic::PQDistanceFloat256);
 #else
     return generic::PQDistanceFloat256(single_dim_centers, single_dim_val, result);
@@ -97,7 +97,7 @@ __inline __m128i __attribute__((__always_inline__)) load_4_short(const uint16_t*
 float
 FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::ComputeIPImpl<simd::SimdTraits<simd::SSE_Tag>>(
+    return simd::ComputeIPImpl<simd::SimdTraits<simd::SseTag>>(
         query, codes, dim, &generic::FP32ComputeIP);
 #else
     return vsag::generic::FP32ComputeIP(query, codes, dim);
@@ -107,7 +107,7 @@ FP32ComputeIP(const float* RESTRICT query, const float* RESTRICT codes, uint64_t
 float
 FP32ComputeL2Sqr(const float* RESTRICT query, const float* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::SSE_Tag>>(
+    return simd::ComputeL2SqrImpl<simd::SimdTraits<simd::SseTag>>(
         query, codes, dim, &generic::FP32ComputeL2Sqr);
 #else
     return vsag::generic::FP32ComputeL2Sqr(query, codes, dim);
@@ -154,7 +154,7 @@ FP32ComputeIPBatch4(const float* RESTRICT query,
                     float& result3,
                     float& result4) {
 #if defined(ENABLE_SSE)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::SSE_Tag>, simd::Batch4Kind::IP>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::SseTag>, simd::Batch4Kind::IP>(
         query,
         dim,
         codes1,
@@ -184,7 +184,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
                        float& result3,
                        float& result4) {
 #if defined(ENABLE_SSE)
-    simd::ComputeBatch4Impl<simd::SimdTraits<simd::SSE_Tag>, simd::Batch4Kind::L2>(
+    simd::ComputeBatch4Impl<simd::SimdTraits<simd::SseTag>, simd::Batch4Kind::L2>(
         query,
         dim,
         codes1,
@@ -205,7 +205,7 @@ FP32ComputeL2SqrBatch4(const float* RESTRICT query,
 void
 FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Sub>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SseTag>, simd::BinaryOp::Sub>(
         x, y, z, dim, &generic::FP32Sub);
 #else
     return generic::FP32Sub(x, y, z, dim);
@@ -215,7 +215,7 @@ FP32Sub(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Add>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SseTag>, simd::BinaryOp::Add>(
         x, y, z, dim, &generic::FP32Add);
 #else
     return generic::FP32Add(x, y, z, dim);
@@ -225,7 +225,7 @@ FP32Add(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Mul>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SseTag>, simd::BinaryOp::Mul>(
         x, y, z, dim, &generic::FP32Mul);
 #else
     return generic::FP32Mul(x, y, z, dim);
@@ -235,7 +235,7 @@ FP32Mul(const float* x, const float* y, float* z, uint64_t dim) {
 void
 FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    simd::BinaryOpImpl<simd::SimdTraits<simd::SSE_Tag>, simd::BinaryOp::Div>(
+    simd::BinaryOpImpl<simd::SimdTraits<simd::SseTag>, simd::BinaryOp::Div>(
         x, y, z, dim, &generic::FP32Div);
 #else
     return generic::FP32Div(x, y, z, dim);
@@ -245,7 +245,7 @@ FP32Div(const float* x, const float* y, float* z, uint64_t dim) {
 float
 FP32ReduceAdd(const float* x, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::ReduceAddImpl<simd::SimdTraits<simd::SSE_Tag>>(x, dim, &generic::FP32ReduceAdd);
+    return simd::ReduceAddImpl<simd::SimdTraits<simd::SseTag>>(x, dim, &generic::FP32ReduceAdd);
 #else
     return generic::FP32ReduceAdd(x, dim);
 #endif
@@ -254,7 +254,7 @@ FP32ReduceAdd(const float* x, uint64_t dim) {
 float
 BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::SSE_BF16_Tag>>(
+    return simd::HalfComputeIPImpl<simd::BF16Traits<simd::SseBF16Tag>>(
         query, codes, dim, &generic::BF16ComputeIP);
 #else
     return generic::BF16ComputeIP(query, codes, dim);
@@ -264,7 +264,7 @@ BF16ComputeIP(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint
 float
 BF16ComputeL2Sqr(const uint8_t* RESTRICT query, const uint8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::SSE_BF16_Tag>>(
+    return simd::HalfComputeL2SqrImpl<simd::BF16Traits<simd::SseBF16Tag>>(
         query, codes, dim, &generic::BF16ComputeL2Sqr);
 #else
     return generic::BF16ComputeL2Sqr(query, codes, dim);
@@ -293,7 +293,7 @@ FP16SparseAccumulate(float* RESTRICT dists,
 float
 INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::SSE_Int8_Tag>>(
+    return simd::Int8ComputeL2SqrImpl<simd::Int8Traits<simd::SseInt8Tag>>(
         query, codes, dim, &generic::INT8ComputeL2Sqr);
 #else
     return generic::INT8ComputeL2Sqr(query, codes, dim);
@@ -303,7 +303,7 @@ INT8ComputeL2Sqr(const int8_t* RESTRICT query, const int8_t* RESTRICT codes, uin
 float
 INT8ComputeIP(const int8_t* __restrict query, const int8_t* __restrict codes, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::SSE_Int8_Tag>>(
+    return simd::Int8ComputeIPImpl<simd::Int8Traits<simd::SseInt8Tag>>(
         query, codes, dim, &generic::INT8ComputeIP);
 #else
     return generic::INT8ComputeIP(query, codes, dim);
@@ -317,7 +317,7 @@ SQ8ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+    return simd::SQ8ComputeIPImpl<simd::SQ8Traits<simd::SseSQ8Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ8ComputeIP);
 #else
     return generic::SQ8ComputeIP(query, codes, lower_bound, diff, dim);
@@ -331,7 +331,7 @@ SQ8ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+    return simd::SQ8ComputeL2SqrImpl<simd::SQ8Traits<simd::SseSQ8Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ8ComputeL2Sqr);
 #else
     return generic::SQ8ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -345,7 +345,7 @@ SQ8ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesIPImpl<simd::SQ8Traits<simd::SseSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesIP);
 #else
     return generic::SQ8ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -359,7 +359,7 @@ SQ8ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::SSE_SQ8_Tag>>(
+    return simd::SQ8ComputeCodesL2SqrImpl<simd::SQ8Traits<simd::SseSQ8Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ8ComputeCodesL2Sqr);
 #else
     return generic::SQ8ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -404,7 +404,7 @@ SQ4ComputeIP(const float* RESTRICT query,
              const float* RESTRICT diff,
              uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+    return simd::SQ4ComputeIPImpl<simd::SQ4Traits<simd::SseSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ4ComputeIP);
 #else
     return generic::SQ4ComputeIP(query, codes, lower_bound, diff, dim);
@@ -418,7 +418,7 @@ SQ4ComputeL2Sqr(const float* RESTRICT query,
                 const float* RESTRICT diff,
                 uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+    return simd::SQ4ComputeL2SqrImpl<simd::SQ4Traits<simd::SseSQ4Tag>>(
         query, codes, lower_bound, diff, dim, &generic::SQ4ComputeL2Sqr);
 #else
     return generic::SQ4ComputeL2Sqr(query, codes, lower_bound, diff, dim);
@@ -432,7 +432,7 @@ SQ4ComputeCodesIP(const uint8_t* RESTRICT codes1,
                   const float* RESTRICT diff,
                   uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesIPImpl<simd::SQ4Traits<simd::SseSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesIP);
 #else
     return generic::SQ4ComputeCodesIP(codes1, codes2, lower_bound, diff, dim);
@@ -446,7 +446,7 @@ SQ4ComputeCodesL2Sqr(const uint8_t* RESTRICT codes1,
                      const float* RESTRICT diff,
                      uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::SSE_SQ4_Tag>>(
+    return simd::SQ4ComputeCodesL2SqrImpl<simd::SQ4Traits<simd::SseSQ4Tag>>(
         codes1, codes2, lower_bound, diff, dim, &generic::SQ4ComputeCodesL2Sqr);
 #else
     return generic::SQ4ComputeCodesL2Sqr(codes1, codes2, lower_bound, diff, dim);
@@ -458,7 +458,7 @@ SQ4UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::SSE_Uniform_Tag>>(
+    return simd::SQ4UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::SseUniformTag>>(
         codes1, codes2, dim, &generic::SQ4UniformComputeCodesIP);
 #else
     return generic::SQ4UniformComputeCodesIP(codes1, codes2, dim);
@@ -470,7 +470,7 @@ SQ8UniformComputeCodesIP(const uint8_t* RESTRICT codes1,
                          const uint8_t* RESTRICT codes2,
                          uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::SSE_Uniform_Tag>>(
+    return simd::SQ8UniformComputeCodesIPImpl<simd::UniformCodeTraits<simd::SseUniformTag>>(
         codes1, codes2, dim, &generic::SQ8UniformComputeCodesIP);
 #else
     return generic::SQ8UniformComputeCodesIP(codes1, codes2, dim);
@@ -545,8 +545,7 @@ RaBitQFloatSupplementCodeIP(const float* vector,
 void
 DivScalar(const float* from, float* to, uint64_t dim, float scalar) {
 #if defined(ENABLE_SSE)
-    simd::DivScalarImpl<simd::SimdTraits<simd::SSE_Tag>>(
-        from, to, dim, scalar, &generic::DivScalar);
+    simd::DivScalarImpl<simd::SimdTraits<simd::SseTag>>(from, to, dim, scalar, &generic::DivScalar);
 #else
     generic::DivScalar(from, to, dim, scalar);
 #endif
@@ -620,7 +619,7 @@ PQFastScanLookUp32(const uint8_t* RESTRICT lookup_table,
 void
 BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    simd::BitAndImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, y, num_byte, result, &generic::BitAnd);
+    simd::BitAndImpl<simd::BitTraits<simd::SseBitTag>>(x, y, num_byte, result, &generic::BitAnd);
 #else
     return generic::BitAnd(x, y, num_byte, result);
 #endif
@@ -629,7 +628,7 @@ BitAnd(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    simd::BitOrImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, y, num_byte, result, &generic::BitOr);
+    simd::BitOrImpl<simd::BitTraits<simd::SseBitTag>>(x, y, num_byte, result, &generic::BitOr);
 #else
     return generic::BitOr(x, y, num_byte, result);
 #endif
@@ -638,7 +637,7 @@ BitOr(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* resu
 void
 BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    simd::BitXorImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, y, num_byte, result, &generic::BitXor);
+    simd::BitXorImpl<simd::BitTraits<simd::SseBitTag>>(x, y, num_byte, result, &generic::BitXor);
 #else
     return generic::BitXor(x, y, num_byte, result);
 #endif
@@ -647,7 +646,7 @@ BitXor(const uint8_t* x, const uint8_t* y, const uint64_t num_byte, uint8_t* res
 void
 BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 #if defined(ENABLE_SSE)
-    simd::BitNotImpl<simd::BitTraits<simd::SSE_Bit_Tag>>(x, num_byte, result, &generic::BitNot);
+    simd::BitNotImpl<simd::BitTraits<simd::SseBitTag>>(x, num_byte, result, &generic::BitNot);
 #else
     return generic::BitNot(x, num_byte, result);
 #endif
@@ -656,7 +655,7 @@ BitNot(const uint8_t* x, const uint64_t num_byte, uint8_t* result) {
 void
 RotateOp(float* data, int idx, int dim_, int step) {
 #if defined(ENABLE_SSE)
-    simd::RotateOpImpl<simd::SimdTraits<simd::SSE_Tag>>(data, idx, dim_, step);
+    simd::RotateOpImpl<simd::SimdTraits<simd::SseTag>>(data, idx, dim_, step);
 #else
     generic::RotateOp(data, idx, dim_, step);
 #endif
@@ -683,7 +682,7 @@ FHTRotate(float* data, uint64_t dim_) {
 void
 VecRescale(float* data, uint64_t dim, float val) {
 #if defined(ENABLE_SSE)
-    simd::VecRescaleImpl<simd::SimdTraits<simd::SSE_Tag>>(data, dim, val, &generic::VecRescale);
+    simd::VecRescaleImpl<simd::SimdTraits<simd::SseTag>>(data, dim, val, &generic::VecRescale);
 #else
     generic::VecRescale(data, dim, val);
 #endif
@@ -692,7 +691,7 @@ VecRescale(float* data, uint64_t dim, float val) {
 void
 KacsWalk(float* data, uint64_t len) {
 #if defined(ENABLE_SSE)
-    simd::KacsWalkImpl<simd::SimdTraits<simd::SSE_Tag>>(data, len, &generic::KacsWalk);
+    simd::KacsWalkImpl<simd::SimdTraits<simd::SseTag>>(data, len, &generic::KacsWalk);
 #else
     generic::KacsWalk(data, len);
 #endif
@@ -701,7 +700,7 @@ KacsWalk(float* data, uint64_t len) {
 float
 NormalizeWithCentroid(const float* from, const float* centroid, float* to, uint64_t dim) {
 #if defined(ENABLE_SSE)
-    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::SSE_Tag>>(
+    return simd::NormalizeWithCentroidImpl<simd::SimdTraits<simd::SseTag>>(
         from, centroid, to, dim, &generic::NormalizeWithCentroid);
 #else
     return generic::NormalizeWithCentroid(from, centroid, to, dim);
@@ -712,7 +711,7 @@ void
 InverseNormalizeWithCentroid(
     const float* from, const float* centroid, float* to, uint64_t dim, float norm) {
 #if defined(ENABLE_SSE)
-    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::SSE_Tag>>(
+    simd::InverseNormalizeWithCentroidImpl<simd::SimdTraits<simd::SseTag>>(
         from, centroid, to, dim, norm, &generic::InverseNormalizeWithCentroid);
 #else
     generic::InverseNormalizeWithCentroid(from, centroid, to, dim, norm);

--- a/src/simd/traits/simd_traits_avx.h
+++ b/src/simd/traits/simd_traits_avx.h
@@ -26,10 +26,10 @@
 
 namespace vsag::simd {
 
-struct AVX_Tag {};
+struct AvxTag {};
 
 template <>
-struct SimdTraits<AVX_Tag> {
+struct SimdTraits<AvxTag> {
     using FloatVec = __m256;
     static constexpr int Width = 8;
 
@@ -89,9 +89,9 @@ struct SimdTraits<AVX_Tag> {
 };
 
 // --- Bit operation traits for AVX (uses float ops since AVX has no 256-bit integer) ---
-struct AVX_Bit_Tag {};
+struct AvxBitTag {};
 template <>
-struct BitTraits<AVX_Bit_Tag> {
+struct BitTraits<AvxBitTag> {
     using IntVec = __m256;  // reuse float vector for bitwise ops
     static constexpr int ByteWidth = 32;
 
@@ -122,9 +122,9 @@ struct BitTraits<AVX_Bit_Tag> {
 };
 
 // --- SQ8 traits for AVX ---
-struct AVX_SQ8_Tag {};
+struct AvxSQ8Tag {};
 template <>
-struct SQ8Traits<AVX_SQ8_Tag> : SimdTraits<AVX_Tag> {
+struct SQ8Traits<AvxSQ8Tag> : SimdTraits<AvxTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_u8_as_float(const uint8_t* p) {
         int32_t lo_val, hi_val;
@@ -137,9 +137,9 @@ struct SQ8Traits<AVX_SQ8_Tag> : SimdTraits<AVX_Tag> {
 };
 
 // --- SQ4Traits for AVX (Width=8, STEP=16 nibbles = 8 bytes per call) ---
-struct AVX_SQ4_Tag {};
+struct AvxSQ4Tag {};
 template <>
-struct SQ4Traits<AVX_SQ4_Tag> : SimdTraits<AVX_Tag> {
+struct SQ4Traits<AvxSQ4Tag> : SimdTraits<AvxTag> {
     static inline __attribute__((always_inline)) void
     load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
         __m128i code0 = _mm_set_epi8(0,
@@ -192,9 +192,9 @@ struct SQ4Traits<AVX_SQ4_Tag> : SimdTraits<AVX_Tag> {
 };
 
 // --- BF16Traits for AVX ---
-struct AVX_BF16_Tag {};
+struct AvxBF16Tag {};
 template <>
-struct BF16Traits<AVX_BF16_Tag> : SimdTraits<AVX_Tag> {
+struct BF16Traits<AvxBF16Tag> : SimdTraits<AvxTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         __m256i v = _mm256_set_epi16(static_cast<short>(p[7]),
@@ -218,9 +218,9 @@ struct BF16Traits<AVX_BF16_Tag> : SimdTraits<AVX_Tag> {
 };
 
 // --- FP16Traits for AVX (uses F16C: _mm256_cvtph_ps) ---
-struct AVX_FP16_Tag {};
+struct AvxFP16Tag {};
 template <>
-struct FP16Traits<AVX_FP16_Tag> : SimdTraits<AVX_Tag> {
+struct FP16Traits<AvxFP16Tag> : SimdTraits<AvxTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         __m128i fp16 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
@@ -229,9 +229,9 @@ struct FP16Traits<AVX_FP16_Tag> : SimdTraits<AVX_Tag> {
 };
 
 // --- RaBitQTraits for AVX (8-wide, no AVX2 integer ops) ---
-struct AVX_RaBitQ_Tag {};
+struct AvxRaBitQTag {};
 template <>
-struct RaBitQTraits<AVX_RaBitQ_Tag> : SimdTraits<AVX_Tag> {
+struct RaBitQTraits<AvxRaBitQTag> : SimdTraits<AvxTag> {
     static inline __attribute__((always_inline)) FloatVec
     bits_to_signed(const uint8_t* bit_ptr, FloatVec pos, FloatVec neg) {
         uint8_t byte = bit_ptr[0];

--- a/src/simd/traits/simd_traits_avx2.h
+++ b/src/simd/traits/simd_traits_avx2.h
@@ -16,17 +16,17 @@
 #pragma once
 
 // AVX2 traits (Width = 8, __m256, with FMA). MUST only be included from
-// a TU compiled with -mavx2 -mfma. Inherits SimdTraits<AVX_Tag> and
+// a TU compiled with -mavx2 -mfma. Inherits SimdTraits<AvxTag> and
 // overrides fmadd to use the real FMA instruction.
 
 #include "simd_traits_avx.h"
 
 namespace vsag::simd {
 
-struct AVX2_Tag {};
+struct Avx2Tag {};
 
 template <>
-struct SimdTraits<AVX2_Tag> : SimdTraits<AVX_Tag> {
+struct SimdTraits<Avx2Tag> : SimdTraits<AvxTag> {
     // Override: AVX2 + FMA gives us a single fused mul-add.
     static inline __attribute__((always_inline)) FloatVec
     fmadd(FloatVec a, FloatVec b, FloatVec c) {
@@ -35,9 +35,9 @@ struct SimdTraits<AVX2_Tag> : SimdTraits<AVX_Tag> {
 };
 
 // --- Int8 traits for AVX2 ---
-struct AVX2_Int8_Tag {};
+struct Avx2Int8Tag {};
 template <>
-struct Int8Traits<AVX2_Int8_Tag> {
+struct Int8Traits<Avx2Int8Tag> {
     using Int8HalfVec = __m128i;
     using Int16Vec = __m256i;
     using Int32Vec = __m256i;
@@ -78,9 +78,9 @@ struct Int8Traits<AVX2_Int8_Tag> {
 };
 
 // --- Bit operation traits for AVX2 ---
-struct AVX2_Bit_Tag {};
+struct Avx2BitTag {};
 template <>
-struct BitTraits<AVX2_Bit_Tag> {
+struct BitTraits<Avx2BitTag> {
     using IntVec = __m256i;
     static constexpr int ByteWidth = 32;
 
@@ -111,9 +111,9 @@ struct BitTraits<AVX2_Bit_Tag> {
 };
 
 // --- SQ8 traits for AVX2 ---
-struct AVX2_SQ8_Tag {};
+struct Avx2SQ8Tag {};
 template <>
-struct SQ8Traits<AVX2_SQ8_Tag> : SimdTraits<AVX2_Tag> {
+struct SQ8Traits<Avx2SQ8Tag> : SimdTraits<Avx2Tag> {
     static inline __attribute__((always_inline)) FloatVec
     load_u8_as_float(const uint8_t* p) {
         __m128i v = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(p));
@@ -122,9 +122,9 @@ struct SQ8Traits<AVX2_SQ8_Tag> : SimdTraits<AVX2_Tag> {
 };
 
 // --- SQ4Traits for AVX2 (Width=8, STEP=16 nibbles = 8 bytes per call) ---
-struct AVX2_SQ4_Tag {};
+struct Avx2SQ4Tag {};
 template <>
-struct SQ4Traits<AVX2_SQ4_Tag> : SimdTraits<AVX2_Tag> {
+struct SQ4Traits<Avx2SQ4Tag> : SimdTraits<Avx2Tag> {
     static inline __attribute__((always_inline)) void
     load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
         __m128i code = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(p));
@@ -141,9 +141,9 @@ struct SQ4Traits<AVX2_SQ4_Tag> : SimdTraits<AVX2_Tag> {
 };
 
 // --- BF16Traits for AVX2 ---
-struct AVX2_BF16_Tag {};
+struct Avx2BF16Tag {};
 template <>
-struct BF16Traits<AVX2_BF16_Tag> : SimdTraits<AVX2_Tag> {
+struct BF16Traits<Avx2BF16Tag> : SimdTraits<Avx2Tag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         __m128i bf16 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
@@ -153,9 +153,9 @@ struct BF16Traits<AVX2_BF16_Tag> : SimdTraits<AVX2_Tag> {
 };
 
 // --- FP16Traits for AVX2 ---
-struct AVX2_FP16_Tag {};
+struct Avx2FP16Tag {};
 template <>
-struct FP16Traits<AVX2_FP16_Tag> : SimdTraits<AVX2_Tag> {
+struct FP16Traits<Avx2FP16Tag> : SimdTraits<Avx2Tag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         __m128i fp16 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
@@ -164,9 +164,9 @@ struct FP16Traits<AVX2_FP16_Tag> : SimdTraits<AVX2_Tag> {
 };
 
 // --- UniformCodeTraits for AVX2 (32-byte integer vectors) ---
-struct AVX2_Uniform_Tag {};
+struct Avx2UniformTag {};
 template <>
-struct UniformCodeTraits<AVX2_Uniform_Tag> {
+struct UniformCodeTraits<Avx2UniformTag> {
     using IntVec = __m256i;
     static constexpr int ByteWidth = 32;
 
@@ -229,9 +229,9 @@ struct UniformCodeTraits<AVX2_Uniform_Tag> {
 };
 
 // --- RaBitQTraits for AVX2 (8-wide, uses AVX2 integer ops for bit decode) ---
-struct AVX2_RaBitQ_Tag {};
+struct Avx2RaBitQTag {};
 template <>
-struct RaBitQTraits<AVX2_RaBitQ_Tag> : SimdTraits<AVX2_Tag> {
+struct RaBitQTraits<Avx2RaBitQTag> : SimdTraits<Avx2Tag> {
     static inline __attribute__((always_inline)) FloatVec
     bits_to_signed(const uint8_t* bit_ptr, FloatVec pos, FloatVec neg) {
         const __m256i bit_masks = _mm256_setr_epi32(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);

--- a/src/simd/traits/simd_traits_avx512.h
+++ b/src/simd/traits/simd_traits_avx512.h
@@ -24,10 +24,10 @@
 
 namespace vsag::simd {
 
-struct AVX512_Tag {};
+struct Avx512Tag {};
 
 template <>
-struct SimdTraits<AVX512_Tag> {
+struct SimdTraits<Avx512Tag> {
     using FloatVec = __m512;
     static constexpr int Width = 16;
 
@@ -83,9 +83,9 @@ struct SimdTraits<AVX512_Tag> {
 };
 
 // --- Int8 traits for AVX512 ---
-struct AVX512_Int8_Tag {};
+struct Avx512Int8Tag {};
 template <>
-struct Int8Traits<AVX512_Int8_Tag> {
+struct Int8Traits<Avx512Int8Tag> {
     using Int8HalfVec = __m256i;
     using Int16Vec = __m512i;
     using Int32Vec = __m512i;
@@ -122,9 +122,9 @@ struct Int8Traits<AVX512_Int8_Tag> {
 };
 
 // --- Bit operation traits for AVX512 ---
-struct AVX512_Bit_Tag {};
+struct Avx512BitTag {};
 template <>
-struct BitTraits<AVX512_Bit_Tag> {
+struct BitTraits<Avx512BitTag> {
     using IntVec = __m512i;
     static constexpr int ByteWidth = 64;
 
@@ -155,9 +155,9 @@ struct BitTraits<AVX512_Bit_Tag> {
 };
 
 // --- SQ8 traits for AVX512 ---
-struct AVX512_SQ8_Tag {};
+struct Avx512SQ8Tag {};
 template <>
-struct SQ8Traits<AVX512_SQ8_Tag> : SimdTraits<AVX512_Tag> {
+struct SQ8Traits<Avx512SQ8Tag> : SimdTraits<Avx512Tag> {
     static inline __attribute__((always_inline)) FloatVec
     load_u8_as_float(const uint8_t* p) {
         __m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
@@ -166,9 +166,9 @@ struct SQ8Traits<AVX512_SQ8_Tag> : SimdTraits<AVX512_Tag> {
 };
 
 // --- SQ4Traits for AVX512 (Width=16, STEP=32 nibbles = 16 bytes per call) ---
-struct AVX512_SQ4_Tag {};
+struct Avx512SQ4Tag {};
 template <>
-struct SQ4Traits<AVX512_SQ4_Tag> : SimdTraits<AVX512_Tag> {
+struct SQ4Traits<Avx512SQ4Tag> : SimdTraits<Avx512Tag> {
     static inline __attribute__((always_inline)) void
     load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
         __m128i code = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
@@ -186,9 +186,9 @@ struct SQ4Traits<AVX512_SQ4_Tag> : SimdTraits<AVX512_Tag> {
 };
 
 // --- BF16Traits for AVX512 ---
-struct AVX512_BF16_Tag {};
+struct Avx512BF16Tag {};
 template <>
-struct BF16Traits<AVX512_BF16_Tag> : SimdTraits<AVX512_Tag> {
+struct BF16Traits<Avx512BF16Tag> : SimdTraits<Avx512Tag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         __m256i bf16 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
@@ -198,9 +198,9 @@ struct BF16Traits<AVX512_BF16_Tag> : SimdTraits<AVX512_Tag> {
 };
 
 // --- FP16Traits for AVX512 ---
-struct AVX512_FP16_Tag {};
+struct Avx512FP16Tag {};
 template <>
-struct FP16Traits<AVX512_FP16_Tag> : SimdTraits<AVX512_Tag> {
+struct FP16Traits<Avx512FP16Tag> : SimdTraits<Avx512Tag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         __m256i fp16 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
@@ -209,9 +209,9 @@ struct FP16Traits<AVX512_FP16_Tag> : SimdTraits<AVX512_Tag> {
 };
 
 // --- UniformCodeTraits for AVX512 (64-byte integer vectors) ---
-struct AVX512_Uniform_Tag {};
+struct Avx512UniformTag {};
 template <>
-struct UniformCodeTraits<AVX512_Uniform_Tag> {
+struct UniformCodeTraits<Avx512UniformTag> {
     using IntVec = __m512i;
     static constexpr int ByteWidth = 64;
 
@@ -268,9 +268,9 @@ struct UniformCodeTraits<AVX512_Uniform_Tag> {
 };
 
 // --- RaBitQTraits for AVX512 (16-wide, uses mask registers) ---
-struct AVX512_RaBitQ_Tag {};
+struct Avx512RaBitQTag {};
 template <>
-struct RaBitQTraits<AVX512_RaBitQ_Tag> : SimdTraits<AVX512_Tag> {
+struct RaBitQTraits<Avx512RaBitQTag> : SimdTraits<Avx512Tag> {
     static inline __attribute__((always_inline)) FloatVec
     bits_to_signed(const uint8_t* bit_ptr, FloatVec pos, FloatVec neg) {
         auto mask = static_cast<__mmask16>(static_cast<uint16_t>(bit_ptr[0]) |

--- a/src/simd/traits/simd_traits_generic.h
+++ b/src/simd/traits/simd_traits_generic.h
@@ -29,7 +29,7 @@
 
 namespace vsag::simd {
 
-struct Generic_Tag {};
+struct GenericTag {};
 
 // Primary template; specializations live in sibling headers.
 template <typename ISA>
@@ -39,7 +39,7 @@ template <typename ISA>
 struct Int8Traits;
 
 template <>
-struct SimdTraits<Generic_Tag> {
+struct SimdTraits<GenericTag> {
     using FloatVec = float;
     static constexpr int Width = 1;
 
@@ -95,9 +95,9 @@ struct SimdTraits<Generic_Tag> {
 };
 
 // --- Int8 traits for generic (scalar) ---
-struct Generic_Int8_Tag {};
+struct GenericInt8Tag {};
 template <>
-struct Int8Traits<Generic_Int8_Tag> {
+struct Int8Traits<GenericInt8Tag> {
     using Int8HalfVec = int8_t;
     using Int16Vec = int16_t;
     using Int32Vec = int32_t;
@@ -138,9 +138,9 @@ template <typename Tag>
 struct BitTraits;
 
 // Generic scalar bit operations (ByteWidth = 1, process byte by byte)
-struct Generic_Bit_Tag {};
+struct GenericBitTag {};
 template <>
-struct BitTraits<Generic_Bit_Tag> {
+struct BitTraits<GenericBitTag> {
     using IntVec = uint8_t;
     static constexpr int ByteWidth = 1;
 
@@ -175,9 +175,9 @@ template <typename Tag>
 struct SQ8Traits;
 
 // Generic SQ8 traits (scalar, Width=1)
-struct Generic_SQ8_Tag {};
+struct GenericSQ8Tag {};
 template <>
-struct SQ8Traits<Generic_SQ8_Tag> : SimdTraits<Generic_Tag> {
+struct SQ8Traits<GenericSQ8Tag> : SimdTraits<GenericTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_u8_as_float(const uint8_t* p) {
         return static_cast<float>(p[0]);
@@ -189,9 +189,9 @@ template <typename Tag>
 struct SQ4Traits;
 
 // Generic SQ4 (scalar, Width=1, STEP=2 nibbles per iter)
-struct Generic_SQ4_Tag {};
+struct GenericSQ4Tag {};
 template <>
-struct SQ4Traits<Generic_SQ4_Tag> : SimdTraits<Generic_Tag> {
+struct SQ4Traits<GenericSQ4Tag> : SimdTraits<GenericTag> {
     static inline __attribute__((always_inline)) void
     load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
         constexpr float inv15 = 1.0f / 15.0f;
@@ -204,9 +204,9 @@ struct SQ4Traits<Generic_SQ4_Tag> : SimdTraits<Generic_Tag> {
 template <typename Tag>
 struct BF16Traits;
 
-struct Generic_BF16_Tag {};
+struct GenericBF16Tag {};
 template <>
-struct BF16Traits<Generic_BF16_Tag> : SimdTraits<Generic_Tag> {
+struct BF16Traits<GenericBF16Tag> : SimdTraits<GenericTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         uint32_t bits = static_cast<uint32_t>(*p) << 16;
@@ -229,9 +229,9 @@ struct UniformCodeTraits;
 template <typename Tag>
 struct FP16Traits;
 
-struct Generic_FP16_Tag {};
+struct GenericFP16Tag {};
 template <>
-struct FP16Traits<Generic_FP16_Tag> : SimdTraits<Generic_Tag> {
+struct FP16Traits<GenericFP16Tag> : SimdTraits<GenericTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         uint32_t h = *p;

--- a/src/simd/traits/simd_traits_neon.h
+++ b/src/simd/traits/simd_traits_neon.h
@@ -24,10 +24,10 @@
 
 namespace vsag::simd {
 
-struct NEON_Tag {};
+struct NeonTag {};
 
 template <>
-struct SimdTraits<NEON_Tag> {
+struct SimdTraits<NeonTag> {
     using FloatVec = float32x4_t;
     static constexpr int Width = 4;
 
@@ -83,9 +83,9 @@ struct SimdTraits<NEON_Tag> {
 };
 
 // --- Int8 traits for NEON ---
-struct NEON_Int8_Tag {};
+struct NeonInt8Tag {};
 template <>
-struct Int8Traits<NEON_Int8_Tag> {
+struct Int8Traits<NeonInt8Tag> {
     using Int8HalfVec = int8x8_t;
     using Int16Vec = int16x8_t;
     using Int32Vec = int32x4_t;
@@ -125,9 +125,9 @@ struct Int8Traits<NEON_Int8_Tag> {
 };
 
 // --- Bit operation traits for NEON ---
-struct NEON_Bit_Tag {};
+struct NeonBitTag {};
 template <>
-struct BitTraits<NEON_Bit_Tag> {
+struct BitTraits<NeonBitTag> {
     using IntVec = uint8x16_t;
     static constexpr int ByteWidth = 16;
 
@@ -158,9 +158,9 @@ struct BitTraits<NEON_Bit_Tag> {
 };
 
 // --- SQ8 traits for NEON ---
-struct NEON_SQ8_Tag {};
+struct NeonSQ8Tag {};
 template <>
-struct SQ8Traits<NEON_SQ8_Tag> : SimdTraits<NEON_Tag> {
+struct SQ8Traits<NeonSQ8Tag> : SimdTraits<NeonTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_u8_as_float(const uint8_t* p) {
         uint32x4_t v32 = {p[0], p[1], p[2], p[3]};
@@ -169,9 +169,9 @@ struct SQ8Traits<NEON_SQ8_Tag> : SimdTraits<NEON_Tag> {
 };
 
 // --- SQ4Traits for NEON (Width=4, STEP=8 nibbles = 4 bytes per call) ---
-struct NEON_SQ4_Tag {};
+struct NeonSQ4Tag {};
 template <>
-struct SQ4Traits<NEON_SQ4_Tag> : SimdTraits<NEON_Tag> {
+struct SQ4Traits<NeonSQ4Tag> : SimdTraits<NeonTag> {
     static inline __attribute__((always_inline)) void
     load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
         constexpr float inv15 = 1.0f / 15.0f;
@@ -194,9 +194,9 @@ struct SQ4Traits<NEON_SQ4_Tag> : SimdTraits<NEON_Tag> {
 };
 
 // --- BF16Traits for NEON ---
-struct NEON_BF16_Tag {};
+struct NeonBF16Tag {};
 template <>
-struct BF16Traits<NEON_BF16_Tag> : SimdTraits<NEON_Tag> {
+struct BF16Traits<NeonBF16Tag> : SimdTraits<NeonTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         uint16x4_t bf16 = vld1_u16(p);
@@ -206,9 +206,9 @@ struct BF16Traits<NEON_BF16_Tag> : SimdTraits<NEON_Tag> {
 };
 
 // --- FP16Traits for NEON ---
-struct NEON_FP16_Tag {};
+struct NeonFP16Tag {};
 template <>
-struct FP16Traits<NEON_FP16_Tag> : SimdTraits<NEON_Tag> {
+struct FP16Traits<NeonFP16Tag> : SimdTraits<NeonTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         float16x4_t fp16 = vld1_f16(reinterpret_cast<const __fp16*>(p));

--- a/src/simd/traits/simd_traits_sse.h
+++ b/src/simd/traits/simd_traits_sse.h
@@ -28,10 +28,10 @@
 
 namespace vsag::simd {
 
-struct SSE_Tag {};
+struct SseTag {};
 
 template <>
-struct SimdTraits<SSE_Tag> {
+struct SimdTraits<SseTag> {
     using FloatVec = __m128;
     static constexpr int Width = 4;
 
@@ -98,9 +98,9 @@ struct SimdTraits<SSE_Tag> {
 };
 
 // --- Int8 traits for SSE ---
-struct SSE_Int8_Tag {};
+struct SseInt8Tag {};
 template <>
-struct Int8Traits<SSE_Int8_Tag> {
+struct Int8Traits<SseInt8Tag> {
     using Int8HalfVec = __m128i;  // only lower 64 bits used
     using Int16Vec = __m128i;
     using Int32Vec = __m128i;
@@ -139,9 +139,9 @@ struct Int8Traits<SSE_Int8_Tag> {
 };
 
 // --- Bit operation traits for SSE ---
-struct SSE_Bit_Tag {};
+struct SseBitTag {};
 template <>
-struct BitTraits<SSE_Bit_Tag> {
+struct BitTraits<SseBitTag> {
     using IntVec = __m128i;
     static constexpr int ByteWidth = 16;
 
@@ -172,9 +172,9 @@ struct BitTraits<SSE_Bit_Tag> {
 };
 
 // --- SQ8 traits for SSE ---
-struct SSE_SQ8_Tag {};
+struct SseSQ8Tag {};
 template <>
-struct SQ8Traits<SSE_SQ8_Tag> : SimdTraits<SSE_Tag> {
+struct SQ8Traits<SseSQ8Tag> : SimdTraits<SseTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_u8_as_float(const uint8_t* p) {
         __m128i v = _mm_set_epi8(0,
@@ -198,9 +198,9 @@ struct SQ8Traits<SSE_SQ8_Tag> : SimdTraits<SSE_Tag> {
 };
 
 // --- SQ4Traits for SSE (Width=4, STEP=8 nibbles = 4 bytes per call) ---
-struct SSE_SQ4_Tag {};
+struct SseSQ4Tag {};
 template <>
-struct SQ4Traits<SSE_SQ4_Tag> : SimdTraits<SSE_Tag> {
+struct SQ4Traits<SseSQ4Tag> : SimdTraits<SseTag> {
     static inline __attribute__((always_inline)) void
     load_nibbles_2x_as_float(const uint8_t* p, FloatVec& out0, FloatVec& out1) {
         __m128i code_vec = _mm_set_epi8(0,
@@ -231,9 +231,9 @@ struct SQ4Traits<SSE_SQ4_Tag> : SimdTraits<SSE_Tag> {
 };
 
 // --- BF16Traits for SSE ---
-struct SSE_BF16_Tag {};
+struct SseBF16Tag {};
 template <>
-struct BF16Traits<SSE_BF16_Tag> : SimdTraits<SSE_Tag> {
+struct BF16Traits<SseBF16Tag> : SimdTraits<SseTag> {
     static inline __attribute__((always_inline)) FloatVec
     load_half(const uint16_t* p) {
         __m128i v = _mm_set_epi16(static_cast<short>(p[3]),
@@ -249,9 +249,9 @@ struct BF16Traits<SSE_BF16_Tag> : SimdTraits<SSE_Tag> {
 };
 
 // --- UniformCodeTraits for SSE (16-byte integer vectors) ---
-struct SSE_Uniform_Tag {};
+struct SseUniformTag {};
 template <>
-struct UniformCodeTraits<SSE_Uniform_Tag> {
+struct UniformCodeTraits<SseUniformTag> {
     using IntVec = __m128i;
     static constexpr int ByteWidth = 16;
 

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -39,7 +39,7 @@ namespace vsag {
 
 namespace {
 
-struct file_closer {
+struct FileCloser {
     void
     operator()(std::FILE* file) const {
         std::fclose(file);
@@ -283,7 +283,7 @@ ReadSeekableBlockPayload(StreamReader& reader,
         return;
     }
 
-    std::unique_ptr<std::FILE, file_closer> temp_file(std::tmpfile());
+    std::unique_ptr<std::FILE, FileCloser> temp_file(std::tmpfile());
     if (temp_file == nullptr) {
         throw VsagException(ErrorType::READ_ERROR,
                             "failed to create temporary file for streaming block payload");

--- a/src/type_helpers.h
+++ b/src/type_helpers.h
@@ -39,11 +39,11 @@ using ConstParamMap = const std::unordered_multimap<std::string, std::vector<std
 using IdFilterFuncType = std::function<bool(LabelType)>;
 
 template <typename Ref>
-struct lvalue_or_rvalue {
+struct LvalueOrRvalue {
     Ref&& ref;
 
     template <typename Arg>
-    constexpr lvalue_or_rvalue(Arg&& arg) noexcept : ref(std::move(arg)) {
+    constexpr LvalueOrRvalue(Arg&& arg) noexcept : ref(std::move(arg)) {
     }
 
     constexpr

--- a/src/utils/function_exists_check.h
+++ b/src/utils/function_exists_check.h
@@ -22,35 +22,35 @@ template <typename...>
 using void_t = void;
 
 template <template <typename...> class Op, typename, typename... Args>
-struct detector : std::false_type {};
+struct Detector : std::false_type {};
 
 template <template <typename...> class Op, typename... Args>
-struct detector<Op, void_t<Op<Args...>>, Args...> : std::true_type {
+struct Detector<Op, void_t<Op<Args...>>, Args...> : std::true_type {
     using type = Op<Args...>;
 };
 
 template <template <typename...> class Op, typename... Args>
-constexpr bool is_detected_v = detector<Op, void, Args...>::value;
+constexpr bool is_detected_v = Detector<Op, void, Args...>::value;
 
 #define GENERATE_HAS_MEMBER_FUNCTION(FuncName, ReturnType, ...)                   \
     template <typename T>                                                         \
     using has_##FuncName##_t = decltype(std::declval<T>().FuncName(__VA_ARGS__)); \
                                                                                   \
     template <typename T>                                                         \
-    struct has_##FuncName                                                         \
+    struct Has##FuncName                                                          \
         : std::conjunction<                                                       \
-              detector<has_##FuncName##_t, void, T>,                              \
-              std::is_same<typename detector<has_##FuncName##_t, void, T>::type, ReturnType>> {};
+              Detector<has_##FuncName##_t, void, T>,                              \
+              std::is_same<typename Detector<has_##FuncName##_t, void, T>::type, ReturnType>> {};
 
 #define GENERATE_HAS_STATIC_CLASS_FUNCTION(FuncName, ReturnType, ...)                   \
     template <typename T>                                                               \
     using has_static_##FuncName##_t = decltype(T::FuncName(__VA_ARGS__));               \
                                                                                         \
     template <typename T>                                                               \
-    struct has_static_##FuncName                                                        \
+    struct HasStatic##FuncName                                                          \
         : std::conjunction<                                                             \
-              detector<has_static_##FuncName##_t, void, T>,                             \
-              std::is_same<typename detector<has_static_##FuncName##_t, void, T>::type, \
+              Detector<has_static_##FuncName##_t, void, T>,                             \
+              std::is_same<typename Detector<has_static_##FuncName##_t, void, T>::type, \
                            ReturnType>> {};
 
 }  // namespace vsag

--- a/tests/fixtures/core/types.cpp
+++ b/tests/fixtures/core/types.cpp
@@ -18,12 +18,12 @@
 
 namespace fixtures {
 
-comparable_float_t::comparable_float_t(float val) {
+ComparableFloatT::ComparableFloatT(float val) {
     this->value = val;
 }
 
 bool
-comparable_float_t::operator==(const comparable_float_t& d) const {
+ComparableFloatT::operator==(const ComparableFloatT& d) const {
     double a = this->value;
     double b = d.value;
     if (std::abs(a - b) < epsilon) {
@@ -35,7 +35,7 @@ comparable_float_t::operator==(const comparable_float_t& d) const {
 }
 
 std::ostream&
-operator<<(std::ostream& os, const comparable_float_t& obj) {
+operator<<(std::ostream& os, const ComparableFloatT& obj) {
     os << obj.value;
     return os;
 }

--- a/tests/fixtures/core/types.h
+++ b/tests/fixtures/core/types.h
@@ -25,41 +25,41 @@
 namespace fixtures {
 
 /**
- * @struct comparable_float_t
+ * @struct ComparableFloatT
  * @brief Float wrapper that compares values with tolerance for relative error.
  * Useful for comparing distances, recall values, and timing measurements in tests.
  */
-struct comparable_float_t {
+struct ComparableFloatT {
     /**
-     * @brief Constructs a comparable_float_t from a float value.
+     * @brief Constructs a ComparableFloatT from a float value.
      * @param val The float value to wrap.
      */
-    comparable_float_t(float val);
+    ComparableFloatT(float val);
 
     /**
-     * @brief Compares two comparable_float_t values with tolerance.
+     * @brief Compares two ComparableFloatT values with tolerance.
      * @param d The other value to compare against.
      * @return True if values are within epsilon tolerance.
      */
     bool
-    operator==(const comparable_float_t& d) const;
+    operator==(const ComparableFloatT& d) const;
 
     /**
      * @brief Outputs the value to a stream.
      * @param os The output stream.
-     * @param obj The comparable_float_t to output.
+     * @param obj The ComparableFloatT to output.
      * @return Reference to the output stream.
      */
     friend std::ostream&
-    operator<<(std::ostream& os, const comparable_float_t& obj);
+    operator<<(std::ostream& os, const ComparableFloatT& obj);
 
     float value;                  // The wrapped float value.
     const double epsilon = 2e-6;  // Tolerance for comparison.
 };
 
-using dist_t = comparable_float_t;
-using time_t = comparable_float_t;
-using recall_t = comparable_float_t;
+using dist_t = ComparableFloatT;
+using time_t = ComparableFloatT;
+using recall_t = ComparableFloatT;
 
 /**
  * @struct IOItem

--- a/tests/scripts/check_struct_names_test.py
+++ b/tests/scripts/check_struct_names_test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts/linters/check-struct-names.py"
+
+
+class CheckStructNamesTest(unittest.TestCase):
+    def run_checker(self, source: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture.h"
+            fixture.write_text(source)
+            return subprocess.run(
+                [str(CHECKER), "--root", directory, str(fixture)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_accepts_camel_case_and_ignores_non_definitions(self):
+        result = self.run_checker(
+            """
+            // struct commented_out {};
+            struct external_type;
+            struct alignas(64) Http2Config {};
+            template <typename T> struct VectorTraits<T*> {};
+            #define DECLARE_TRAIT(Name) struct Has##Name {};
+            DECLARE_TRAIT(ReadImpl)
+            """
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_rejects_non_camel_case_definition(self):
+        result = self.run_checker("struct invalid_name {};\n")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("fixture.h:1: struct 'invalid_name' is not CamelCase", result.stdout)
+
+    def test_rejects_non_camel_case_token_pasted_definition(self):
+        result = self.run_checker("#define DECLARE(Name) struct invalid_##Name {};\n")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("struct 'invalid_Name' is not CamelCase", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/autotune/autotune.cpp
+++ b/tools/autotune/autotune.cpp
@@ -214,7 +214,7 @@ metric_type(const std::string& dataset_metric) {
     throw std::invalid_argument("unsupported dataset distance: " + dataset_metric);
 }
 
-struct offline_dataset_owner {
+struct OfflineDatasetOwner {
     eval::EvalDatasetPtr source;
     std::vector<int64_t> identity_ids;
     DatasetPtr base;
@@ -232,7 +232,7 @@ attach_offline_dataset(IndexRequest& request,
                 dataset->GetTestDataType() == vsag::DATATYPE_FLOAT32,
             "AutoTune V1 supports only float32 datasets");
 
-    auto owner = std::make_shared<offline_dataset_owner>();
+    auto owner = std::make_shared<OfflineDatasetOwner>();
     owner->source = dataset;
     const auto base_count = dataset->GetNumberOfBase();
     const auto query_count = dataset->GetNumberOfQuery();

--- a/tools/eval/eval_config.cpp
+++ b/tools/eval/eval_config.cpp
@@ -71,7 +71,7 @@ EvalConfig::Load(argparse::ArgumentParser& parser) {
 }
 
 EvalConfig
-EvalConfig::Load(YAML::Node& yaml_node, const eval_job& global_options) {
+EvalConfig::Load(YAML::Node& yaml_node, const EvalJob& global_options) {
     EvalConfig config;
 
     // set global options at first

--- a/tools/eval/eval_config.h
+++ b/tools/eval/eval_config.h
@@ -27,7 +27,7 @@ public:
     Load(argparse::ArgumentParser& parser);
 
     static EvalConfig
-    Load(YAML::Node& yaml_node, const eval_job& global_options);
+    Load(YAML::Node& yaml_node, const EvalJob& global_options);
 
     static void
     CheckKeyAndType(YAML::Node& yaml_node);

--- a/tools/eval/eval_job.cpp
+++ b/tools/eval/eval_job.cpp
@@ -19,9 +19,9 @@
 
 namespace vsag::eval {
 
-exporter
-exporter::Load(YAML::Node& node) {
-    exporter ret;
+ExporterConfig
+ExporterConfig::Load(YAML::Node& node) {
+    ExporterConfig ret;
     ret.format = check_and_get_value(node, "format");
     ret.to = check_and_get_value(node, "to");
     if (not node["vars"].IsDefined()) {

--- a/tools/eval/eval_job.h
+++ b/tools/eval/eval_job.h
@@ -23,8 +23,8 @@
 
 namespace vsag::eval {
 
-struct exporter {
-    static exporter
+struct ExporterConfig {
+    static ExporterConfig
     Load(YAML::Node&);
 
     std::string format{"json"};  // json, text/table, line_protocol
@@ -38,15 +38,15 @@ struct HttpServer {
     int port = 8080;  // default port
 };
 
-// a eval_job contains multiple eval cases
-struct eval_job {
+// a EvalJob contains multiple eval cases
+struct EvalJob {
     using eval_case = YAML::Node;
     using name2case = std::pair<std::string, eval_case>;
 
     std::vector<name2case> cases;
 
     // global options
-    std::vector<exporter> exporters;
+    std::vector<ExporterConfig> exporters;
     std::optional<int32_t> num_threads_building;
     std::optional<int32_t> num_threads_searching;
     std::optional<HttpServer> http_server;

--- a/tools/eval/main.cpp
+++ b/tools/eval/main.cpp
@@ -115,19 +115,19 @@ parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
     }
 }
 
-vsag::eval::eval_job
+vsag::eval::EvalJob
 parse_yaml_file(const std::string& yaml_file) {
     using Node = YAML::Node;
     Node config_all = YAML::LoadFile(yaml_file);
 
-    vsag::eval::eval_job cac;
+    vsag::eval::EvalJob cac;
     try {
         if (config_all["global"]) {
             if (config_all["global"]["exporters"]) {
                 auto exporters_root = config_all["global"]["exporters"];
                 if (exporters_root.IsMap()) {
                     for (auto it = exporters_root.begin(); it != exporters_root.end(); ++it) {
-                        auto exporter = vsag::eval::exporter::Load(it->second);
+                        auto exporter = vsag::eval::ExporterConfig::Load(it->second);
                         cac.exporters.emplace_back(exporter);
                     }
                 }


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

Not applicable for this `kind/improvement` maintenance change.

## What Changed

- Keep `readability-identifier-naming.StructCase: CamelCase` in the root Clang 15 configuration.
- Migrate every verified non-CamelCase named struct definition in tracked project-owned C/C++ sources and headers.
- Add a tracked-header-aware validator to `make lint`, plus positive and negative fixtures.

The inventory started from lexical candidates and every ordinary declaration was verified with Clang 15 AST queries. Macro-generated declarations were verified through their compile expansions. The run artifact contains the exact declaration-aware inventory and verification notes.

<details>
<summary>Complete old-to-new mapping (79 identifiers)</summary>

| Old identifier | New identifier | Declaration location |
| --- | --- | --- |
| `streaming_index_load_target` | `StreamingIndexLoadTarget` | `src/factory/factory.cpp:227` |
| `manifest_block` | `ManifestBlock` | `src/factory/factory.cpp:329` |
| `analyze_options` | `AnalyzeOptions` | `src/analyzer/sindi_analyzer.cpp:46` |
| `lvalue_or_rvalue` | `LvalueOrRvalue` | `src/type_helpers.h:42` |
| `detector` | `Detector` | `src/utils/function_exists_check.h:25,28` |
| `pending_reset_guard` | `PendingResetGuard` | `src/algorithm/hgraph/hgraph_build.cpp:822` |
| `visited_list_guard` | `HGraphVisitedListGuard` | `src/algorithm/hgraph/hgraph_search.cpp:544` |
| `rerank_layout_record` | `RerankLayoutRecord` | `src/algorithm/sindi_v2/sindi_v2.cpp:267` |
| `cluster_member_entry` | `ClusterMemberEntry` | `src/algorithm/simq/simq.cpp:53` |
| `per_thread_cluster_data` | `PerThreadClusterData` | `src/algorithm/simq/simq.cpp:758` |
| `token_search_result` | `TokenSearchResult` | `src/algorithm/simq/simq.cpp:1253` |
| `file_closer` | `FileCloser` | `src/storage/tlv_section.cpp:42` |
| `mce_stats` | `MceStats` | `src/algorithm/mci/mci_mce.h:11` |
| `query_term_read_plan` | `QueryTermReadPlan` | `src/datacell/disk_sindi_term_datacell.cpp:294` |
| `rebind` | `Rebind` | `src/impl/allocator/allocator_wrapper.h:77` |
| `comparable_float_t` | `ComparableFloatT` | `tests/fixtures/core/types.h:32` |
| `exporter` | `ExporterConfig` | `tools/eval/eval_job.h:26` |
| `eval_job` | `EvalJob` | `tools/eval/eval_job.h:42` |
| `offline_dataset_owner` | `OfflineDatasetOwner` | `tools/autotune/autotune.cpp:217` |
| `has_ComputeDistsBatch4Impl` | `HasComputeDistsBatch4Impl` | `src/quantization/quantizer.h:367 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_ComputeDistWithThresholdImpl` | `HasComputeDistWithThresholdImpl` | `src/quantization/quantizer.h:378 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_ComputeDistWithLowerBoundImpl` | `HasComputeDistWithLowerBoundImpl` | `src/quantization/quantizer.h:384 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_static_CheckAndMappingExternalParam` | `HasStaticCheckAndMappingExternalParam` | `src/index/index_impl.h:28 (macro spelling src/utils/function_exists_check.h:50)` |
| `has_WriteImpl` | `HasWriteImpl` | `src/io/common/basic_io.h:897 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_ReadImpl` | `HasReadImpl` | `src/io/common/basic_io.h:902 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_DirectReadImpl` | `HasDirectReadImpl` | `src/io/common/basic_io.h:907 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_MultiReadImpl` | `HasMultiReadImpl` | `src/io/common/basic_io.h:912 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_PrefetchImpl` | `HasPrefetchImpl` | `src/io/common/basic_io.h:918 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_ReleaseImpl` | `HasReleaseImpl` | `src/io/common/basic_io.h:922 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_InitIOImpl` | `HasInitIOImpl` | `src/io/common/basic_io.h:923 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_ResizeImpl` | `HasResizeImpl` | `src/io/common/basic_io.h:924 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_ShrinkImpl` | `HasShrinkImpl` | `src/io/common/basic_io.h:925 (macro spelling src/utils/function_exists_check.h:40)` |
| `has_GetMemoryUsageImpl` | `HasGetMemoryUsageImpl` | `src/io/common/basic_io.h:926 (macro spelling src/utils/function_exists_check.h:40)` |
| `AVX_Tag` | `AvxTag` | `src/simd/traits/simd_traits_avx.h:29` |
| `AVX_Bit_Tag` | `AvxBitTag` | `src/simd/traits/simd_traits_avx.h:92` |
| `AVX_SQ8_Tag` | `AvxSQ8Tag` | `src/simd/traits/simd_traits_avx.h:125` |
| `AVX_SQ4_Tag` | `AvxSQ4Tag` | `src/simd/traits/simd_traits_avx.h:140` |
| `AVX_BF16_Tag` | `AvxBF16Tag` | `src/simd/traits/simd_traits_avx.h:195` |
| `AVX_FP16_Tag` | `AvxFP16Tag` | `src/simd/traits/simd_traits_avx.h:221` |
| `AVX_RaBitQ_Tag` | `AvxRaBitQTag` | `src/simd/traits/simd_traits_avx.h:232` |
| `AVX2_Tag` | `Avx2Tag` | `src/simd/traits/simd_traits_avx2.h:26` |
| `AVX2_Int8_Tag` | `Avx2Int8Tag` | `src/simd/traits/simd_traits_avx2.h:38` |
| `AVX2_Bit_Tag` | `Avx2BitTag` | `src/simd/traits/simd_traits_avx2.h:81` |
| `AVX2_SQ8_Tag` | `Avx2SQ8Tag` | `src/simd/traits/simd_traits_avx2.h:114` |
| `AVX2_SQ4_Tag` | `Avx2SQ4Tag` | `src/simd/traits/simd_traits_avx2.h:125` |
| `AVX2_BF16_Tag` | `Avx2BF16Tag` | `src/simd/traits/simd_traits_avx2.h:144` |
| `AVX2_FP16_Tag` | `Avx2FP16Tag` | `src/simd/traits/simd_traits_avx2.h:156` |
| `AVX2_Uniform_Tag` | `Avx2UniformTag` | `src/simd/traits/simd_traits_avx2.h:167` |
| `AVX2_RaBitQ_Tag` | `Avx2RaBitQTag` | `src/simd/traits/simd_traits_avx2.h:232` |
| `AVX512_Tag` | `Avx512Tag` | `src/simd/traits/simd_traits_avx512.h:27` |
| `AVX512_Int8_Tag` | `Avx512Int8Tag` | `src/simd/traits/simd_traits_avx512.h:86` |
| `AVX512_Bit_Tag` | `Avx512BitTag` | `src/simd/traits/simd_traits_avx512.h:125` |
| `AVX512_SQ8_Tag` | `Avx512SQ8Tag` | `src/simd/traits/simd_traits_avx512.h:158` |
| `AVX512_SQ4_Tag` | `Avx512SQ4Tag` | `src/simd/traits/simd_traits_avx512.h:169` |
| `AVX512_BF16_Tag` | `Avx512BF16Tag` | `src/simd/traits/simd_traits_avx512.h:189` |
| `AVX512_FP16_Tag` | `Avx512FP16Tag` | `src/simd/traits/simd_traits_avx512.h:201` |
| `AVX512_Uniform_Tag` | `Avx512UniformTag` | `src/simd/traits/simd_traits_avx512.h:212` |
| `AVX512_RaBitQ_Tag` | `Avx512RaBitQTag` | `src/simd/traits/simd_traits_avx512.h:271` |
| `NEON_Tag` | `NeonTag` | `src/simd/traits/simd_traits_neon.h:27` |
| `NEON_Int8_Tag` | `NeonInt8Tag` | `src/simd/traits/simd_traits_neon.h:86` |
| `NEON_Bit_Tag` | `NeonBitTag` | `src/simd/traits/simd_traits_neon.h:128` |
| `NEON_SQ8_Tag` | `NeonSQ8Tag` | `src/simd/traits/simd_traits_neon.h:161` |
| `NEON_SQ4_Tag` | `NeonSQ4Tag` | `src/simd/traits/simd_traits_neon.h:172` |
| `NEON_BF16_Tag` | `NeonBF16Tag` | `src/simd/traits/simd_traits_neon.h:197` |
| `NEON_FP16_Tag` | `NeonFP16Tag` | `src/simd/traits/simd_traits_neon.h:209` |
| `Generic_Tag` | `GenericTag` | `src/simd/traits/simd_traits_generic.h:32` |
| `Generic_Int8_Tag` | `GenericInt8Tag` | `src/simd/traits/simd_traits_generic.h:98` |
| `Generic_Bit_Tag` | `GenericBitTag` | `src/simd/traits/simd_traits_generic.h:141` |
| `Generic_SQ8_Tag` | `GenericSQ8Tag` | `src/simd/traits/simd_traits_generic.h:178` |
| `Generic_SQ4_Tag` | `GenericSQ4Tag` | `src/simd/traits/simd_traits_generic.h:192` |
| `Generic_BF16_Tag` | `GenericBF16Tag` | `src/simd/traits/simd_traits_generic.h:207` |
| `Generic_FP16_Tag` | `GenericFP16Tag` | `src/simd/traits/simd_traits_generic.h:232` |
| `SSE_Tag` | `SseTag` | `src/simd/traits/simd_traits_sse.h:31` |
| `SSE_Int8_Tag` | `SseInt8Tag` | `src/simd/traits/simd_traits_sse.h:101` |
| `SSE_Bit_Tag` | `SseBitTag` | `src/simd/traits/simd_traits_sse.h:142` |
| `SSE_SQ8_Tag` | `SseSQ8Tag` | `src/simd/traits/simd_traits_sse.h:175` |
| `SSE_SQ4_Tag` | `SseSQ4Tag` | `src/simd/traits/simd_traits_sse.h:201` |
| `SSE_BF16_Tag` | `SseBF16Tag` | `src/simd/traits/simd_traits_sse.h:234` |
| `SSE_Uniform_Tag` | `SseUniformTag` | `src/simd/traits/simd_traits_sse.h:252` |

</details>

## Scope and Exclusions

- Scanned 936 tracked project-owned C/C++ files, including headers and `.inl` files rather than only configured translation units.
- Excluded `extern/`, vendor/third-party, generated/build output, deprecated HNSW/DiskANN paths, and the vendored `include/vsag/expected.hpp` implementation.
- No files under `extern/` or other excluded dependency trees were changed.
- Normalized `src/algorithm/simq/simq.cpp` to the repository standard LF line endings; no path-specific `.gitattributes` exception is required.

## Compatibility and Collision Decisions

- Supported public headers under `include/vsag/` had no affected project-owned struct definitions, so no public API aliases were needed.
- `AllocatorWrapper::Rebind` retains a lowercase `rebind` alias because that spelling is the standard allocator compatibility hook; the struct definition itself is CamelCase.
- `exporter` became `ExporterConfig` to avoid the existing `eval::Exporter` class.
- The local HGraph guard became `HGraphVisitedListGuard` to avoid the existing Pyramid `VisitedListGuard` name.
- SIMD acronyms use the spellings emitted by Clang 15's CamelCase fixer (`Avx`, `Sse`, `Neon`, while preserving suffixes such as `SQ8`, `BF16`, and `RaBitQ`).

## Test Evidence

- [x] `clang-format-15` on all changed C/C++ files
- [x] Clang 15 `readability-identifier-naming` over changed compiled translation units
- [x] Header-aware validator over all 936 in-scope files
- [x] Positive/negative validator fixture tests
- [x] Debug developer build with tools/tests/examples (`make dev`)
- [x] Focused SIMQ functional tests: 8 cases / 4,773 assertions
- [x] Eval dataset tests: 14 cases / 121 assertions
- [x] Autotune tests: 24 cases / 250 assertions
- [x] Public C++ and C API header syntax checks with `clang++-15`
- [x] `git diff --check`

The full unit suite passed all 792 cases / 85,350,391 assertions on the rebased branch. The unfiltered functional runner was stopped during an unrelated Daily HGraph case after 64 cases had passed; the focused SIMQ and affected tool suites then ran to completion as listed above.

## Compatibility, Performance, and Documentation Impact

- API/ABI: no supported public API rename; one internal standard-hook alias retained.
- Runtime behavior/performance/concurrency: no intended change.
- Documentation: no user-facing behavior change; no website update needed.

## Risk and Rollback

- Risk is limited to internal source identifiers and lint enforcement.
- Rollback by reverting the single commit.

