### PR TITLE
[Backport 0.18] feat(pyramid): support paths in GetDataByIdsWithFlag

### DIFF
--- a/examples/cpp/107_index_pyramid.cpp
+++ b/examples/cpp/107_index_pyramid.cpp
@@ -97,6 +97,7 @@ main(int argc, char** argv) {
     // - "precise_quantization_type": The precise quantization codes
     // - "index_min_size": The minimum size required to build the index
     // - "support_duplicate": support for duplicate data in the index
+    // - "store_paths": retain paths for GetDataByIds (disabled by default)
     auto pyramid_build_paramesters = R"(
     {
         "dtype": "float32",
@@ -109,6 +110,7 @@ main(int argc, char** argv) {
             "graph_iter_turn": 15,
             "neighbor_sample_rate": 0.2,
             "no_build_levels": [0, 1],
+            "store_paths": true,
             "use_reorder": true,
             "graph_type": "odescent",
             "build_thread_count": 16
@@ -125,6 +127,11 @@ main(int argc, char** argv) {
         std::cerr << "Failed to build index: " << build_result.error().message << std::endl;
         exit(-1);
     }
+
+    int64_t requested_ids[] = {1, 0};
+    auto restored = index->GetDataByIds(requested_ids, 2).value();
+    std::cout << "Paths by id: " << restored->GetPaths()[0] << ", " << restored->GetPaths()[1]
+              << std::endl;
 
     /******************* KnnSearch For Pyramid Index *****************/
     auto query_path = new std::string[1];

--- a/examples/cpp/107_index_pyramid.cpp
+++ b/examples/cpp/107_index_pyramid.cpp
@@ -97,7 +97,7 @@ main(int argc, char** argv) {
     // - "precise_quantization_type": The precise quantization codes
     // - "index_min_size": The minimum size required to build the index
     // - "support_duplicate": support for duplicate data in the index
-    // - "store_paths": retain paths for GetDataByIds (disabled by default)
+    // - "store_paths": retain paths for DATA_FLAG_PATH retrieval (disabled by default)
     auto pyramid_build_paramesters = R"(
     {
         "dtype": "float32",
@@ -129,7 +129,7 @@ main(int argc, char** argv) {
     }
 
     int64_t requested_ids[] = {1, 0};
-    auto restored = index->GetDataByIds(requested_ids, 2).value();
+    auto restored = index->GetDataByIdsWithFlag(requested_ids, 2, DATA_FLAG_PATH).value();
     std::cout << "Paths by id: " << restored->GetPaths()[0] << ", " << restored->GetPaths()[1]
               << std::endl;
 

--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -126,6 +126,7 @@ extern const char* const PYRAMID_PARAMETER_EF_SEARCH;
 extern const char* const PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH;
 extern const char* const PYRAMID_NO_BUILD_LEVELS;
 extern const char* const PYRAMID_INDEX_MIN_SIZE;
+extern const char* const PYRAMID_STORE_PATHS;
 
 extern const char PART_SLASH;
 extern const char PART_BAR;

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -51,6 +51,7 @@ enum class IndexType { HNSW, DISKANN, HGRAPH, IVF, PYRAMID, BRUTEFORCE, SPARSE, 
 #define DATA_FLAG_EXTRA_INFO 0x10
 #define DATA_FLAG_ATTRIBUTE 0x20
 #define DATA_FLAG_ID 0x40
+#define DATA_FLAG_PATH 0x80
 
 using OffsetType = uint64_t;
 using SizeType = uint64_t;
@@ -532,16 +533,17 @@ public:
     };
 
     /**
-     * @brief Retrieve all data associated with vectors identified by given IDs.
+     * @brief Retrieve selected data associated with vectors identified by given IDs.
      *
-     * This method fetches data stored with the vectors in the index
-     * (e.g., attributes, labels, or extra infos).
+     * This method fetches selected data stored with the vectors in the index
+     * (e.g., vectors, attributes, extra infos, IDs, or retained paths).
      *
      * @param ids Array of vector IDs for which extra information is requested.
      * @param count Number of IDs in the 'ids' array.
-     * @param selected_data_flag selected data flag, set with DATA_FLAG_*
+     * @param selected_data_flag Selected data flags, set with DATA_FLAG_*.
+     *        DATA_FLAG_PATH requests retained paths from indexes that support them.
      * @return tl::expected<DatasetPtr, Error>
-     *         - On success: A DatasetPtr containing the extra data, attribute and vector
+     *         - On success: A DatasetPtr containing the selected data fields
      *         - On failure: An error object (e.g., invalid ID, out of memory).
      * @throws std::runtime_error If the index implementation does not support this operation
      *            (default behavior for base class).
@@ -585,7 +587,7 @@ public:
     };
 
     /**
-     * @brief Retrieve all data associated with vectors identified by given IDs.
+     * @brief Retrieve the default data fields associated with vectors identified by given IDs.
      *
      * This method fetches data stored with the vectors in the index
      * (e.g., attributes, labels, or extra infos).
@@ -593,11 +595,12 @@ public:
      * @param ids Array of vector IDs for which extra information is requested.
      * @param count Number of IDs in the 'ids' array.
      * @return tl::expected<DatasetPtr, Error>
-     *         - On success: A DatasetPtr containing the extra data, attribute and vector
+     *         - On success: A DatasetPtr containing the implementation's default fields
      *         - On failure: An error object (e.g., invalid ID, out of memory).
      * @throws std::runtime_error If the index implementation does not support this operation
      *            (default behavior for base class).
-     * @note The default implementation returns all data which in current index
+     * @note The default implementation returns the standard data fields supported by the index.
+     *       Optional fields such as retained paths require an explicit data flag.
      */
     virtual tl::expected<DatasetPtr, Error>
     GetDataByIds(const int64_t* ids, int64_t count) const {

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -446,6 +446,14 @@ InnerIndexInterface::ExportIDs() const {
 
 DatasetPtr
 InnerIndexInterface::GetDataByIds(const int64_t* ids, int64_t count) const {
+    Vector<InnerIdType> inner_ids(allocator_);
+    return this->get_data_by_ids(ids, count, inner_ids);
+}
+
+DatasetPtr
+InnerIndexInterface::get_data_by_ids(const int64_t* ids,
+                                     int64_t count,
+                                     Vector<InnerIdType>& inner_ids) const {
     uint64_t selected_flag = DATA_FLAG_ID;
     if (this->has_raw_vector_) {
         selected_flag |= DATA_FLAG_FLOAT32_VECTOR;
@@ -456,22 +464,29 @@ InnerIndexInterface::GetDataByIds(const int64_t* ids, int64_t count) const {
     if (this->extra_info_size_ > 0) {
         selected_flag |= DATA_FLAG_EXTRA_INFO;
     }
-    return this->GetDataByIdsWithFlag(ids, count, selected_flag);
+    return this->get_data_by_ids_with_flag(ids, count, selected_flag, inner_ids);
 }
 
 DatasetPtr
 InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
                                           int64_t count,
                                           uint64_t selected_data_flag) const {
-    if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U && not this->has_raw_vector_) {
-        throw VsagException(ErrorType::INVALID_ARGUMENT, "has_raw_vector_ is false");
-    }
-    auto* inner_ids =
-        reinterpret_cast<InnerIdType*>(this->allocator_->Allocate(count * sizeof(InnerIdType)));
+    Vector<InnerIdType> inner_ids(allocator_);
+    return this->get_data_by_ids_with_flag(ids, count, selected_data_flag, inner_ids);
+}
+
+DatasetPtr
+InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
+                                               int64_t count,
+                                               uint64_t selected_data_flag,
+                                               Vector<InnerIdType>& inner_ids) const {
+    CHECK_ARGUMENT(count >= 0, "count must not be negative");
+    inner_ids.clear();
+    inner_ids.reserve(static_cast<uint64_t>(count));
     {
         std::shared_lock lock(this->label_lookup_mutex_);
         for (int64_t i = 0; i < count; ++i) {
-            inner_ids[i] = this->label_table_->GetIdByLabel(ids[i]);
+            inner_ids.emplace_back(this->label_table_->GetIdByLabel(ids[i]));
         }
     }
     auto thread_count = static_cast<int64_t>(this->build_thread_count_);
@@ -484,8 +499,7 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
         dataset->Float32Vectors(fp32_data);
         auto get_vec_func = [&](int64_t begin, int64_t end) {
             for (int64_t i = begin; i < end; ++i) {
-                auto inner_id = this->label_table_->GetIdByLabel(ids[i]);
-                this->GetVectorByInnerId(inner_id, fp32_data + i * this->dim_);
+                this->GetVectorByInnerId(inner_ids[i], fp32_data + i * this->dim_);
             }
         };
         if (this->thread_pool_ != nullptr) {
@@ -511,8 +525,7 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
         dataset->AttributeSets(attribute_data);
         auto get_attr_func = [&](int64_t begin, int64_t end) {
             for (int64_t i = begin; i < end; ++i) {
-                auto inner_id = this->label_table_->GetIdByLabel(ids[i]);
-                this->GetAttributeSetByInnerId(inner_id, attribute_data + i);
+                this->GetAttributeSetByInnerId(inner_ids[i], attribute_data + i);
             }
         };
         if (this->thread_pool_ != nullptr) {
@@ -539,8 +552,8 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
         dataset->ExtraInfos(extra_info);
         auto get_extra_info_func = [&](int64_t begin, int64_t end) {
             for (int64_t i = begin; i < end; ++i) {
-                auto inner_id = this->label_table_->GetIdByLabel(ids[i]);
-                this->extra_infos_->GetExtraInfoById(inner_id, extra_info + i * extra_info_size_);
+                this->extra_infos_->GetExtraInfoById(inner_ids[i],
+                                                     extra_info + i * extra_info_size_);
             }
         };
         if (this->thread_pool_ != nullptr) {
@@ -564,7 +577,6 @@ InnerIndexInterface::GetDataByIdsWithFlag(const int64_t* ids,
         memcpy(new_ids, ids, count * sizeof(int64_t));
         dataset->Ids(new_ids);
     }
-    this->allocator_->Deallocate(inner_ids);
     return dataset;
 }
 

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -446,14 +446,6 @@ InnerIndexInterface::ExportIDs() const {
 
 DatasetPtr
 InnerIndexInterface::GetDataByIds(const int64_t* ids, int64_t count) const {
-    Vector<InnerIdType> inner_ids(allocator_);
-    return this->get_data_by_ids(ids, count, inner_ids);
-}
-
-DatasetPtr
-InnerIndexInterface::get_data_by_ids(const int64_t* ids,
-                                     int64_t count,
-                                     Vector<InnerIdType>& inner_ids) const {
     uint64_t selected_flag = DATA_FLAG_ID;
     if (this->has_raw_vector_) {
         selected_flag |= DATA_FLAG_FLOAT32_VECTOR;
@@ -464,7 +456,7 @@ InnerIndexInterface::get_data_by_ids(const int64_t* ids,
     if (this->extra_info_size_ > 0) {
         selected_flag |= DATA_FLAG_EXTRA_INFO;
     }
-    return this->get_data_by_ids_with_flag(ids, count, selected_flag, inner_ids);
+    return this->GetDataByIdsWithFlag(ids, count, selected_flag);
 }
 
 DatasetPtr

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -480,6 +480,9 @@ InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
                                                int64_t count,
                                                uint64_t selected_data_flag,
                                                Vector<InnerIdType>& inner_ids) const {
+    if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U && not this->has_raw_vector_) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "has_raw_vector_ is false");
+    }
     CHECK_ARGUMENT(count >= 0, "count must not be negative");
     inner_ids.clear();
     inner_ids.reserve(static_cast<uint64_t>(count));

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -399,6 +399,15 @@ public:
     }
 
 protected:
+    DatasetPtr
+    get_data_by_ids(const int64_t* ids, int64_t count, Vector<InnerIdType>& inner_ids) const;
+
+    DatasetPtr
+    get_data_by_ids_with_flag(const int64_t* ids,
+                              int64_t count,
+                              uint64_t selected_data_flag,
+                              Vector<InnerIdType>& inner_ids) const;
+
     void
     analyze_quantizer(JsonType& stats,
                       const float* data,

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -400,9 +400,6 @@ public:
 
 protected:
     DatasetPtr
-    get_data_by_ids(const int64_t* ids, int64_t count, Vector<InnerIdType>& inner_ids) const;
-
-    DatasetPtr
     get_data_by_ids_with_flag(const int64_t* ids,
                               int64_t count,
                               uint64_t selected_data_flag,

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -230,7 +230,10 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
         for (uint64_t inner_id = 0; inner_id < static_cast<uint64_t>(data_num); ++inner_id) {
             label_table_->InsertRemap(data_ids[inner_id], static_cast<InnerIdType>(inner_id));
         }
-        path_store_->Record(path, static_cast<uint64_t>(data_num));
+        auto writer = path_store_->AcquireWriter();
+        for (uint64_t offset = 0; offset < static_cast<uint64_t>(data_num); ++offset) {
+            writer.Insert(static_cast<InnerIdType>(offset), path[offset]);
+        }
     }
     auto codes = use_reorder_ ? precise_codes_ : base_codes_;
 
@@ -527,6 +530,7 @@ Pyramid::Add(const DatasetPtr& base) {
     const auto* data_ids = base->GetIds();
     std::vector<int64_t> failed_ids;
     Vector<int64_t> data_biases(allocator_);
+    Vector<InnerIdType> accepted_inner_ids(allocator_);
     int64_t local_cur_element_count = 0;
     {
         std::lock_guard lock(cur_element_count_mutex_);
@@ -541,21 +545,26 @@ Pyramid::Add(const DatasetPtr& base) {
             resize(new_capacity);
         }
         int64_t valid_id_count = 0;
+        if (store_paths_) {
+            accepted_inner_ids.reserve(data_num);
+        }
         for (int64_t i = 0; i < data_num; ++i) {
             if (not label_table_->CheckLabel(data_ids[i])) {
-                label_table_->Insert(valid_id_count + local_cur_element_count, data_ids[i]);
-                base_codes_->InsertVector(data_vectors + dim_ * i,
-                                          valid_id_count + local_cur_element_count);
+                const auto inner_id =
+                    static_cast<InnerIdType>(valid_id_count + local_cur_element_count);
+                label_table_->Insert(inner_id, data_ids[i]);
+                base_codes_->InsertVector(data_vectors + dim_ * i, inner_id);
                 if (use_reorder_) {
-                    precise_codes_->InsertVector(data_vectors + dim_ * i,
-                                                 valid_id_count + local_cur_element_count);
+                    precise_codes_->InsertVector(data_vectors + dim_ * i, inner_id);
                 }
                 if (create_new_raw_vector_) {
-                    raw_vector_->InsertVector(data_vectors + dim_ * i,
-                                              valid_id_count + local_cur_element_count);
+                    raw_vector_->InsertVector(data_vectors + dim_ * i, inner_id);
                 }
                 valid_id_count++;
                 data_biases.push_back(i);
+                if (store_paths_) {
+                    accepted_inner_ids.push_back(inner_id);
+                }
             } else {
                 logger::warn("Label {} already exists, skip adding.", data_ids[i]);
                 failed_ids.push_back(data_ids[i]);
@@ -603,7 +612,10 @@ Pyramid::Add(const DatasetPtr& base) {
         }
     }
     if (store_paths_) {
-        path_store_->Record(path, data_biases, local_cur_element_count);
+        auto writer = path_store_->AcquireWriter();
+        for (uint64_t offset = 0; offset < data_biases.size(); ++offset) {
+            writer.Insert(accepted_inner_ids[offset], path[data_biases[offset]]);
+        }
     }
     return failed_ids;
 }

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -226,11 +226,8 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
         raw_vector_->BatchInsertVector(data_vectors, data_num);
     }
     if (store_paths_) {
-        label_table_->ResetRemap(static_cast<uint64_t>(data_num));
-        for (uint64_t inner_id = 0; inner_id < static_cast<uint64_t>(data_num); ++inner_id) {
-            label_table_->InsertRemap(data_ids[inner_id], static_cast<InnerIdType>(inner_id));
-        }
         auto writer = path_store_->AcquireWriter();
+        writer.EnsureSlots(static_cast<uint64_t>(data_num));
         for (uint64_t offset = 0; offset < static_cast<uint64_t>(data_num); ++offset) {
             writer.Insert(static_cast<InnerIdType>(offset), path[offset]);
         }
@@ -611,8 +608,9 @@ Pyramid::Add(const DatasetPtr& base) {
             future.get();
         }
     }
-    if (store_paths_) {
+    if (store_paths_ && not accepted_inner_ids.empty()) {
         auto writer = path_store_->AcquireWriter();
+        writer.EnsureSlots(static_cast<uint64_t>(accepted_inner_ids.back()) + 1);
         for (uint64_t offset = 0; offset < data_biases.size(); ++offset) {
             writer.Insert(accepted_inner_ids[offset], path[data_biases[offset]]);
         }

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -29,6 +29,9 @@
 namespace vsag {
 
 const static float RADIUS_EPSILON = 1.1F;
+static constexpr uint64_t PYRAMID_PATHS_MAGIC = 0x5059525041544853ULL;  // PYRPATHS
+static constexpr int64_t PYRAMID_PATHS_FORMAT_VERSION = 1;
+static constexpr const char* PYRAMID_PATHS_FORMAT_VERSION_KEY = "pyramid_paths_format_version";
 
 std::vector<std::string>
 split(const std::string& str, char delimiter) {
@@ -224,6 +227,13 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
     }
     if (create_new_raw_vector_) {
         raw_vector_->BatchInsertVector(data_vectors, data_num);
+    }
+    if (store_paths_) {
+        label_table_->ResetRemap(static_cast<uint64_t>(data_num));
+        for (uint64_t inner_id = 0; inner_id < static_cast<uint64_t>(data_num); ++inner_id) {
+            label_table_->InsertRemap(data_ids[inner_id], static_cast<InnerIdType>(inner_id));
+        }
+        path_store_->Record(path, static_cast<uint64_t>(data_num));
     }
     auto codes = use_reorder_ ? precise_codes_ : base_codes_;
 
@@ -433,9 +443,17 @@ Pyramid::Serialize(StreamWriter& writer) const {
     }
     root_->Serialize(writer);
 
-    // serialize footer (introduced since v0.15)
+    if (store_paths_) {
+        StreamWriter::WriteObj(writer, PYRAMID_PATHS_MAGIC);
+        serialize_paths(writer);
+    }
+
+    // The current Pyramid format always ends with a footer.
     JsonType basic_info;
     basic_info["max_capacity"].SetInt(max_capacity_);
+    if (store_paths_) {
+        basic_info[PYRAMID_PATHS_FORMAT_VERSION_KEY].SetInt(PYRAMID_PATHS_FORMAT_VERSION);
+    }
     auto metadata = std::make_shared<Metadata>();
     metadata->Set(BASIC_INFO, basic_info);
     auto footer = std::make_shared<Footer>(metadata);
@@ -444,14 +462,19 @@ Pyramid::Serialize(StreamWriter& writer) const {
 
 void
 Pyramid::Deserialize(StreamReader& reader) {
-    // try to deserialize footer (only in new version)
+    // The current Pyramid format requires a footer.
     auto footer = Footer::Parse(reader);
+    if (footer == nullptr) {
+        throw VsagException(ErrorType::READ_ERROR, "failed to read Pyramid index footer");
+    }
     auto metadata = footer->GetMetadata();
     auto basic_info = metadata->Get(BASIC_INFO);
     auto max_capacity = basic_info["max_capacity"].GetInt();
 
+    const auto body_length = reader.Length() - footer->Length();
+    auto body_reader = reader.Slice(0, body_length);
     BufferStreamReader buffer_reader(
-        &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
+        &body_reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
     label_table_->Deserialize(buffer_reader);
     base_codes_->Deserialize(buffer_reader);
@@ -463,6 +486,26 @@ Pyramid::Deserialize(StreamReader& reader) {
     }
     cur_element_count_ = base_codes_->TotalCount();
     root_->Deserialize(buffer_reader);
+
+    const bool has_paths = basic_info.Contains(PYRAMID_PATHS_FORMAT_VERSION_KEY);
+    if (has_paths != store_paths_) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "serialized Pyramid paths metadata does not match config");
+    }
+    if (has_paths) {
+        const auto format_version = basic_info[PYRAMID_PATHS_FORMAT_VERSION_KEY].GetInt();
+        if (format_version != PYRAMID_PATHS_FORMAT_VERSION) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "unsupported Pyramid paths format version");
+        }
+        uint64_t magic = 0;
+        StreamReader::ReadObj(buffer_reader, magic);
+        if (magic != PYRAMID_PATHS_MAGIC) {
+            throw VsagException(ErrorType::READ_ERROR, "missing Pyramid paths marker");
+        }
+        deserialize_paths(buffer_reader, static_cast<uint64_t>(cur_element_count_));
+        validate_paths(static_cast<uint64_t>(cur_element_count_));
+    }
     resize(max_capacity);
     this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());
 }
@@ -570,6 +613,9 @@ Pyramid::Add(const DatasetPtr& base) {
             future.get();
         }
     }
+    if (store_paths_) {
+        path_store_->Record(path, data_biases, local_cur_element_count);
+    }
     return failed_ids;
 }
 
@@ -642,6 +688,9 @@ Pyramid::InitFeatures() {
     if (can_decode_exact_vector || raw_vector_ != nullptr) {
         this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_RAW_VECTOR_BY_IDS);
     }
+    if (store_paths_) {
+        this->index_feature_list_->SetFeature(IndexFeature::SUPPORT_GET_DATA_BY_IDS);
+    }
 }
 
 static const std::string HGRAPH_PARAMS_TEMPLATE =
@@ -713,7 +762,8 @@ static const std::string HGRAPH_PARAMS_TEMPLATE =
         "{EF_CONSTRUCTION_KEY}": 400,
         "{NO_BUILD_LEVELS}":[],
         "{INDEX_MIN_SIZE}": 0,
-        "{SUPPORT_DUPLICATE}": false
+        "{SUPPORT_DUPLICATE}": false,
+        "{PYRAMID_STORE_PATHS_KEY}": false
     })";
 
 ParamPtr
@@ -751,7 +801,8 @@ Pyramid::CheckAndMappingExternalParam(const JsonType& external_param,
         {ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE,
          {GRAPH_KEY, ODESCENT_PARAMETER_NEIGHBOR_SAMPLE_RATE}},
         {PYRAMID_INDEX_MIN_SIZE, {INDEX_MIN_SIZE}},
-        {PYRAMID_SUPPORT_DUPLICATE, {SUPPORT_DUPLICATE}}};
+        {PYRAMID_SUPPORT_DUPLICATE, {SUPPORT_DUPLICATE}},
+        {PYRAMID_STORE_PATHS, {PYRAMID_STORE_PATHS_KEY}}};
 
     std::string str = format_map(HGRAPH_PARAMS_TEMPLATE, DEFAULT_MAP);
     auto inner_json = JsonType::Parse(str);

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -444,10 +444,12 @@ Pyramid::Serialize(StreamWriter& writer) const {
         serialize_paths(writer);
     }
 
-    // The current Pyramid format always ends with a footer.
+    // serialize footer (introduced since v0.15)
     JsonType basic_info;
     basic_info["max_capacity"].SetInt(max_capacity_);
-    basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
+    if (store_paths_) {
+        basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
+    }
     auto metadata = std::make_shared<Metadata>();
     metadata->Set(BASIC_INFO, basic_info);
     auto footer = std::make_shared<Footer>(metadata);
@@ -456,11 +458,8 @@ Pyramid::Serialize(StreamWriter& writer) const {
 
 void
 Pyramid::Deserialize(StreamReader& reader) {
-    // The current Pyramid format requires a footer.
+    // try to deserialize footer (only in new version)
     auto footer = Footer::Parse(reader);
-    if (footer == nullptr) {
-        throw VsagException(ErrorType::READ_ERROR, "failed to read Pyramid index footer");
-    }
     auto metadata = footer->GetMetadata();
     auto basic_info = metadata->Get(BASIC_INFO);
     auto max_capacity = basic_info["max_capacity"].GetInt();
@@ -475,10 +474,8 @@ Pyramid::Deserialize(StreamReader& reader) {
                             "serialized Pyramid store_paths does not match config");
     }
 
-    const auto body_length = reader.Length() - footer->Length();
-    auto body_reader = reader.Slice(0, body_length);
     BufferStreamReader buffer_reader(
-        &body_reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
+        &reader, std::numeric_limits<uint64_t>::max(), this->allocator_);
 
     label_table_->Deserialize(buffer_reader);
     base_codes_->Deserialize(buffer_reader);
@@ -493,7 +490,6 @@ Pyramid::Deserialize(StreamReader& reader) {
 
     if (store_paths_) {
         deserialize_paths(buffer_reader, static_cast<uint64_t>(cur_element_count_));
-        validate_paths(static_cast<uint64_t>(cur_element_count_));
     }
     resize(max_capacity);
     this->current_memory_usage_ = static_cast<int64_t>(this->CalSerializeSize());

--- a/src/algorithm/pyramid.cpp
+++ b/src/algorithm/pyramid.cpp
@@ -29,9 +29,6 @@
 namespace vsag {
 
 const static float RADIUS_EPSILON = 1.1F;
-static constexpr uint64_t PYRAMID_PATHS_MAGIC = 0x5059525041544853ULL;  // PYRPATHS
-static constexpr int64_t PYRAMID_PATHS_FORMAT_VERSION = 1;
-static constexpr const char* PYRAMID_PATHS_FORMAT_VERSION_KEY = "pyramid_paths_format_version";
 
 std::vector<std::string>
 split(const std::string& str, char delimiter) {
@@ -444,16 +441,13 @@ Pyramid::Serialize(StreamWriter& writer) const {
     root_->Serialize(writer);
 
     if (store_paths_) {
-        StreamWriter::WriteObj(writer, PYRAMID_PATHS_MAGIC);
         serialize_paths(writer);
     }
 
     // The current Pyramid format always ends with a footer.
     JsonType basic_info;
     basic_info["max_capacity"].SetInt(max_capacity_);
-    if (store_paths_) {
-        basic_info[PYRAMID_PATHS_FORMAT_VERSION_KEY].SetInt(PYRAMID_PATHS_FORMAT_VERSION);
-    }
+    basic_info[INDEX_PARAM].SetString(this->create_param_ptr_->ToString());
     auto metadata = std::make_shared<Metadata>();
     metadata->Set(BASIC_INFO, basic_info);
     auto footer = std::make_shared<Footer>(metadata);
@@ -470,6 +464,16 @@ Pyramid::Deserialize(StreamReader& reader) {
     auto metadata = footer->GetMetadata();
     auto basic_info = metadata->Get(BASIC_INFO);
     auto max_capacity = basic_info["max_capacity"].GetInt();
+    bool serialized_store_paths = false;
+    if (basic_info.Contains(INDEX_PARAM)) {
+        const auto param_json = JsonType::Parse(basic_info[INDEX_PARAM].GetString());
+        serialized_store_paths = param_json.Contains(PYRAMID_STORE_PATHS_KEY) &&
+                                 param_json[PYRAMID_STORE_PATHS_KEY].GetBool();
+    }
+    if (serialized_store_paths != store_paths_) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "serialized Pyramid store_paths does not match config");
+    }
 
     const auto body_length = reader.Length() - footer->Length();
     auto body_reader = reader.Slice(0, body_length);
@@ -487,22 +491,7 @@ Pyramid::Deserialize(StreamReader& reader) {
     cur_element_count_ = base_codes_->TotalCount();
     root_->Deserialize(buffer_reader);
 
-    const bool has_paths = basic_info.Contains(PYRAMID_PATHS_FORMAT_VERSION_KEY);
-    if (has_paths != store_paths_) {
-        throw VsagException(ErrorType::READ_ERROR,
-                            "serialized Pyramid paths metadata does not match config");
-    }
-    if (has_paths) {
-        const auto format_version = basic_info[PYRAMID_PATHS_FORMAT_VERSION_KEY].GetInt();
-        if (format_version != PYRAMID_PATHS_FORMAT_VERSION) {
-            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                                "unsupported Pyramid paths format version");
-        }
-        uint64_t magic = 0;
-        StreamReader::ReadObj(buffer_reader, magic);
-        if (magic != PYRAMID_PATHS_MAGIC) {
-            throw VsagException(ErrorType::READ_ERROR, "missing Pyramid paths marker");
-        }
+    if (store_paths_) {
         deserialize_paths(buffer_reader, static_cast<uint64_t>(cur_element_count_));
         validate_paths(static_cast<uint64_t>(cur_element_count_));
     }

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -208,10 +208,7 @@ private:
     serialize_paths(StreamWriter& writer) const;
 
     void
-    deserialize_paths(StreamReader& reader, uint64_t max_count);
-
-    void
-    validate_paths(uint64_t expected_count) const;
+    deserialize_paths(StreamReader& reader, uint64_t expected_count);
 
     void
     resize(int64_t new_max_capacity);

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -143,7 +143,9 @@ public:
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;
 
     DatasetPtr
-    GetDataByIds(const int64_t* ids, int64_t count) const override;
+    GetDataByIdsWithFlag(const int64_t* ids,
+                         int64_t count,
+                         uint64_t selected_data_flag) const override;
 
     void
     Deserialize(StreamReader& reader) override;
@@ -275,7 +277,7 @@ private:
     // static
     uint32_t index_min_size_{0};
     bool immutable_{false};
-    bool store_paths_{false};
+    bool store_paths_{false};  // whether to retain paths for ID-based retrieval
     std::unique_ptr<PyramidPathStore> path_store_{nullptr};
 };
 

--- a/src/algorithm/pyramid.h
+++ b/src/algorithm/pyramid.h
@@ -27,6 +27,7 @@
 #include "index_feature_list.h"
 #include "inner_index_interface.h"
 #include "io/memory_io_parameter.h"
+#include "pyramid_path_store.h"
 #include "pyramid_zparameters.h"
 #include "quantization/fp32_quantizer_parameter.h"
 #include "query_context.h"
@@ -103,11 +104,15 @@ public:
           ef_construction_(pyramid_param->ef_construction),
           max_degree_(pyramid_param->max_degree),
           index_min_size_(pyramid_param->index_min_size),
-          graph_type_(pyramid_param->graph_type) {
+          graph_type_(pyramid_param->graph_type),
+          store_paths_(pyramid_param->store_paths) {
         label_table_->compress_duplicate_data_ = pyramid_param->support_duplicate;
         base_codes_ = FlattenInterface::MakeInstance(pyramid_param->base_codes_param, common_param);
         root_ =
             std::make_shared<IndexNode>(allocator_, pyramid_param->graph_param, index_min_size_);
+        if (store_paths_) {
+            path_store_ = std::make_unique<PyramidPathStore>(allocator_);
+        }
         points_mutex_ = std::make_shared<PointsMutex>(max_capacity_, allocator_);
         searcher_ = std::make_unique<BasicSearcher>(common_param, points_mutex_);
         no_build_levels_.assign(pyramid_param->no_build_levels.begin(),
@@ -136,6 +141,9 @@ public:
 
     DatasetPtr
     CalDistanceById(const float* query, const int64_t* ids, int64_t count) const override;
+
+    DatasetPtr
+    GetDataByIds(const int64_t* ids, int64_t count) const override;
 
     void
     Deserialize(StreamReader& reader) override;
@@ -193,6 +201,15 @@ private:
     void
     check_and_init_raw_vector(const FlattenInterfaceParamPtr& raw_vector_param,
                               const IndexCommonParam& common_param);
+
+    void
+    serialize_paths(StreamWriter& writer) const;
+
+    void
+    deserialize_paths(StreamReader& reader, uint64_t max_count);
+
+    void
+    validate_paths(uint64_t expected_count) const;
 
     void
     resize(int64_t new_max_capacity);
@@ -258,6 +275,8 @@ private:
     // static
     uint32_t index_min_size_{0};
     bool immutable_{false};
+    bool store_paths_{false};
+    std::unique_ptr<PyramidPathStore> path_store_{nullptr};
 };
 
 }  // namespace vsag

--- a/src/algorithm/pyramid_path_store.cpp
+++ b/src/algorithm/pyramid_path_store.cpp
@@ -54,19 +54,27 @@ write_path_string(StreamWriter& writer, const std::string& value) {
 }  // namespace
 
 void
+PyramidPathStore::Writer::EnsureSlots(uint64_t slot_count) {
+    if (slot_count <= store_.paths_by_inner_id_.size()) {
+        return;
+    }
+
+    const auto old_path_count = store_.paths_by_inner_id_.size();
+    const auto old_presence_count = store_.has_path_.size();
+    try {
+        store_.paths_by_inner_id_.resize(slot_count);
+        store_.has_path_.resize(slot_count, 0);
+    } catch (...) {
+        store_.paths_by_inner_id_.resize(old_path_count);
+        store_.has_path_.resize(old_presence_count);
+        throw;
+    }
+}
+
+void
 PyramidPathStore::Writer::Insert(InnerIdType inner_id, const std::string& path) {
     const auto slot = static_cast<uint64_t>(inner_id);
-    if (store_.paths_by_inner_id_.size() <= slot) {
-        const auto old_size = store_.paths_by_inner_id_.size();
-        try {
-            store_.paths_by_inner_id_.resize(slot + 1);
-            store_.has_path_.resize(slot + 1, 0);
-        } catch (...) {
-            store_.paths_by_inner_id_.resize(old_size);
-            store_.has_path_.resize(old_size);
-            throw;
-        }
-    }
+    EnsureSlots(slot + 1);
     CHECK_ARGUMENT(store_.has_path_[slot] == 0, "inner id already has a Pyramid path");
     store_.paths_by_inner_id_[slot] = path;
     store_.has_path_[slot] = 1;

--- a/src/algorithm/pyramid_path_store.cpp
+++ b/src/algorithm/pyramid_path_store.cpp
@@ -1,0 +1,166 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pyramid_path_store.h"
+
+#include <limits>
+#include <mutex>
+
+#include "common.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+namespace {
+
+std::string
+read_path_string(StreamReader& reader) {
+    uint64_t length = 0;
+    StreamReader::ReadObj(reader, length);
+    const auto cursor = reader.GetCursor();
+    const auto reader_length = reader.Length();
+    if (length > static_cast<uint64_t>(std::numeric_limits<std::string::size_type>::max()) ||
+        cursor > reader_length || length > reader_length - cursor) {
+        throw VsagException(ErrorType::READ_ERROR, "corrupted Pyramid path string length");
+    }
+    std::string value(length, '\0');
+    if (length > 0) {
+        reader.Read(value.data(), length);
+    }
+    return value;
+}
+
+void
+write_path_string(StreamWriter& writer, const std::string& value) {
+    const auto length = static_cast<uint64_t>(value.size());
+    StreamWriter::WriteObj(writer, length);
+    if (length > 0) {
+        writer.Write(value.data(), length);
+    }
+}
+
+}  // namespace
+
+void
+PyramidPathStore::Record(const std::string* paths,
+                         const Vector<int64_t>& data_biases,
+                         int64_t first_inner_id) {
+    CHECK_ARGUMENT(paths != nullptr, "paths must not be null");
+    CHECK_ARGUMENT(first_inner_id >= 0, "first inner id must not be negative");
+    if (data_biases.empty()) {
+        return;
+    }
+
+    const auto begin = static_cast<uint64_t>(first_inner_id);
+    CHECK_ARGUMENT(begin <= std::numeric_limits<uint64_t>::max() - data_biases.size(),
+                   "Pyramid path count overflow");
+    const auto end = begin + data_biases.size();
+    std::unique_lock lock(mutex_);
+    if (paths_by_inner_id_.size() < end) {
+        paths_by_inner_id_.resize(end);
+        has_path_.resize(end, 0);
+    }
+    for (uint64_t offset = 0; offset < data_biases.size(); ++offset) {
+        const auto inner_id = begin + offset;
+        paths_by_inner_id_[inner_id] = paths[data_biases[offset]];
+        has_path_[inner_id] = 1;
+    }
+}
+
+void
+PyramidPathStore::Record(const std::string* paths, uint64_t count) {
+    CHECK_ARGUMENT(paths != nullptr, "paths must not be null");
+    std::unique_lock lock(mutex_);
+    paths_by_inner_id_.resize(count);
+    has_path_.resize(count, 0);
+    for (uint64_t inner_id = 0; inner_id < count; ++inner_id) {
+        paths_by_inner_id_[inner_id] = paths[inner_id];
+        has_path_[inner_id] = 1;
+    }
+}
+
+bool
+PyramidPathStore::GetPaths(const Vector<InnerIdType>& inner_ids, std::string* paths) const {
+    std::shared_lock lock(mutex_);
+    for (uint64_t offset = 0; offset < inner_ids.size(); ++offset) {
+        const auto inner_id = static_cast<uint64_t>(inner_ids[offset]);
+        if (inner_id >= has_path_.size() || has_path_[inner_id] == 0) {
+            return false;
+        }
+        paths[offset] = paths_by_inner_id_[inner_id];
+    }
+    return true;
+}
+
+void
+PyramidPathStore::Serialize(StreamWriter& writer) const {
+    std::shared_lock lock(mutex_);
+    if (paths_by_inner_id_.size() != has_path_.size()) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "Pyramid path store size mismatch");
+    }
+    StreamWriter::WriteObj(writer, static_cast<uint64_t>(paths_by_inner_id_.size()));
+    for (uint64_t inner_id = 0; inner_id < has_path_.size(); ++inner_id) {
+        const auto present = has_path_[inner_id];
+        if (present > 1) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "Pyramid path store has invalid presence value");
+        }
+        StreamWriter::WriteObj(writer, present);
+        if (present != 0) {
+            write_path_string(writer, paths_by_inner_id_[inner_id]);
+        }
+    }
+}
+
+void
+PyramidPathStore::Deserialize(StreamReader& reader, uint64_t max_count) {
+    uint64_t slot_count = 0;
+    StreamReader::ReadObj(reader, slot_count);
+    if (slot_count > max_count) {
+        throw VsagException(ErrorType::READ_ERROR, "corrupted Pyramid path slot count");
+    }
+    const auto cursor = reader.GetCursor();
+    const auto reader_length = reader.Length();
+    if (cursor > reader_length || slot_count > reader_length - cursor) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "corrupted Pyramid path slots exceed remaining payload");
+    }
+
+    Vector<std::string> restored_paths(slot_count, std::string{}, allocator_);
+    Vector<uint8_t> restored_has_path(slot_count, 0, allocator_);
+    for (uint64_t inner_id = 0; inner_id < slot_count; ++inner_id) {
+        uint8_t present = 0;
+        StreamReader::ReadObj(reader, present);
+        if (present > 1) {
+            throw VsagException(ErrorType::READ_ERROR, "corrupted Pyramid path presence value");
+        }
+        restored_has_path[inner_id] = present;
+        if (present != 0) {
+            restored_paths[inner_id] = read_path_string(reader);
+        }
+    }
+
+    std::unique_lock lock(mutex_);
+    paths_by_inner_id_.swap(restored_paths);
+    has_path_.swap(restored_has_path);
+}
+
+uint64_t
+PyramidPathStore::Size() const {
+    std::shared_lock lock(mutex_);
+    return paths_by_inner_id_.size();
+}
+
+}  // namespace vsag

--- a/src/algorithm/pyramid_path_store.cpp
+++ b/src/algorithm/pyramid_path_store.cpp
@@ -14,7 +14,6 @@
 
 #include "pyramid_path_store.h"
 
-#include <limits>
 #include <mutex>
 
 #include "common.h"
@@ -23,35 +22,6 @@
 #include "vsag_exception.h"
 
 namespace vsag {
-namespace {
-
-std::string
-read_path_string(StreamReader& reader) {
-    uint64_t length = 0;
-    StreamReader::ReadObj(reader, length);
-    const auto cursor = reader.GetCursor();
-    const auto reader_length = reader.Length();
-    if (length > static_cast<uint64_t>(std::numeric_limits<std::string::size_type>::max()) ||
-        cursor > reader_length || length > reader_length - cursor) {
-        throw VsagException(ErrorType::READ_ERROR, "corrupted Pyramid path string length");
-    }
-    std::string value(length, '\0');
-    if (length > 0) {
-        reader.Read(value.data(), length);
-    }
-    return value;
-}
-
-void
-write_path_string(StreamWriter& writer, const std::string& value) {
-    const auto length = static_cast<uint64_t>(value.size());
-    StreamWriter::WriteObj(writer, length);
-    if (length > 0) {
-        writer.Write(value.data(), length);
-    }
-}
-
-}  // namespace
 
 void
 PyramidPathStore::Writer::EnsureSlots(uint64_t slot_count) {
@@ -107,22 +77,18 @@ PyramidPathStore::Serialize(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, static_cast<uint64_t>(paths_by_inner_id_.size()));
     for (uint64_t inner_id = 0; inner_id < has_path_.size(); ++inner_id) {
         const auto present = has_path_[inner_id];
-        if (present > 1) {
-            throw VsagException(ErrorType::INTERNAL_ERROR,
-                                "Pyramid path store has invalid presence value");
-        }
         StreamWriter::WriteObj(writer, present);
         if (present != 0) {
-            write_path_string(writer, paths_by_inner_id_[inner_id]);
+            StreamWriter::WriteString(writer, paths_by_inner_id_[inner_id]);
         }
     }
 }
 
 void
-PyramidPathStore::Deserialize(StreamReader& reader, uint64_t max_count) {
+PyramidPathStore::Deserialize(StreamReader& reader, uint64_t expected_count) {
     uint64_t slot_count = 0;
     StreamReader::ReadObj(reader, slot_count);
-    if (slot_count > max_count) {
+    if (slot_count != expected_count) {
         throw VsagException(ErrorType::READ_ERROR, "corrupted Pyramid path slot count");
     }
     const auto cursor = reader.GetCursor();
@@ -142,19 +108,13 @@ PyramidPathStore::Deserialize(StreamReader& reader, uint64_t max_count) {
         }
         restored_has_path[inner_id] = present;
         if (present != 0) {
-            restored_paths[inner_id] = read_path_string(reader);
+            restored_paths[inner_id] = StreamReader::ReadString(reader);
         }
     }
 
     std::unique_lock lock(mutex_);
     paths_by_inner_id_.swap(restored_paths);
     has_path_.swap(restored_has_path);
-}
-
-uint64_t
-PyramidPathStore::Size() const {
-    std::shared_lock lock(mutex_);
-    return paths_by_inner_id_.size();
 }
 
 }  // namespace vsag

--- a/src/algorithm/pyramid_path_store.cpp
+++ b/src/algorithm/pyramid_path_store.cpp
@@ -83,6 +83,8 @@ void
 PyramidPathStore::Record(const std::string* paths, uint64_t count) {
     CHECK_ARGUMENT(paths != nullptr, "paths must not be null");
     std::unique_lock lock(mutex_);
+    CHECK_ARGUMENT(paths_by_inner_id_.empty() && has_path_.empty(),
+                   "Pyramid path store must be empty before full-build recording");
     paths_by_inner_id_.resize(count);
     has_path_.resize(count, 0);
     for (uint64_t inner_id = 0; inner_id < count; ++inner_id) {

--- a/src/algorithm/pyramid_path_store.cpp
+++ b/src/algorithm/pyramid_path_store.cpp
@@ -54,43 +54,27 @@ write_path_string(StreamWriter& writer, const std::string& value) {
 }  // namespace
 
 void
-PyramidPathStore::Record(const std::string* paths,
-                         const Vector<int64_t>& data_biases,
-                         int64_t first_inner_id) {
-    CHECK_ARGUMENT(paths != nullptr, "paths must not be null");
-    CHECK_ARGUMENT(first_inner_id >= 0, "first inner id must not be negative");
-    if (data_biases.empty()) {
-        return;
+PyramidPathStore::Writer::Insert(InnerIdType inner_id, const std::string& path) {
+    const auto slot = static_cast<uint64_t>(inner_id);
+    if (store_.paths_by_inner_id_.size() <= slot) {
+        const auto old_size = store_.paths_by_inner_id_.size();
+        try {
+            store_.paths_by_inner_id_.resize(slot + 1);
+            store_.has_path_.resize(slot + 1, 0);
+        } catch (...) {
+            store_.paths_by_inner_id_.resize(old_size);
+            store_.has_path_.resize(old_size);
+            throw;
+        }
     }
-
-    const auto begin = static_cast<uint64_t>(first_inner_id);
-    CHECK_ARGUMENT(begin <= std::numeric_limits<uint64_t>::max() - data_biases.size(),
-                   "Pyramid path count overflow");
-    const auto end = begin + data_biases.size();
-    std::unique_lock lock(mutex_);
-    if (paths_by_inner_id_.size() < end) {
-        paths_by_inner_id_.resize(end);
-        has_path_.resize(end, 0);
-    }
-    for (uint64_t offset = 0; offset < data_biases.size(); ++offset) {
-        const auto inner_id = begin + offset;
-        paths_by_inner_id_[inner_id] = paths[data_biases[offset]];
-        has_path_[inner_id] = 1;
-    }
+    CHECK_ARGUMENT(store_.has_path_[slot] == 0, "inner id already has a Pyramid path");
+    store_.paths_by_inner_id_[slot] = path;
+    store_.has_path_[slot] = 1;
 }
 
-void
-PyramidPathStore::Record(const std::string* paths, uint64_t count) {
-    CHECK_ARGUMENT(paths != nullptr, "paths must not be null");
-    std::unique_lock lock(mutex_);
-    CHECK_ARGUMENT(paths_by_inner_id_.empty() && has_path_.empty(),
-                   "Pyramid path store must be empty before full-build recording");
-    paths_by_inner_id_.resize(count);
-    has_path_.resize(count, 0);
-    for (uint64_t inner_id = 0; inner_id < count; ++inner_id) {
-        paths_by_inner_id_[inner_id] = paths[inner_id];
-        has_path_[inner_id] = 1;
-    }
+PyramidPathStore::Writer
+PyramidPathStore::AcquireWriter() {
+    return Writer(*this);
 }
 
 bool

--- a/src/algorithm/pyramid_path_store.h
+++ b/src/algorithm/pyramid_path_store.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 
@@ -26,15 +27,35 @@ namespace vsag {
 
 class PyramidPathStore {
 public:
+    class Writer {
+    public:
+        Writer(const Writer&) = delete;
+        Writer&
+        operator=(const Writer&) = delete;
+        Writer(Writer&&) = delete;
+        Writer&
+        operator=(Writer&&) = delete;
+
+        void
+        Insert(InnerIdType inner_id, const std::string& path);
+
+    private:
+        friend class PyramidPathStore;
+
+        explicit Writer(PyramidPathStore& store) : store_(store), lock_(store.mutex_) {
+        }
+
+        PyramidPathStore& store_;
+        std::unique_lock<std::shared_mutex> lock_;
+    };
+
     explicit PyramidPathStore(Allocator* allocator)
         : paths_by_inner_id_(allocator), has_path_(allocator), allocator_(allocator) {
     }
 
-    void
-    Record(const std::string* paths, const Vector<int64_t>& data_biases, int64_t first_inner_id);
-
-    void
-    Record(const std::string* paths, uint64_t count);
+    // Holds the store's exclusive lock for the lifetime of the returned writer.
+    [[nodiscard]] Writer
+    AcquireWriter();
 
     [[nodiscard]] bool
     GetPaths(const Vector<InnerIdType>& inner_ids, std::string* paths) const;

--- a/src/algorithm/pyramid_path_store.h
+++ b/src/algorithm/pyramid_path_store.h
@@ -67,10 +67,7 @@ public:
     Serialize(StreamWriter& writer) const;
 
     void
-    Deserialize(StreamReader& reader, uint64_t max_count);
-
-    [[nodiscard]] uint64_t
-    Size() const;
+    Deserialize(StreamReader& reader, uint64_t expected_count);
 
 private:
     mutable std::shared_mutex mutex_;

--- a/src/algorithm/pyramid_path_store.h
+++ b/src/algorithm/pyramid_path_store.h
@@ -37,6 +37,9 @@ public:
         operator=(Writer&&) = delete;
 
         void
+        EnsureSlots(uint64_t slot_count);
+
+        void
         Insert(InnerIdType inner_id, const std::string& path);
 
     private:

--- a/src/algorithm/pyramid_path_store.h
+++ b/src/algorithm/pyramid_path_store.h
@@ -1,0 +1,58 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <shared_mutex>
+#include <string>
+
+#include "typing.h"
+
+class StreamReader;
+class StreamWriter;
+
+namespace vsag {
+
+class PyramidPathStore {
+public:
+    explicit PyramidPathStore(Allocator* allocator)
+        : paths_by_inner_id_(allocator), has_path_(allocator), allocator_(allocator) {
+    }
+
+    void
+    Record(const std::string* paths, const Vector<int64_t>& data_biases, int64_t first_inner_id);
+
+    void
+    Record(const std::string* paths, uint64_t count);
+
+    [[nodiscard]] bool
+    GetPaths(const Vector<InnerIdType>& inner_ids, std::string* paths) const;
+
+    void
+    Serialize(StreamWriter& writer) const;
+
+    void
+    Deserialize(StreamReader& reader, uint64_t max_count);
+
+    [[nodiscard]] uint64_t
+    Size() const;
+
+private:
+    mutable std::shared_mutex mutex_;
+    Vector<std::string> paths_by_inner_id_;
+    Vector<uint8_t> has_path_;
+    Allocator* allocator_{nullptr};
+};
+
+}  // namespace vsag

--- a/src/algorithm/pyramid_path_store_test.cpp
+++ b/src/algorithm/pyramid_path_store_test.cpp
@@ -17,7 +17,6 @@
 #include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
-#include <cstring>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -38,8 +37,6 @@ TEST_CASE("PyramidPathStore inserts and reorders paths", "[ut][pyramid][path_sto
             writer.Insert(static_cast<vsag::InnerIdType>(slot), source[slot]);
         }
     }
-    REQUIRE(store.Size() == source.size());
-
     vsag::Vector<vsag::InnerIdType> inner_ids(allocator.get());
     inner_ids.push_back(2);
     inner_ids.push_back(0);
@@ -53,7 +50,6 @@ TEST_CASE("PyramidPathStore inserts and reorders paths", "[ut][pyramid][path_sto
         auto writer = store.AcquireWriter();
         REQUIRE_THROWS(writer.Insert(0, "duplicate"));
     }
-    REQUIRE(store.Size() == source.size());
 }
 
 TEST_CASE("PyramidPathStore inserts paths with holes", "[ut][pyramid][path_store]") {
@@ -67,8 +63,6 @@ TEST_CASE("PyramidPathStore inserts paths with holes", "[ut][pyramid][path_store
         writer.Insert(4, source[3]);
         writer.EnsureSlots(3);
     }
-    REQUIRE(store.Size() == 8);
-
     vsag::Vector<vsag::InnerIdType> present_ids(allocator.get());
     present_ids.push_back(5);
     present_ids.push_back(4);
@@ -102,8 +96,6 @@ TEST_CASE("PyramidPathStore serialization roundtrip", "[ut][pyramid][path_store]
     vsag::PyramidPathStore restored_store(allocator.get());
     IOStreamReader reader(stream);
     restored_store.Deserialize(reader, 4);
-    REQUIRE(restored_store.Size() == 4);
-
     vsag::Vector<vsag::InnerIdType> present_ids(allocator.get());
     present_ids.push_back(2);
     present_ids.push_back(3);
@@ -116,40 +108,10 @@ TEST_CASE("PyramidPathStore serialization roundtrip", "[ut][pyramid][path_store]
     REQUIRE_FALSE(restored_store.GetPaths(hole_ids, restored.data()));
 }
 
-TEST_CASE("PyramidPathStore uses fixed-width path lengths", "[ut][pyramid][path_store]") {
-    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
-    vsag::PyramidPathStore store(allocator.get());
-    const std::array<std::string, 1> source = {"path"};
-    {
-        auto writer = store.AcquireWriter();
-        writer.Insert(0, source[0]);
-    }
-
-    std::stringstream stream;
-    IOStreamWriter writer(stream);
-    store.Serialize(writer);
-    const auto payload = stream.str();
-    REQUIRE(payload.size() == sizeof(uint64_t) + sizeof(uint8_t) + sizeof(uint64_t) + 4);
-
-    uint64_t path_length = 0;
-    std::memcpy(
-        &path_length, payload.data() + sizeof(uint64_t) + sizeof(uint8_t), sizeof(path_length));
-    REQUIRE(path_length == 4);
-
-    vsag::PyramidPathStore restored_store(allocator.get());
-    IOStreamReader reader(stream);
-    restored_store.Deserialize(reader, 1);
-    vsag::Vector<vsag::InnerIdType> inner_ids(allocator.get());
-    inner_ids.push_back(0);
-    std::array<std::string, 1> restored;
-    REQUIRE(restored_store.GetPaths(inner_ids, restored.data()));
-    REQUIRE(restored == source);
-}
-
 TEST_CASE("PyramidPathStore rejects malformed serialization", "[ut][pyramid][path_store]") {
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
 
-    SECTION("slot count exceeds maximum") {
+    SECTION("slot count does not match expected count") {
         std::stringstream stream;
         IOStreamWriter writer(stream);
         StreamWriter::WriteObj(writer, uint64_t{3});

--- a/src/algorithm/pyramid_path_store_test.cpp
+++ b/src/algorithm/pyramid_path_store_test.cpp
@@ -26,12 +26,17 @@
 #include "storage/stream_reader.h"
 #include "storage/stream_writer.h"
 
-TEST_CASE("PyramidPathStore records and reorders paths", "[ut][pyramid][path_store]") {
+TEST_CASE("PyramidPathStore inserts and reorders paths", "[ut][pyramid][path_store]") {
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
     vsag::PyramidPathStore store(allocator.get());
     const std::array<std::string, 4> source = {"root/a", "", "root/c", "root/d"};
 
-    store.Record(source.data(), source.size());
+    {
+        auto writer = store.AcquireWriter();
+        for (uint64_t slot = 0; slot < source.size(); ++slot) {
+            writer.Insert(static_cast<vsag::InnerIdType>(slot), source[slot]);
+        }
+    }
     REQUIRE(store.Size() == source.size());
 
     vsag::Vector<vsag::InnerIdType> inner_ids(allocator.get());
@@ -43,19 +48,22 @@ TEST_CASE("PyramidPathStore records and reorders paths", "[ut][pyramid][path_sto
     REQUIRE(store.GetPaths(inner_ids, restored.data()));
     REQUIRE(restored == std::array<std::string, 3>{"root/c", "root/a", ""});
 
-    REQUIRE_THROWS(store.Record(source.data(), source.size()));
+    {
+        auto writer = store.AcquireWriter();
+        REQUIRE_THROWS(writer.Insert(0, "duplicate"));
+    }
     REQUIRE(store.Size() == source.size());
 }
 
-TEST_CASE("PyramidPathStore records filtered paths with holes", "[ut][pyramid][path_store]") {
+TEST_CASE("PyramidPathStore inserts paths with holes", "[ut][pyramid][path_store]") {
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
     vsag::PyramidPathStore store(allocator.get());
     const std::array<std::string, 4> source = {"zero", "one", "two", "three"};
-    vsag::Vector<int64_t> data_biases(allocator.get());
-    data_biases.push_back(3);
-    data_biases.push_back(1);
-
-    store.Record(source.data(), data_biases, 4);
+    {
+        auto writer = store.AcquireWriter();
+        writer.Insert(5, source[1]);
+        writer.Insert(4, source[3]);
+    }
     REQUIRE(store.Size() == 6);
 
     vsag::Vector<vsag::InnerIdType> present_ids(allocator.get());
@@ -78,10 +86,11 @@ TEST_CASE("PyramidPathStore serialization roundtrip", "[ut][pyramid][path_store]
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
     vsag::PyramidPathStore store(allocator.get());
     const std::array<std::string, 3> source = {"first", "unused", ""};
-    vsag::Vector<int64_t> data_biases(allocator.get());
-    data_biases.push_back(2);
-    data_biases.push_back(0);
-    store.Record(source.data(), data_biases, 2);
+    {
+        auto writer = store.AcquireWriter();
+        writer.Insert(3, source[0]);
+        writer.Insert(2, source[2]);
+    }
 
     std::stringstream stream;
     IOStreamWriter writer(stream);
@@ -108,7 +117,10 @@ TEST_CASE("PyramidPathStore uses fixed-width path lengths", "[ut][pyramid][path_
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
     vsag::PyramidPathStore store(allocator.get());
     const std::array<std::string, 1> source = {"path"};
-    store.Record(source.data(), source.size());
+    {
+        auto writer = store.AcquireWriter();
+        writer.Insert(0, source[0]);
+    }
 
     std::stringstream stream;
     IOStreamWriter writer(stream);

--- a/src/algorithm/pyramid_path_store_test.cpp
+++ b/src/algorithm/pyramid_path_store_test.cpp
@@ -42,6 +42,9 @@ TEST_CASE("PyramidPathStore records and reorders paths", "[ut][pyramid][path_sto
 
     REQUIRE(store.GetPaths(inner_ids, restored.data()));
     REQUIRE(restored == std::array<std::string, 3>{"root/c", "root/a", ""});
+
+    REQUIRE_THROWS(store.Record(source.data(), source.size()));
+    REQUIRE(store.Size() == source.size());
 }
 
 TEST_CASE("PyramidPathStore records filtered paths with holes", "[ut][pyramid][path_store]") {

--- a/src/algorithm/pyramid_path_store_test.cpp
+++ b/src/algorithm/pyramid_path_store_test.cpp
@@ -1,0 +1,176 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pyramid_path_store.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <sstream>
+#include <string>
+
+#include "impl/allocator/safe_allocator.h"
+#include "storage/stream_reader.h"
+#include "storage/stream_writer.h"
+
+TEST_CASE("PyramidPathStore records and reorders paths", "[ut][pyramid][path_store]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::PyramidPathStore store(allocator.get());
+    const std::array<std::string, 4> source = {"root/a", "", "root/c", "root/d"};
+
+    store.Record(source.data(), source.size());
+    REQUIRE(store.Size() == source.size());
+
+    vsag::Vector<vsag::InnerIdType> inner_ids(allocator.get());
+    inner_ids.push_back(2);
+    inner_ids.push_back(0);
+    inner_ids.push_back(1);
+    std::array<std::string, 3> restored;
+
+    REQUIRE(store.GetPaths(inner_ids, restored.data()));
+    REQUIRE(restored == std::array<std::string, 3>{"root/c", "root/a", ""});
+}
+
+TEST_CASE("PyramidPathStore records filtered paths with holes", "[ut][pyramid][path_store]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::PyramidPathStore store(allocator.get());
+    const std::array<std::string, 4> source = {"zero", "one", "two", "three"};
+    vsag::Vector<int64_t> data_biases(allocator.get());
+    data_biases.push_back(3);
+    data_biases.push_back(1);
+
+    store.Record(source.data(), data_biases, 4);
+    REQUIRE(store.Size() == 6);
+
+    vsag::Vector<vsag::InnerIdType> present_ids(allocator.get());
+    present_ids.push_back(5);
+    present_ids.push_back(4);
+    std::array<std::string, 2> restored;
+    REQUIRE(store.GetPaths(present_ids, restored.data()));
+    REQUIRE(restored == std::array<std::string, 2>{"one", "three"});
+
+    vsag::Vector<vsag::InnerIdType> hole_ids(allocator.get());
+    hole_ids.push_back(3);
+    REQUIRE_FALSE(store.GetPaths(hole_ids, restored.data()));
+
+    vsag::Vector<vsag::InnerIdType> out_of_range_ids(allocator.get());
+    out_of_range_ids.push_back(6);
+    REQUIRE_FALSE(store.GetPaths(out_of_range_ids, restored.data()));
+}
+
+TEST_CASE("PyramidPathStore serialization roundtrip", "[ut][pyramid][path_store]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::PyramidPathStore store(allocator.get());
+    const std::array<std::string, 3> source = {"first", "unused", ""};
+    vsag::Vector<int64_t> data_biases(allocator.get());
+    data_biases.push_back(2);
+    data_biases.push_back(0);
+    store.Record(source.data(), data_biases, 2);
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    store.Serialize(writer);
+
+    vsag::PyramidPathStore restored_store(allocator.get());
+    IOStreamReader reader(stream);
+    restored_store.Deserialize(reader, 4);
+    REQUIRE(restored_store.Size() == 4);
+
+    vsag::Vector<vsag::InnerIdType> present_ids(allocator.get());
+    present_ids.push_back(2);
+    present_ids.push_back(3);
+    std::array<std::string, 2> restored;
+    REQUIRE(restored_store.GetPaths(present_ids, restored.data()));
+    REQUIRE(restored == std::array<std::string, 2>{"", "first"});
+
+    vsag::Vector<vsag::InnerIdType> hole_ids(allocator.get());
+    hole_ids.push_back(0);
+    REQUIRE_FALSE(restored_store.GetPaths(hole_ids, restored.data()));
+}
+
+TEST_CASE("PyramidPathStore uses fixed-width path lengths", "[ut][pyramid][path_store]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::PyramidPathStore store(allocator.get());
+    const std::array<std::string, 1> source = {"path"};
+    store.Record(source.data(), source.size());
+
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    store.Serialize(writer);
+    const auto payload = stream.str();
+    REQUIRE(payload.size() == sizeof(uint64_t) + sizeof(uint8_t) + sizeof(uint64_t) + 4);
+
+    uint64_t path_length = 0;
+    std::memcpy(
+        &path_length, payload.data() + sizeof(uint64_t) + sizeof(uint8_t), sizeof(path_length));
+    REQUIRE(path_length == 4);
+
+    vsag::PyramidPathStore restored_store(allocator.get());
+    IOStreamReader reader(stream);
+    restored_store.Deserialize(reader, 1);
+    vsag::Vector<vsag::InnerIdType> inner_ids(allocator.get());
+    inner_ids.push_back(0);
+    std::array<std::string, 1> restored;
+    REQUIRE(restored_store.GetPaths(inner_ids, restored.data()));
+    REQUIRE(restored == source);
+}
+
+TEST_CASE("PyramidPathStore rejects malformed serialization", "[ut][pyramid][path_store]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("slot count exceeds maximum") {
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        StreamWriter::WriteObj(writer, uint64_t{3});
+
+        vsag::PyramidPathStore store(allocator.get());
+        IOStreamReader reader(stream);
+        REQUIRE_THROWS(store.Deserialize(reader, 2));
+    }
+
+    SECTION("presence byte is invalid") {
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        StreamWriter::WriteObj(writer, uint64_t{1});
+        StreamWriter::WriteObj(writer, uint8_t{2});
+
+        vsag::PyramidPathStore store(allocator.get());
+        IOStreamReader reader(stream);
+        REQUIRE_THROWS(store.Deserialize(reader, 1));
+    }
+
+    SECTION("slot count exceeds remaining payload") {
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        StreamWriter::WriteObj(writer, uint64_t{2});
+
+        vsag::PyramidPathStore store(allocator.get());
+        IOStreamReader reader(stream);
+        REQUIRE_THROWS(store.Deserialize(reader, 2));
+    }
+
+    SECTION("path length exceeds remaining payload") {
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        StreamWriter::WriteObj(writer, uint64_t{1});
+        StreamWriter::WriteObj(writer, uint8_t{1});
+        StreamWriter::WriteObj(writer, std::numeric_limits<uint64_t>::max());
+
+        vsag::PyramidPathStore store(allocator.get());
+        IOStreamReader reader(stream);
+        REQUIRE_THROWS(store.Deserialize(reader, 1));
+    }
+}

--- a/src/algorithm/pyramid_path_store_test.cpp
+++ b/src/algorithm/pyramid_path_store_test.cpp
@@ -33,6 +33,7 @@ TEST_CASE("PyramidPathStore inserts and reorders paths", "[ut][pyramid][path_sto
 
     {
         auto writer = store.AcquireWriter();
+        writer.EnsureSlots(source.size());
         for (uint64_t slot = 0; slot < source.size(); ++slot) {
             writer.Insert(static_cast<vsag::InnerIdType>(slot), source[slot]);
         }
@@ -61,10 +62,12 @@ TEST_CASE("PyramidPathStore inserts paths with holes", "[ut][pyramid][path_store
     const std::array<std::string, 4> source = {"zero", "one", "two", "three"};
     {
         auto writer = store.AcquireWriter();
+        writer.EnsureSlots(8);
         writer.Insert(5, source[1]);
         writer.Insert(4, source[3]);
+        writer.EnsureSlots(3);
     }
-    REQUIRE(store.Size() == 6);
+    REQUIRE(store.Size() == 8);
 
     vsag::Vector<vsag::InnerIdType> present_ids(allocator.get());
     present_ids.push_back(5);
@@ -78,7 +81,7 @@ TEST_CASE("PyramidPathStore inserts paths with holes", "[ut][pyramid][path_store
     REQUIRE_FALSE(store.GetPaths(hole_ids, restored.data()));
 
     vsag::Vector<vsag::InnerIdType> out_of_range_ids(allocator.get());
-    out_of_range_ids.push_back(6);
+    out_of_range_ids.push_back(8);
     REQUIRE_FALSE(store.GetPaths(out_of_range_ids, restored.data()));
 }
 

--- a/src/algorithm/pyramid_paths.cpp
+++ b/src/algorithm/pyramid_paths.cpp
@@ -48,7 +48,8 @@ Pyramid::GetDataByIdsWithFlag(const int64_t* ids,
                               uint64_t selected_data_flag) const {
     const bool wants_paths = (selected_data_flag & DATA_FLAG_PATH) != 0U;
     if (wants_paths) {
-        CHECK_ARGUMENT(store_paths_, "store_paths is false");
+        CHECK_ARGUMENT(store_paths_,
+                       "DATA_FLAG_PATH requires store_paths=true in the Pyramid build parameters");
         if (path_store_ == nullptr) {
             throw VsagException(ErrorType::INTERNAL_ERROR, "Pyramid path store is missing");
         }

--- a/src/algorithm/pyramid_paths.cpp
+++ b/src/algorithm/pyramid_paths.cpp
@@ -43,14 +43,21 @@ Pyramid::validate_paths(uint64_t expected_count) const {
 }
 
 DatasetPtr
-Pyramid::GetDataByIds(const int64_t* ids, int64_t count) const {
-    Vector<InnerIdType> inner_ids(allocator_);
-    auto result = this->get_data_by_ids(ids, count, inner_ids);
-    if (not store_paths_) {
-        return result;
+Pyramid::GetDataByIdsWithFlag(const int64_t* ids,
+                              int64_t count,
+                              uint64_t selected_data_flag) const {
+    const bool wants_paths = (selected_data_flag & DATA_FLAG_PATH) != 0U;
+    if (wants_paths) {
+        CHECK_ARGUMENT(store_paths_, "store_paths is false");
+        if (path_store_ == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR, "Pyramid path store is missing");
+        }
     }
-    if (path_store_ == nullptr) {
-        throw VsagException(ErrorType::INTERNAL_ERROR, "Pyramid path store is missing");
+
+    Vector<InnerIdType> inner_ids(allocator_);
+    auto result = this->get_data_by_ids_with_flag(ids, count, selected_data_flag, inner_ids);
+    if (not wants_paths) {
+        return result;
     }
 
     auto paths = std::make_unique<std::string[]>(static_cast<uint64_t>(count));
@@ -58,7 +65,8 @@ Pyramid::GetDataByIds(const int64_t* ids, int64_t count) const {
         throw VsagException(ErrorType::INTERNAL_ERROR,
                             "Pyramid path is unavailable for a requested id");
     }
-    result->Paths(paths.release());
+    result->Paths(paths.get());
+    paths.release();
     return result;
 }
 

--- a/src/algorithm/pyramid_paths.cpp
+++ b/src/algorithm/pyramid_paths.cpp
@@ -1,0 +1,65 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "pyramid.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+void
+Pyramid::serialize_paths(StreamWriter& writer) const {
+    if (path_store_ == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "Pyramid path store is missing");
+    }
+    path_store_->Serialize(writer);
+}
+
+void
+Pyramid::deserialize_paths(StreamReader& reader, uint64_t max_count) {
+    if (path_store_ == nullptr) {
+        throw VsagException(ErrorType::READ_ERROR, "Pyramid path storage is disabled");
+    }
+    path_store_->Deserialize(reader, max_count);
+}
+
+void
+Pyramid::validate_paths(uint64_t expected_count) const {
+    if (path_store_ == nullptr || path_store_->Size() != expected_count) {
+        throw VsagException(ErrorType::READ_ERROR, "corrupted Pyramid path slot count");
+    }
+}
+
+DatasetPtr
+Pyramid::GetDataByIds(const int64_t* ids, int64_t count) const {
+    Vector<InnerIdType> inner_ids(allocator_);
+    auto result = this->get_data_by_ids(ids, count, inner_ids);
+    if (not store_paths_) {
+        return result;
+    }
+    if (path_store_ == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR, "Pyramid path store is missing");
+    }
+
+    auto paths = std::make_unique<std::string[]>(static_cast<uint64_t>(count));
+    if (not path_store_->GetPaths(inner_ids, paths.get())) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "Pyramid path is unavailable for a requested id");
+    }
+    result->Paths(paths.release());
+    return result;
+}
+
+}  // namespace vsag

--- a/src/algorithm/pyramid_paths.cpp
+++ b/src/algorithm/pyramid_paths.cpp
@@ -28,18 +28,11 @@ Pyramid::serialize_paths(StreamWriter& writer) const {
 }
 
 void
-Pyramid::deserialize_paths(StreamReader& reader, uint64_t max_count) {
+Pyramid::deserialize_paths(StreamReader& reader, uint64_t expected_count) {
     if (path_store_ == nullptr) {
         throw VsagException(ErrorType::READ_ERROR, "Pyramid path storage is disabled");
     }
-    path_store_->Deserialize(reader, max_count);
-}
-
-void
-Pyramid::validate_paths(uint64_t expected_count) const {
-    if (path_store_ == nullptr || path_store_->Size() != expected_count) {
-        throw VsagException(ErrorType::READ_ERROR, "corrupted Pyramid path slot count");
-    }
+    path_store_->Deserialize(reader, expected_count);
 }
 
 DatasetPtr

--- a/src/algorithm/pyramid_test.cpp
+++ b/src/algorithm/pyramid_test.cpp
@@ -211,11 +211,11 @@ TEST_CASE("Pyramid raw-vector capability does not imply stored raw data",
                        data_result.value()->GetIds() + requested_ids.size(),
                        requested_ids.begin()));
     REQUIRE(data_result.value()->GetFloat32Vectors() == nullptr);
-    REQUIRE_FALSE(index
-                      ->GetDataByIdsWithFlag(requested_ids.data(),
-                                             requested_ids.size(),
-                                             DATA_FLAG_ID | DATA_FLAG_FLOAT32_VECTOR)
-                      .has_value());
+    auto unavailable_raw = index->GetDataByIdsWithFlag(
+        requested_ids.data(), requested_ids.size(), DATA_FLAG_ID | DATA_FLAG_FLOAT32_VECTOR);
+    REQUIRE_FALSE(unavailable_raw.has_value());
+    REQUIRE(unavailable_raw.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    REQUIRE(unavailable_raw.error().message == "has_raw_vector_ is false");
 
     std::array<float, PYRAMID_RAW_VECTOR_TEST_DIM> added_vector = {8.0F, 6.0F, 4.0F, 2.0F};
     std::array<int64_t, 1> added_id = {77};

--- a/src/algorithm/pyramid_zparameters.cpp
+++ b/src/algorithm/pyramid_zparameters.cpp
@@ -68,6 +68,10 @@ PyramidParameters::FromJson(const JsonType& json) {
     if (json.Contains(SUPPORT_DUPLICATE)) {
         this->support_duplicate = json[SUPPORT_DUPLICATE].GetBool();
     }
+
+    if (json.Contains(PYRAMID_STORE_PATHS_KEY)) {
+        this->store_paths = json[PYRAMID_STORE_PATHS_KEY].GetBool();
+    }
 }
 JsonType
 PyramidParameters::ToJson() const {
@@ -87,6 +91,7 @@ PyramidParameters::ToJson() const {
     json[USE_REORDER_KEY].SetBool(this->use_reorder);
     json[INDEX_MIN_SIZE].SetInt(index_min_size);
     json[SUPPORT_DUPLICATE].SetBool(support_duplicate);
+    json[PYRAMID_STORE_PATHS_KEY].SetBool(store_paths);
     if (this->use_reorder) {
         json[PRECISE_CODES_KEY].SetJson(precise_codes_param->ToJson());
     }
@@ -141,6 +146,11 @@ PyramidParameters::CheckCompatibility(const ParamPtr& other) const {
     if (this->support_duplicate != pyramid_param->support_duplicate) {
         logger::error(
             "PyramidParameters::CheckCompatibility: support_duplicate are not compatible");
+        return false;
+    }
+
+    if (this->store_paths != pyramid_param->store_paths) {
+        logger::error("PyramidParameters::CheckCompatibility: store_paths are not compatible");
         return false;
     }
 

--- a/src/algorithm/pyramid_zparameters.h
+++ b/src/algorithm/pyramid_zparameters.h
@@ -56,6 +56,7 @@ public:
     uint32_t index_min_size{0};
 
     bool support_duplicate{false};
+    bool store_paths{false};
 };
 
 class PyramidSearchParameters : public IndexSearchParameter {

--- a/src/algorithm/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid_zparameters_test.cpp
@@ -37,6 +37,7 @@ struct PyramidDefaultParam {
     std::string precise_file_path = "precise_path";
     uint32_t index_min_size = 1000;
     bool support_duplicate = false;
+    bool store_paths = false;
 };
 
 std::string
@@ -97,7 +98,8 @@ generate_pyramid(const PyramidDefaultParam& param) {
             "type": "pyramid",
             "use_reorder": {},
             "index_min_size": {},
-            "support_duplicate": {}
+            "support_duplicate": {},
+            "store_paths": {}
         }}
     )";
     return fmt::format(param_str,
@@ -117,7 +119,8 @@ generate_pyramid(const PyramidDefaultParam& param) {
                        param.precise_quantization_type,
                        param.use_reorder,
                        param.index_min_size,
-                       param.support_duplicate);
+                       param.support_duplicate,
+                       param.store_paths);
 }
 
 TEST_CASE("Pyramid Parameters Test", "[ut][PyramidParameters]") {
@@ -127,6 +130,12 @@ TEST_CASE("Pyramid Parameters Test", "[ut][PyramidParameters]") {
     auto param = std::make_shared<vsag::PyramidParameters>();
     param->FromJson(param_json);
     vsag::ParameterTest::TestToJson(param);
+    REQUIRE_FALSE(param->store_paths);
+
+    param_json["store_paths"].SetBool(true);
+    param->FromJson(param_json);
+    REQUIRE(param->store_paths);
+    REQUIRE(param->ToJson()["store_paths"].GetBool());
 }
 
 #define TEST_COMPATIBILITY_CASE(section_name, param_member, val1, val2, expect_compatible) \
@@ -178,4 +187,5 @@ TEST_CASE("Pyramid Parameters CheckCompatibility", "[ut][PyramidParameter][Check
         "different precise quantization type", precise_quantization_type, "fp32", "fp16", false);
     TEST_COMPATIBILITY_CASE("different index min size", index_min_size, 500, 1500, false);
     TEST_COMPATIBILITY_CASE("different support duplicate", support_duplicate, false, true, false);
+    TEST_COMPATIBILITY_CASE("different store paths", store_paths, false, true, false);
 }

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -217,6 +217,7 @@ const char* const PYRAMID_PARAMETER_EF_SEARCH = "ef_search";
 const char* const PYRAMID_PARAMETER_SUBINDEX_EF_SEARCH = "subindex_ef_search";
 const char* const PYRAMID_NO_BUILD_LEVELS = "no_build_levels";
 const char* const PYRAMID_INDEX_MIN_SIZE = "index_min_size";
+const char* const PYRAMID_STORE_PATHS = "store_paths";
 
 const char* const GNO_IMI_FIRST_ORDER_BUCKETS_COUNT = "first_order_buckets_count";
 const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT = "second_order_buckets_count";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -47,6 +47,7 @@ const char* const HGRAPH_USE_ELP_OPTIMIZER_KEY = "use_elp_optimizer";
 const char* const HGRAPH_IGNORE_REORDER_KEY = "ignore_reorder";
 const char* const HGRAPH_BUILD_BY_BASE_QUANTIZATION_KEY = "build_by_base";
 const char* const HGRAPH_USE_REVERSE_EDGES_KEY = "use_reverse_edges";
+const char* const PYRAMID_STORE_PATHS_KEY = "store_paths";
 const char* const LABEL_REMAP_TYPE_VALUE_ROBIN = "robin";
 const char* const LABEL_REMAP_TYPE_VALUE_PG = "pg";
 const char* const GRAPH_KEY = "graph";
@@ -257,6 +258,7 @@ const std::unordered_map<std::string, std::string> DEFAULT_MAP = {
     {"GRAPH_SUPPORT_REMOVE", GRAPH_SUPPORT_REMOVE},
     {"REMOVE_FLAG_BIT", REMOVE_FLAG_BIT},
     {"HOLD_MOLDS", HOLD_MOLDS},
+    {"PYRAMID_STORE_PATHS_KEY", PYRAMID_STORE_PATHS_KEY},
     {"IVF_PARTITION_STRATEGY_TYPE_GNO_IMI", IVF_PARTITION_STRATEGY_TYPE_GNO_IMI},
     {"STORE_RAW_VECTOR_KEY", STORE_RAW_VECTOR_KEY},
     {"RAW_VECTOR_KEY", RAW_VECTOR_KEY},

--- a/tests/test_pyramid_paths.cpp
+++ b/tests/test_pyramid_paths.cpp
@@ -21,6 +21,8 @@
 #include <utility>
 #include <vector>
 
+#include "storage/serialization.h"
+#include "storage/stream_reader.h"
 #include "vsag/vsag.h"
 
 namespace {
@@ -104,6 +106,23 @@ RequirePaths(const std::string* actual, const std::vector<std::string>& expected
     }
 }
 
+uint64_t
+GetPathSidecarOffset(const vsag::Binary& binary, const std::vector<std::string>& paths) {
+    auto read_func = [&binary](uint64_t offset, uint64_t length, void* destination) {
+        std::memcpy(destination, binary.data.get() + offset, length);
+    };
+    ReadFuncStreamReader reader(read_func, 0, binary.size);
+    const auto footer = vsag::Footer::Parse(reader);
+    REQUIRE(footer != nullptr);
+
+    uint64_t payload_size = sizeof(uint64_t);
+    for (const auto& path : paths) {
+        payload_size += sizeof(uint8_t) + sizeof(uint64_t) + static_cast<uint64_t>(path.size());
+    }
+    REQUIRE(binary.size >= footer->Length() + payload_size);
+    return binary.size - footer->Length() - payload_size;
+}
+
 }  // namespace
 
 TEST_CASE("Pyramid advertises GetDataByIds only when paths are retained",
@@ -139,6 +158,29 @@ TEST_CASE("Pyramid retained paths support empty-index serialization",
     auto restored = MakePyramidIndex("nsw", true);
     REQUIRE(restored->Deserialize(binary_set.value()).has_value());
     REQUIRE(restored->Serialize().has_value());
+}
+
+TEST_CASE("Pyramid serialized path storage configuration must match",
+          "[ft][pyramid][paths][serialization]") {
+    SECTION("stored paths require an enabled reader") {
+        auto index = MakePyramidIndex("nsw", true);
+        REQUIRE(index->Build(MakeDataset({4}, {"path"})).has_value());
+        auto binary_set = index->Serialize();
+        REQUIRE(binary_set.has_value());
+
+        auto restored = MakePyramidIndex("nsw", false);
+        REQUIRE_FALSE(restored->Deserialize(binary_set.value()).has_value());
+    }
+
+    SECTION("a reader requiring paths rejects an index without them") {
+        auto index = MakePyramidIndex("nsw", false);
+        REQUIRE(index->Build(MakeDataset({4}, {"path"})).has_value());
+        auto binary_set = index->Serialize();
+        REQUIRE(binary_set.has_value());
+
+        auto restored = MakePyramidIndex("nsw", true);
+        REQUIRE_FALSE(restored->Deserialize(binary_set.value()).has_value());
+    }
 }
 
 TEST_CASE("Pyramid retains paths for NSW and ODescent Build", "[ft][pyramid][paths]") {
@@ -219,27 +261,16 @@ TEST_CASE("Pyramid rejects selected paths when storage is disabled", "[ft][pyram
 
 TEST_CASE("Pyramid rejects an incomplete serialized path sidecar",
           "[ft][pyramid][paths][serialization]") {
+    const std::vector<std::string> paths = {"left", "right"};
     auto index = MakePyramidIndex("nsw", true);
-    REQUIRE(index->Build(MakeDataset({4, 8}, {"left", "right"})).has_value());
+    REQUIRE(index->Build(MakeDataset({4, 8}, paths)).has_value());
 
     auto binary_set = index->Serialize();
     REQUIRE(binary_set.has_value());
     auto binary = binary_set.value().Get("pyramid");
-    constexpr uint64_t paths_magic = 0x5059525041544853ULL;
-    bool found_paths = false;
-    for (uint64_t offset = 0; offset + sizeof(uint64_t) * 2 <= binary.size; ++offset) {
-        uint64_t value = 0;
-        std::memcpy(&value, binary.data.get() + offset, sizeof(value));
-        if (value == paths_magic) {
-            const uint64_t empty_slot_count = 0;
-            std::memcpy(binary.data.get() + offset + sizeof(value),
-                        &empty_slot_count,
-                        sizeof(empty_slot_count));
-            found_paths = true;
-            break;
-        }
-    }
-    REQUIRE(found_paths);
+    const auto sidecar_offset = GetPathSidecarOffset(binary, paths);
+    const uint64_t empty_slot_count = 0;
+    std::memcpy(binary.data.get() + sidecar_offset, &empty_slot_count, sizeof(empty_slot_count));
 
     auto restored = MakePyramidIndex("nsw", true);
     REQUIRE_FALSE(restored->Deserialize(binary_set.value()).has_value());
@@ -247,25 +278,15 @@ TEST_CASE("Pyramid rejects an incomplete serialized path sidecar",
 
 TEST_CASE("Pyramid reports a retained path missing at query time",
           "[ft][pyramid][paths][serialization]") {
+    const std::vector<std::string> paths = {""};
     auto index = MakePyramidIndex("nsw", true);
-    REQUIRE(index->Build(MakeDataset({4}, {""})).has_value());
+    REQUIRE(index->Build(MakeDataset({4}, paths)).has_value());
 
     auto binary_set = index->Serialize();
     REQUIRE(binary_set.has_value());
     auto binary = binary_set.value().Get("pyramid");
-    constexpr uint64_t paths_magic = 0x5059525041544853ULL;
-    bool found_paths = false;
-    for (uint64_t offset = 0; offset + sizeof(uint64_t) * 2 + sizeof(uint8_t) <= binary.size;
-         ++offset) {
-        uint64_t value = 0;
-        std::memcpy(&value, binary.data.get() + offset, sizeof(value));
-        if (value == paths_magic) {
-            binary.data.get()[offset + sizeof(uint64_t) * 2] = 0;
-            found_paths = true;
-            break;
-        }
-    }
-    REQUIRE(found_paths);
+    const auto sidecar_offset = GetPathSidecarOffset(binary, paths);
+    binary.data.get()[sidecar_offset + sizeof(uint64_t)] = 0;
 
     auto restored = MakePyramidIndex("nsw", true);
     REQUIRE(restored->Deserialize(binary_set.value()).has_value());

--- a/tests/test_pyramid_paths.cpp
+++ b/tests/test_pyramid_paths.cpp
@@ -16,6 +16,7 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <utility>
@@ -193,17 +194,34 @@ TEST_CASE("Pyramid retains paths for NSW and ODescent Build", "[ft][pyramid][pat
     REQUIRE(data->GetIds() == nullptr);
 }
 
-TEST_CASE("Pyramid Add stores paths using accepted input offsets", "[ft][pyramid][paths]") {
+TEST_CASE("Pyramid Add stores paths for allocated inner IDs", "[ft][pyramid][paths]") {
     auto index = MakePyramidIndex("nsw", true);
     REQUIRE(index->Build(MakeDataset({10}, {"original"})).has_value());
 
     auto add_result =
-        index->Add(MakeDataset({10, 20, 30}, {"duplicate-path", "path-20", "path-30"}));
+        index->Add(MakeDataset({20, 10, 30}, {"path-20", "duplicate-path", "path-30"}));
     REQUIRE(add_result.has_value());
     REQUIRE(add_result.value() == std::vector<int64_t>{10});
 
     RequirePaths(GetDataWithFlag(index, {20, 30, 10}, DATA_FLAG_PATH)->GetPaths(),
                  {"path-20", "path-30", "original"});
+}
+
+TEST_CASE("Pyramid concurrent Add keeps paths aligned with IDs", "[ft][pyramid][paths]") {
+    auto index = MakePyramidIndex("nsw", true);
+    REQUIRE(index->Build(MakeDataset({10}, {"original"})).has_value());
+    auto first = MakeDataset({20, 21}, {"first/20", "first/21"});
+    auto second = MakeDataset({30, 31}, {"second/30", "second/31"});
+
+    auto first_result =
+        std::async(std::launch::async, [index, first]() { return index->Add(first); });
+    auto second_result =
+        std::async(std::launch::async, [index, second]() { return index->Add(second); });
+    REQUIRE(first_result.get().has_value());
+    REQUIRE(second_result.get().has_value());
+
+    auto data = GetDataWithFlag(index, {31, 20, 30, 21}, DATA_FLAG_PATH);
+    RequirePaths(data->GetPaths(), {"second/31", "first/20", "second/30", "first/21"});
 }
 
 TEST_CASE("Pyramid serialization and Clone preserve retained paths", "[ft][pyramid][paths]") {

--- a/tests/test_pyramid_paths.cpp
+++ b/tests/test_pyramid_paths.cpp
@@ -86,6 +86,16 @@ GetData(const vsag::IndexPtr& index, const std::vector<int64_t>& ids) {
     return result.value();
 }
 
+vsag::DatasetPtr
+GetDataWithFlag(const vsag::IndexPtr& index,
+                const std::vector<int64_t>& ids,
+                uint64_t selected_data_flag) {
+    auto result = index->GetDataByIdsWithFlag(
+        ids.data(), static_cast<int64_t>(ids.size()), selected_data_flag);
+    REQUIRE(result.has_value());
+    return result.value();
+}
+
 void
 RequirePaths(const std::string* actual, const std::vector<std::string>& expected) {
     REQUIRE(actual != nullptr);
@@ -136,7 +146,9 @@ TEST_CASE("Pyramid retains paths for NSW and ODescent Build", "[ft][pyramid][pat
     auto index = MakePyramidIndex(graph_type, true);
     REQUIRE(index->Build(MakeDataset({101, 42, 900}, {"alpha", "", "beta/gamma"})).has_value());
 
-    RequirePaths(GetData(index, {900, 101, 42})->GetPaths(), {"beta/gamma", "alpha", ""});
+    auto data = GetDataWithFlag(index, {900, 101, 42}, DATA_FLAG_PATH);
+    RequirePaths(data->GetPaths(), {"beta/gamma", "alpha", ""});
+    REQUIRE(data->GetIds() == nullptr);
 }
 
 TEST_CASE("Pyramid Add stores paths using accepted input offsets", "[ft][pyramid][paths]") {
@@ -148,7 +160,8 @@ TEST_CASE("Pyramid Add stores paths using accepted input offsets", "[ft][pyramid
     REQUIRE(add_result.has_value());
     REQUIRE(add_result.value() == std::vector<int64_t>{10});
 
-    RequirePaths(GetData(index, {20, 30, 10})->GetPaths(), {"path-20", "path-30", "original"});
+    RequirePaths(GetDataWithFlag(index, {20, 30, 10}, DATA_FLAG_PATH)->GetPaths(),
+                 {"path-20", "path-30", "original"});
 }
 
 TEST_CASE("Pyramid serialization and Clone preserve retained paths", "[ft][pyramid][paths]") {
@@ -157,13 +170,51 @@ TEST_CASE("Pyramid serialization and Clone preserve retained paths", "[ft][pyram
 
     auto clone = index->Clone();
     REQUIRE(clone.has_value());
-    RequirePaths(GetData(clone.value(), {8, 4})->GetPaths(), {"right", "left"});
+    RequirePaths(GetDataWithFlag(clone.value(), {8, 4}, DATA_FLAG_PATH)->GetPaths(),
+                 {"right", "left"});
 
     auto binary_set = index->Serialize();
     REQUIRE(binary_set.has_value());
     auto restored = MakePyramidIndex("nsw", true);
     REQUIRE(restored->Deserialize(binary_set.value()).has_value());
-    RequirePaths(GetData(restored, {4, 8})->GetPaths(), {"left", "right"});
+    auto restored_data = GetDataWithFlag(restored, {4, 8}, DATA_FLAG_ID | DATA_FLAG_PATH);
+    RequirePaths(restored_data->GetPaths(), {"left", "right"});
+    REQUIRE(restored_data->GetIds() != nullptr);
+    REQUIRE(restored_data->GetIds()[0] == 4);
+    REQUIRE(restored_data->GetIds()[1] == 8);
+}
+
+TEST_CASE("Pyramid returns paths only when selected", "[ft][pyramid][paths]") {
+    auto index = MakePyramidIndex("nsw", true);
+    REQUIRE(index->Build(MakeDataset({1, 2}, {"a", "b"})).has_value());
+
+    auto all_standard_data = GetData(index, {2, 1});
+    REQUIRE(all_standard_data->GetIds() != nullptr);
+    REQUIRE(all_standard_data->GetPaths() == nullptr);
+
+    auto ids_only = GetDataWithFlag(index, {2, 1}, DATA_FLAG_ID);
+    REQUIRE(ids_only->GetIds() != nullptr);
+    REQUIRE(ids_only->GetPaths() == nullptr);
+
+    auto paths_only = GetDataWithFlag(index, {2, 1}, DATA_FLAG_PATH);
+    REQUIRE(paths_only->GetIds() == nullptr);
+    RequirePaths(paths_only->GetPaths(), {"b", "a"});
+}
+
+TEST_CASE("Pyramid rejects selected paths when storage is disabled", "[ft][pyramid][paths]") {
+    auto index = MakePyramidIndex("nsw", false);
+    REQUIRE(index->Build(MakeDataset({1}, {"a"})).has_value());
+
+    const int64_t id = 1;
+    auto ids_only = index->GetDataByIdsWithFlag(&id, 1, DATA_FLAG_ID);
+    REQUIRE(ids_only.has_value());
+    REQUIRE(ids_only.value()->GetIds() != nullptr);
+    REQUIRE(ids_only.value()->GetIds()[0] == id);
+    REQUIRE(ids_only.value()->GetPaths() == nullptr);
+
+    auto result = index->GetDataByIdsWithFlag(&id, 1, DATA_FLAG_PATH);
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
 }
 
 TEST_CASE("Pyramid rejects an incomplete serialized path sidecar",
@@ -219,7 +270,7 @@ TEST_CASE("Pyramid reports a retained path missing at query time",
     auto restored = MakePyramidIndex("nsw", true);
     REQUIRE(restored->Deserialize(binary_set.value()).has_value());
     const int64_t id = 4;
-    auto result = restored->GetDataByIds(&id, 1);
+    auto result = restored->GetDataByIdsWithFlag(&id, 1, DATA_FLAG_PATH);
     REQUIRE_FALSE(result.has_value());
     REQUIRE(result.error().type == vsag::ErrorType::INTERNAL_ERROR);
 }

--- a/tests/test_pyramid_paths.cpp
+++ b/tests/test_pyramid_paths.cpp
@@ -1,0 +1,225 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <cstdint>
+#include <cstring>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "vsag/vsag.h"
+
+namespace {
+
+std::string
+MakePyramidParameters(const std::string& graph_type, bool store_paths) {
+    nlohmann::json index_param = {
+        {"max_degree", 4},
+        {"alpha", 1.2},
+        {"ef_construction", 8},
+        {"graph_type", graph_type},
+        {"graph_iter_turn", 1},
+        {"neighbor_sample_rate", 0.2},
+        {"base_quantization_type", "fp32"},
+        {"use_reorder", false},
+        {"index_min_size", 100},
+        {"no_build_levels", {0, 1, 2, 3}},
+    };
+    if (store_paths) {
+        index_param["store_paths"] = true;
+    }
+    return nlohmann::json({{"dtype", "float32"},
+                           {"metric_type", "l2"},
+                           {"dim", 2},
+                           {"index_param", std::move(index_param)}})
+        .dump();
+}
+
+vsag::IndexPtr
+MakePyramidIndex(const std::string& graph_type, bool store_paths) {
+    auto result =
+        vsag::Factory::CreateIndex("pyramid", MakePyramidParameters(graph_type, store_paths));
+    REQUIRE(result.has_value());
+    return result.value();
+}
+
+vsag::DatasetPtr
+MakeDataset(const std::vector<int64_t>& ids, const std::vector<std::string>& paths) {
+    REQUIRE(ids.size() == paths.size());
+    auto* vectors = new float[ids.size() * 2];
+    auto* raw_ids = new int64_t[ids.size()];
+    auto* raw_paths = new std::string[paths.size()];
+    for (uint64_t offset = 0; offset < ids.size(); ++offset) {
+        vectors[offset * 2] = static_cast<float>(offset);
+        vectors[offset * 2 + 1] = static_cast<float>(offset + 1);
+        raw_ids[offset] = ids[offset];
+        raw_paths[offset] = paths[offset];
+    }
+
+    return vsag::Dataset::Make()
+        ->NumElements(static_cast<int64_t>(ids.size()))
+        ->Dim(2)
+        ->Float32Vectors(vectors)
+        ->Ids(raw_ids)
+        ->Paths(raw_paths)
+        ->Owner(true);
+}
+
+vsag::DatasetPtr
+GetData(const vsag::IndexPtr& index, const std::vector<int64_t>& ids) {
+    auto result = index->GetDataByIds(ids.data(), static_cast<int64_t>(ids.size()));
+    REQUIRE(result.has_value());
+    return result.value();
+}
+
+void
+RequirePaths(const std::string* actual, const std::vector<std::string>& expected) {
+    REQUIRE(actual != nullptr);
+    for (uint64_t offset = 0; offset < expected.size(); ++offset) {
+        REQUIRE(actual[offset] == expected[offset]);
+    }
+}
+
+}  // namespace
+
+TEST_CASE("Pyramid advertises GetDataByIds only when paths are retained",
+          "[ft][pyramid][paths][feature]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    REQUIRE_FALSE(MakePyramidIndex(graph_type, false)->CheckFeature(vsag::SUPPORT_GET_DATA_BY_IDS));
+    REQUIRE(MakePyramidIndex(graph_type, true)->CheckFeature(vsag::SUPPORT_GET_DATA_BY_IDS));
+}
+
+TEST_CASE("Pyramid NSW preserves legacy GetDataByIds when path storage is disabled",
+          "[ft][pyramid][paths]") {
+    auto index = MakePyramidIndex("nsw", false);
+    REQUIRE(index->Build(MakeDataset({10, 20}, {"a", "b"})).has_value());
+
+    // Feature discovery intentionally stays disabled without the optional sidecar; it is not an
+    // invocation gate. NSW has always populated reverse label lookup, so legacy direct calls still
+    // return IDs without retained paths.
+    REQUIRE(GetData(index, {20, 10})->GetPaths() == nullptr);
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto restored = MakePyramidIndex("nsw", false);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    REQUIRE(GetData(restored, {10, 20})->GetPaths() == nullptr);
+}
+
+TEST_CASE("Pyramid retained paths support empty-index serialization",
+          "[ft][pyramid][paths][serialization]") {
+    auto index = MakePyramidIndex("nsw", true);
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto restored = MakePyramidIndex("nsw", true);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    REQUIRE(restored->Serialize().has_value());
+}
+
+TEST_CASE("Pyramid retains paths for NSW and ODescent Build", "[ft][pyramid][paths]") {
+    const auto graph_type = GENERATE(std::string("nsw"), std::string("odescent"));
+    auto index = MakePyramidIndex(graph_type, true);
+    REQUIRE(index->Build(MakeDataset({101, 42, 900}, {"alpha", "", "beta/gamma"})).has_value());
+
+    RequirePaths(GetData(index, {900, 101, 42})->GetPaths(), {"beta/gamma", "alpha", ""});
+}
+
+TEST_CASE("Pyramid Add stores paths using accepted input offsets", "[ft][pyramid][paths]") {
+    auto index = MakePyramidIndex("nsw", true);
+    REQUIRE(index->Build(MakeDataset({10}, {"original"})).has_value());
+
+    auto add_result =
+        index->Add(MakeDataset({10, 20, 30}, {"duplicate-path", "path-20", "path-30"}));
+    REQUIRE(add_result.has_value());
+    REQUIRE(add_result.value() == std::vector<int64_t>{10});
+
+    RequirePaths(GetData(index, {20, 30, 10})->GetPaths(), {"path-20", "path-30", "original"});
+}
+
+TEST_CASE("Pyramid serialization and Clone preserve retained paths", "[ft][pyramid][paths]") {
+    auto index = MakePyramidIndex("nsw", true);
+    REQUIRE(index->Build(MakeDataset({4, 8}, {"left", "right"})).has_value());
+
+    auto clone = index->Clone();
+    REQUIRE(clone.has_value());
+    RequirePaths(GetData(clone.value(), {8, 4})->GetPaths(), {"right", "left"});
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto restored = MakePyramidIndex("nsw", true);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    RequirePaths(GetData(restored, {4, 8})->GetPaths(), {"left", "right"});
+}
+
+TEST_CASE("Pyramid rejects an incomplete serialized path sidecar",
+          "[ft][pyramid][paths][serialization]") {
+    auto index = MakePyramidIndex("nsw", true);
+    REQUIRE(index->Build(MakeDataset({4, 8}, {"left", "right"})).has_value());
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto binary = binary_set.value().Get("pyramid");
+    constexpr uint64_t paths_magic = 0x5059525041544853ULL;
+    bool found_paths = false;
+    for (uint64_t offset = 0; offset + sizeof(uint64_t) * 2 <= binary.size; ++offset) {
+        uint64_t value = 0;
+        std::memcpy(&value, binary.data.get() + offset, sizeof(value));
+        if (value == paths_magic) {
+            const uint64_t empty_slot_count = 0;
+            std::memcpy(binary.data.get() + offset + sizeof(value),
+                        &empty_slot_count,
+                        sizeof(empty_slot_count));
+            found_paths = true;
+            break;
+        }
+    }
+    REQUIRE(found_paths);
+
+    auto restored = MakePyramidIndex("nsw", true);
+    REQUIRE_FALSE(restored->Deserialize(binary_set.value()).has_value());
+}
+
+TEST_CASE("Pyramid reports a retained path missing at query time",
+          "[ft][pyramid][paths][serialization]") {
+    auto index = MakePyramidIndex("nsw", true);
+    REQUIRE(index->Build(MakeDataset({4}, {""})).has_value());
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto binary = binary_set.value().Get("pyramid");
+    constexpr uint64_t paths_magic = 0x5059525041544853ULL;
+    bool found_paths = false;
+    for (uint64_t offset = 0; offset + sizeof(uint64_t) * 2 + sizeof(uint8_t) <= binary.size;
+         ++offset) {
+        uint64_t value = 0;
+        std::memcpy(&value, binary.data.get() + offset, sizeof(value));
+        if (value == paths_magic) {
+            binary.data.get()[offset + sizeof(uint64_t) * 2] = 0;
+            found_paths = true;
+            break;
+        }
+    }
+    REQUIRE(found_paths);
+
+    auto restored = MakePyramidIndex("nsw", true);
+    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
+    const int64_t id = 4;
+    auto result = restored->GetDataByIds(&id, 1);
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == vsag::ErrorType::INTERNAL_ERROR);
+}

--- a/tests/test_pyramid_paths.cpp
+++ b/tests/test_pyramid_paths.cpp
@@ -15,15 +15,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <cstdint>
-#include <cstring>
 #include <future>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "storage/serialization.h"
-#include "storage/stream_reader.h"
 #include "vsag/vsag.h"
 
 namespace {
@@ -105,23 +102,6 @@ RequirePaths(const std::string* actual, const std::vector<std::string>& expected
     for (uint64_t offset = 0; offset < expected.size(); ++offset) {
         REQUIRE(actual[offset] == expected[offset]);
     }
-}
-
-uint64_t
-GetPathSidecarOffset(const vsag::Binary& binary, const std::vector<std::string>& paths) {
-    auto read_func = [&binary](uint64_t offset, uint64_t length, void* destination) {
-        std::memcpy(destination, binary.data.get() + offset, length);
-    };
-    ReadFuncStreamReader reader(read_func, 0, binary.size);
-    const auto footer = vsag::Footer::Parse(reader);
-    REQUIRE(footer != nullptr);
-
-    uint64_t payload_size = sizeof(uint64_t);
-    for (const auto& path : paths) {
-        payload_size += sizeof(uint8_t) + sizeof(uint64_t) + static_cast<uint64_t>(path.size());
-    }
-    REQUIRE(binary.size >= footer->Length() + payload_size);
-    return binary.size - footer->Length() - payload_size;
 }
 
 }  // namespace
@@ -275,41 +255,4 @@ TEST_CASE("Pyramid rejects selected paths when storage is disabled", "[ft][pyram
     auto result = index->GetDataByIdsWithFlag(&id, 1, DATA_FLAG_PATH);
     REQUIRE_FALSE(result.has_value());
     REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
-}
-
-TEST_CASE("Pyramid rejects an incomplete serialized path sidecar",
-          "[ft][pyramid][paths][serialization]") {
-    const std::vector<std::string> paths = {"left", "right"};
-    auto index = MakePyramidIndex("nsw", true);
-    REQUIRE(index->Build(MakeDataset({4, 8}, paths)).has_value());
-
-    auto binary_set = index->Serialize();
-    REQUIRE(binary_set.has_value());
-    auto binary = binary_set.value().Get("pyramid");
-    const auto sidecar_offset = GetPathSidecarOffset(binary, paths);
-    const uint64_t empty_slot_count = 0;
-    std::memcpy(binary.data.get() + sidecar_offset, &empty_slot_count, sizeof(empty_slot_count));
-
-    auto restored = MakePyramidIndex("nsw", true);
-    REQUIRE_FALSE(restored->Deserialize(binary_set.value()).has_value());
-}
-
-TEST_CASE("Pyramid reports a retained path missing at query time",
-          "[ft][pyramid][paths][serialization]") {
-    const std::vector<std::string> paths = {""};
-    auto index = MakePyramidIndex("nsw", true);
-    REQUIRE(index->Build(MakeDataset({4}, paths)).has_value());
-
-    auto binary_set = index->Serialize();
-    REQUIRE(binary_set.has_value());
-    auto binary = binary_set.value().Get("pyramid");
-    const auto sidecar_offset = GetPathSidecarOffset(binary, paths);
-    binary.data.get()[sidecar_offset + sizeof(uint64_t)] = 0;
-
-    auto restored = MakePyramidIndex("nsw", true);
-    REQUIRE(restored->Deserialize(binary_set.value()).has_value());
-    const int64_t id = 4;
-    auto result = restored->GetDataByIdsWithFlag(&id, 1, DATA_FLAG_PATH);
-    REQUIRE_FALSE(result.has_value());
-    REQUIRE(result.error().type == vsag::ErrorType::INTERNAL_ERROR);
 }


### PR DESCRIPTION
## Change Type

- [x] Improvement

## Linked Issue

Related to #2754. Backport of #2763 to the 0.18 branch.

## What Changed

- Add store_paths as an opt-in Pyramid parameter, disabled by default.
- Keep the 0.18 implementation single-path and return a path only when GetDataByIdsWithFlag selects DATA_FLAG_PATH.
- Store paths directly by allocated inner ID in the separate PyramidPathStore.
- Pre-size path slots once for Build/Add batches and remove the redundant ODescent reverse-label remap rebuild; LabelTable::Insert already maintains it.
- Append the path sidecar before the existing footer only when enabled. INDEX_PARAM is also added only for enabled indexes, so default-off serialization remains on the prior body/footer path.
- No multi-path SoA, named hierarchy, streaming, map, sparse/adaptive index, magic, or private version is backported.

## Compatibility and Performance

- Default-off creates no path store, allocates no per-vector path data, and writes neither a sidecar nor the added parameter payload.
- One Writer lock covers each enabled batch; EnsureSlots avoids incremental slot-vector growth.

## Validation

- Debug unittests and functests targets built successfully.
- Pyramid unit tests: 584 assertions / 10 cases.
- Pyramid path functional tests: 118 assertions / 10 cases.
- clang-format-15, clang-tidy-15 on changed implementation files, and git diff --check passed.
- Independent final review found no P0-P2 issue and no remaining out-of-scope or over-defensive design.