### PR TITLE
ci: publish build performance metrics

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -87,10 +87,13 @@ jobs:
       - name: Prepare Host
         run: |
           sudo env VSAG_INSTALL_INTEL_MKL=OFF bash ./scripts/deps/install_deps_ubuntu.sh
-          sudo apt-get install -y clang-tidy-15
+          sudo apt-get install -y clang-tidy-15 time
           ninja --version
           cmake --version
           g++ --version
+      - name: Start Dependency Preparation Timer
+        id: dependency-preparation-start
+        run: echo "started_ns=$(date +%s%N)" >> "$GITHUB_OUTPUT"
       - name: Prepare FetchContent Sources
         uses: ./.github/actions/prepare-fetchcontent
         with:
@@ -103,19 +106,61 @@ jobs:
           key: external-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('extern/**/*.cmake') }}
           restore-keys: |
             external-${{ runner.os }}-${{ runner.arch }}-
-      - name: Load Cache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          max-size: "2G"
-          save: ${{ github.event_name != 'pull_request' }}
-          key: build-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
-      - name: Make Asan
+      - name: Finish Dependency Preparation Timer
+        id: dependency-preparation
+        env:
+          STARTED_NS: ${{ steps.dependency-preparation-start.outputs.started_ns }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          import time
+
+          elapsed = (time.time_ns() - int(os.environ["STARTED_NS"])) / 1_000_000_000
+          print(f"seconds={elapsed:.3f}")
+          PY
+      - name: Make Asan and collect build metrics
         # The source-build OpenBLAS path remains covered by daily_test.yml.
+        env:
+          BUILD_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+          CCACHE_DIR: ${{ github.workspace }}/.build-metrics-ccache
+          COMPILER_CACHE_KEY: build-metrics-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
+          DEPENDENCY_CACHE_KEY: external-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('extern/**/*.cmake') }}
+          DEPENDENCY_PREPARATION_SECONDS: ${{ steps.dependency-preparation.outputs.seconds }}
         run: |
           export CMAKE_GENERATOR="Ninja"
           export CMAKE_EXPORT_COMPILE_COMMANDS=ON
           export EXTRA_DEFINED="-DVSAG_USE_SYSTEM_OPENBLAS=ON"
-          make asan VSAG_ENABLE_EXAMPLES=ON VSAG_ENABLE_TOOLS=ON COMPILE_JOBS=3
+          export VSAG_ENABLE_EXAMPLES=ON
+          export VSAG_ENABLE_TOOLS=ON
+          COMPILER=$(g++ -dumpfullversion -dumpversion)
+          python3 scripts/collect_build_metrics.py \
+            --base-sha "$BUILD_BASE_SHA" \
+            --commit-sha "$GITHUB_SHA" \
+            --compiler "gcc-$COMPILER" \
+            --compiler-cache-key "$COMPILER_CACHE_KEY-gcc-$COMPILER" \
+            --dependency-cache-key "$DEPENDENCY_CACHE_KEY" \
+            --dependency-preparation-seconds "$DEPENDENCY_PREPARATION_SECONDS" \
+            --jobs 3 \
+            --clear-ccache
+      - name: Append build metrics job summary
+        if: always()
+        run: |
+          if [ -f build-metrics/job-summary.md ]; then
+            cat build-metrics/job-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Build performance metrics" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The collector failed before producing a report." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload build metrics
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          path: ./build-metrics
+          name: build-performance-metrics-${{ github.run_id }}
+          compression-level: 6
+          retention-days: 14
+          if-no-files-found: warn
       - name: Get changed source files
         id: changed-srcs
         run: |

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 CMAKE_GENERATOR ?= "Unix Makefiles"
 CMAKE_INSTALL_PREFIX ?= "/usr/local/"
 COMPILE_JOBS ?= 6
+CMAKE_BUILD_ARGS ?=
 DEBUG_BUILD_DIR ?= "./build/"
 RELEASE_BUILD_DIR ?= "./build-release/"
 VSAG_ENABLE_TESTS ?= OFF
@@ -106,10 +107,16 @@ test:                    ## Build and run unit tests.
 test-cmake:              ## Run focused CMake helper tests.
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/thirdparty_override_test.cmake
 
-.PHONY: asan
+.PHONY: asan configure-asan build-asan
 asan:                    ## Build with AddressSanitizer option.
+	$(MAKE) configure-asan
+	$(MAKE) build-asan
+
+configure-asan:
 	cmake ${VSAG_CMAKE_ARGS} -B${DEBUG_BUILD_DIR} -DCMAKE_BUILD_TYPE=Sanitize -DENABLE_ASAN=ON -DENABLE_TSAN=OFF -DENABLE_CCACHE=ON -DENABLE_TESTS=ON -DENABLE_MOCKIMPL=ON
-	cmake --build ${DEBUG_BUILD_DIR} --parallel ${COMPILE_JOBS}
+
+build-asan:
+	cmake --build ${DEBUG_BUILD_DIR} --parallel ${COMPILE_JOBS} -- ${CMAKE_BUILD_ARGS}
 
 .PHONY: test_asan
 test_asan: asan          ## Run unit tests with AddressSanitizer option.

--- a/scripts/collect_build_metrics.py
+++ b/scripts/collect_build_metrics.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Collect repeatable CMake, Ninja, and ccache build-performance metrics."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def elapsed_seconds(start_ns: int, end_ns: int) -> float:
+    return round((end_ns - start_ns) / 1_000_000_000, 3)
+
+
+def load_ccache_stats(text: str) -> dict[str, Any]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        values = {}
+        for line in text.splitlines():
+            fields = line.split("\t", 1)
+            if len(fields) == 2 and fields[1].isdigit():
+                values[fields[0]] = int(fields[1])
+        if not values:
+            return {"available": False, "raw": text.strip()}
+        return {
+            "available": True,
+            "cache_hit": values.get("direct_cache_hit", 0)
+            + values.get("preprocessed_cache_hit", 0),
+            "cache_miss": values.get("cache_miss", 0),
+            "raw": values,
+        }
+    stats = data.get("stats", data)
+    return {
+        "available": True,
+        "cache_hit": stats.get("cache_hit", stats.get("cache_hit_direct", 0)),
+        "cache_miss": stats.get("cache_miss", 0),
+        "raw": data,
+    }
+
+
+def read_compile_commands(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    commands = json.loads(path.read_text(encoding="utf-8"))
+    sources: dict[str, str] = {}
+    for entry in commands:
+        arguments = entry.get("arguments")
+        if arguments is None:
+            arguments = shlex.split(entry.get("command", ""))
+        try:
+            output = arguments[arguments.index("-o") + 1]
+        except (ValueError, IndexError):
+            output = entry.get("output")
+        if output:
+            sources[str(Path(output))] = entry.get("file", "")
+            sources[Path(output).name] = entry.get("file", "")
+    return sources
+
+
+def is_dependency_output(normalized: str) -> bool:
+    return normalized.startswith(("_deps/", "extern/", "hdf5", "openblas")) or any(
+        part in normalized for part in ("/_deps/", "/extern/", "/hdf5", "/openblas")
+    )
+
+
+def classify_edge(output: str, link_outputs: set[str] | None = None) -> str:
+    normalized = output.replace("\\", "/").lower()
+    if normalized.endswith((".o", ".obj")):
+        if is_dependency_output(normalized):
+            return "dependency_compile"
+        if normalized.startswith(("tests/", "mockimpl/")) or any(
+            part in normalized for part in ("/tests/", "test.dir/", "_test.dir/", "/mockimpl/")
+        ):
+            return "test_compile"
+        if normalized.startswith("src/cmakefiles/") or "/src/cmakefiles/" in normalized:
+            return "production_compile"
+        return "other_compile"
+    if is_dependency_output(normalized):
+        return "dependency_build"
+    if link_outputs and output in link_outputs:
+        return "link"
+    if normalized.endswith((".a", ".so", ".dylib", ".dll", ".exe")):
+        return "link"
+    return "other"
+
+
+def read_link_outputs(build_dir: Path) -> set[str]:
+    result = subprocess.run(
+        ["ninja", "-C", str(build_dir), "-t", "targets", "all"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    outputs = set()
+    for line in result.stdout.splitlines():
+        output, separator, rule = line.rpartition(": ")
+        if separator and "LINKER" in rule:
+            outputs.add(output)
+    return outputs
+
+
+def parse_ninja_log(
+    path: Path, compile_commands: dict[str, str], link_outputs: set[str] | None = None
+) -> dict[str, Any]:
+    categories: dict[str, dict[str, float | int]] = {}
+    translation_units: list[dict[str, Any]] = []
+    if not path.is_file():
+        return {"available": False, "categories": categories, "slowest_translation_units": []}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) < 4:
+            continue
+        try:
+            start_ms, end_ms = int(fields[0]), int(fields[1])
+        except ValueError:
+            continue
+        output = fields[3]
+        duration = max(0, end_ms - start_ms) / 1000
+        category = classify_edge(output, link_outputs)
+        current = categories.setdefault(category, {"edges": 0, "cumulative_seconds": 0.0})
+        current["edges"] = int(current["edges"]) + 1
+        current["cumulative_seconds"] = round(float(current["cumulative_seconds"]) + duration, 3)
+        if output.lower().endswith((".o", ".obj")):
+            source = compile_commands.get(output, compile_commands.get(Path(output).name, output))
+            translation_units.append(
+                {"source": source, "output": output, "seconds": round(duration, 3), "category": category}
+            )
+    translation_units.sort(key=lambda item: item["seconds"], reverse=True)
+    return {
+        "available": True,
+        "categories": categories,
+        "slowest_translation_units": translation_units[:20],
+    }
+
+
+def parse_peak_rss(path: Path) -> int | None:
+    if not path.is_file():
+        return None
+    match = re.search(
+        r"Maximum resident set size \(kbytes\):\s*(\d+)",
+        path.read_text(encoding="utf-8", errors="replace"),
+    )
+    return int(match.group(1)) if match else None
+
+
+def parse_ninja_stats(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    start = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.strip().startswith("metric") and "count" in line and "avg (us)" in line
+        ),
+        None,
+    )
+    if start is None:
+        return []
+    return [line for line in lines[start : start + 20] if line.strip()]
+
+
+class Collector:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.root = Path.cwd().resolve()
+        self.build_dir = (self.root / args.build_dir).resolve()
+        self.output_dir = (self.root / args.output_dir).resolve()
+        self.phases: list[dict[str, Any]] = []
+        self.failure_code = 0
+        if self.root not in self.build_dir.parents or self.build_dir == self.root:
+            raise ValueError("build directory must be a child of the repository")
+        if self.root not in self.output_dir.parents or self.output_dir == self.root:
+            raise ValueError("output directory must be a child of the repository")
+        if self.build_dir == self.output_dir or self.build_dir in self.output_dir.parents:
+            raise ValueError("output directory must not be inside the build directory")
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def run_logged(self, name: str, command: list[str]) -> dict[str, Any]:
+        log_path = self.output_dir / f"{name}.log"
+        time_path = self.output_dir / f"{name}.time.txt"
+        timed_command = command
+        time_binary = Path("/usr/bin/time")
+        if time_binary.is_file():
+            timed_command = [str(time_binary), "-v", "-o", str(time_path), *command]
+        started = time.monotonic_ns()
+        with log_path.open("w", encoding="utf-8") as log:
+            process = subprocess.Popen(
+                timed_command,
+                cwd=self.root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            assert process.stdout is not None
+            for line in process.stdout:
+                sys.stdout.write(line)
+                log.write(line)
+            return_code = process.wait()
+        finished = time.monotonic_ns()
+        phase = {
+            "name": name,
+            "command": command,
+            "elapsed_seconds": elapsed_seconds(started, finished),
+            "exit_code": return_code,
+            "peak_rss_kib": parse_peak_rss(time_path),
+            "ninja_stats": parse_ninja_stats(log_path),
+        }
+        self.phases.append(phase)
+        if return_code and not self.failure_code:
+            self.failure_code = return_code
+        return phase
+
+    def ccache(self, *arguments: str) -> dict[str, Any]:
+        result = subprocess.run(
+            ["ccache", *arguments], cwd=self.root, text=True, capture_output=True, check=False
+        )
+        if "--print-stats" in arguments:
+            return load_ccache_stats(result.stdout)
+        return {"exit_code": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+
+    def capture_build(self, name: str) -> None:
+        ninja_log = self.build_dir / ".ninja_log"
+        ninja_log.unlink(missing_ok=True)
+        self.ccache("--zero-stats")
+        phase = self.run_logged(
+            name,
+            [
+                "make",
+                "build-asan",
+                f"COMPILE_JOBS={self.args.jobs}",
+                "CMAKE_BUILD_ARGS=-d stats",
+            ],
+        )
+        captured_log = self.output_dir / f"{name}.ninja_log"
+        if ninja_log.is_file():
+            shutil.copy2(ninja_log, captured_log)
+        phase["ccache"] = self.ccache("--print-stats")
+        phase["ninja"] = parse_ninja_log(
+            captured_log,
+            read_compile_commands(self.build_dir / "compile_commands.json"),
+            read_link_outputs(self.build_dir),
+        )
+
+    def collect(self) -> int:
+        if self.build_dir.exists():
+            shutil.rmtree(self.build_dir)
+        if self.args.clear_ccache:
+            self.ccache("--clear")
+        self.ccache("--zero-stats")
+        configure = self.run_logged(
+            "configure",
+            ["make", "configure-asan", f"COMPILE_JOBS={self.args.jobs}"],
+        )
+        configure["ccache"] = self.ccache("--print-stats")
+        if not self.failure_code:
+            self.capture_build("cold_build")
+        if not self.failure_code:
+            self.run_logged(
+                "clean_for_warm_build",
+                ["cmake", "--build", str(self.build_dir), "--target", "clean"],
+            )
+            if not self.failure_code:
+                self.capture_build("warm_ccache_build")
+        if not self.failure_code:
+            self.capture_build("noop_incremental_build")
+        self.write_reports()
+        return self.failure_code
+
+    def write_reports(self) -> None:
+        report = {
+            "schema_version": 1,
+            "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "status": "failed" if self.failure_code else "success",
+            "base_sha": self.args.base_sha,
+            "commit_sha": self.args.commit_sha,
+            "configuration": {
+                "jobs": self.args.jobs,
+                "build_dir": str(self.build_dir.relative_to(self.root)),
+                "cold_ccache_cleared": self.args.clear_ccache,
+                "compiler": self.args.compiler,
+                "compiler_cache_key": self.args.compiler_cache_key,
+                "dependency_cache_key": self.args.dependency_cache_key,
+                "dependency_preparation_seconds": self.args.dependency_preparation_seconds,
+            },
+            "phases": self.phases,
+        }
+        (self.output_dir / "build-metrics.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        detailed = render_markdown(report, concise=False)
+        summary = render_markdown(report, concise=True)
+        (self.output_dir / "build-metrics.md").write_text(detailed, encoding="utf-8")
+        (self.output_dir / "job-summary.md").write_text(summary, encoding="utf-8")
+
+
+def metric(phase: dict[str, Any], category: str) -> float:
+    return float(
+        phase.get("ninja", {})
+        .get("categories", {})
+        .get(category, {})
+        .get("cumulative_seconds", 0)
+    )
+
+
+def render_markdown(report: dict[str, Any], concise: bool) -> str:
+    config = report["configuration"]
+    phases = {phase["name"]: phase for phase in report["phases"]}
+    lines = ["## Build performance metrics", ""]
+    lines.extend(
+        [
+            f"Status: **{report['status']}** · compiler: `{config['compiler']}` · parallel jobs: `{config['jobs']}`",
+            "",
+            "| Phase | Wall time | Peak RSS | ccache hits | ccache misses |",
+            "| --- | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for name, label in (
+        ("configure", "CMake configure"),
+        ("cold_build", "Cold build"),
+        ("warm_ccache_build", "Warm ccache rebuild"),
+        ("noop_incremental_build", "No-op incremental"),
+    ):
+        phase = phases.get(name)
+        if phase is None:
+            continue
+        ccache = phase.get("ccache", {})
+        peak = phase.get("peak_rss_kib")
+        peak_text = f"{peak / 1024:.1f} MiB" if peak is not None else "n/a"
+        lines.append(
+            f"| {label} | {phase['elapsed_seconds']:.3f} s | {peak_text} | "
+            f"{ccache.get('cache_hit', 'n/a')} | {ccache.get('cache_miss', 'n/a')} |"
+        )
+    lines.extend(
+        [
+            "",
+            f"Dependency source preparation: **{config['dependency_preparation_seconds']:.3f} s**",
+            "",
+            f"Compiler cache key: `{config['compiler_cache_key']}`  ",
+            f"Dependency cache key: `{config['dependency_cache_key']}`",
+            "",
+        ]
+    )
+    cold = phases.get("cold_build", {})
+    if cold:
+        lines.extend(
+            [
+                "Cold-build cumulative Ninja edge time (parallel edges overlap):",
+                "",
+                f"- Dependencies: {metric(cold, 'dependency_compile') + metric(cold, 'dependency_build'):.3f} s",
+                f"- VSAG production compile: {metric(cold, 'production_compile'):.3f} s",
+                f"- Test compile: {metric(cold, 'test_compile'):.3f} s",
+                f"- Link: {metric(cold, 'link'):.3f} s",
+                "",
+            ]
+        )
+    if concise:
+        lines.append("The `build-performance-metrics` artifact contains JSON, complete logs, Ninja statistics, and the slowest translation units.")
+        return "\n".join(lines) + "\n"
+    slowest = cold.get("ninja", {}).get("slowest_translation_units", [])
+    lines.extend(
+        [
+            "### Slowest translation units (cold build)",
+            "",
+            "| Translation unit | Category | Time |",
+            "| --- | --- | ---: |",
+        ]
+    )
+    for unit in slowest:
+        lines.append(f"| `{unit['source']}` | {unit['category']} | {unit['seconds']:.3f} s |")
+    for phase in report["phases"]:
+        if phase.get("ninja_stats"):
+            lines.extend(
+                [
+                    "",
+                    f"### Ninja scheduling statistics: {phase['name']}",
+                    "",
+                    "```text",
+                    *phase["ninja_stats"],
+                    "```",
+                ]
+            )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--output-dir", default="build-metrics")
+    parser.add_argument("--jobs", type=int, default=3)
+    parser.add_argument("--base-sha", default="")
+    parser.add_argument("--commit-sha", default="")
+    parser.add_argument("--compiler", default="unknown")
+    parser.add_argument("--compiler-cache-key", default="unknown")
+    parser.add_argument("--dependency-cache-key", default="unknown")
+    parser.add_argument("--dependency-preparation-seconds", type=float, default=0)
+    parser.add_argument("--clear-ccache", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    return Collector(parse_args()).collect()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_collect_build_metrics.py
+++ b/tests/scripts/test_collect_build_metrics.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Focused tests for the build-performance report parser."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "collect_build_metrics", ROOT / "scripts/collect_build_metrics.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+METRICS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(METRICS)
+
+
+class BuildMetricsTest(unittest.TestCase):
+    def test_parse_ninja_log_classifies_edges_and_sorts_translation_units(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            ninja_log = Path(directory) / ".ninja_log"
+            ninja_log.write_text(
+                "# ninja log v5\n"
+                "0\t2500\t0\tsrc/CMakeFiles/vsag.dir/index.cpp.o\thash\n"
+                "0\t900\t0\ttests/CMakeFiles/unittests.dir/test.cpp.o\thash\n"
+                "0\t500\t0\t_deps/fmt-build/CMakeFiles/fmt.dir/format.cc.o\thash\n"
+                "500\t1300\t0\thdf5-prefix/src/hdf5-stamp/hdf5-build\thash\n"
+                "2500\t2800\t0\tsrc/libvsag.so\thash\n",
+                encoding="utf-8",
+            )
+
+            result = METRICS.parse_ninja_log(
+                ninja_log, {"index.cpp.o": "src/index.cpp", "test.cpp.o": "tests/test.cpp"}
+            )
+
+        self.assertEqual(result["categories"]["production_compile"]["cumulative_seconds"], 2.5)
+        self.assertEqual(result["categories"]["test_compile"]["cumulative_seconds"], 0.9)
+        self.assertEqual(result["categories"]["dependency_compile"]["cumulative_seconds"], 0.5)
+        self.assertEqual(result["categories"]["dependency_build"]["cumulative_seconds"], 0.8)
+        self.assertEqual(result["categories"]["link"]["cumulative_seconds"], 0.3)
+        self.assertEqual(result["slowest_translation_units"][0]["source"], "src/index.cpp")
+
+    def test_rendered_summary_uses_real_newlines(self) -> None:
+        report = {
+            "status": "success",
+            "configuration": {
+                "compiler": "gcc",
+                "jobs": 3,
+                "dependency_preparation_seconds": 1.25,
+                "compiler_cache_key": "compiler-key",
+                "dependency_cache_key": "dependency-key",
+            },
+            "phases": [
+                {
+                    "name": "configure",
+                    "elapsed_seconds": 2.5,
+                    "peak_rss_kib": None,
+                    "ccache": {"cache_hit": 0, "cache_miss": 0},
+                }
+            ],
+        }
+
+        summary = METRICS.render_markdown(report, concise=True)
+
+        self.assertIn("\n| Phase | Wall time", summary)
+        self.assertNotIn("\\n", summary)
+        self.assertTrue(summary.endswith("\n"))
+
+    def test_ccache_json_supports_version_four_stats(self) -> None:
+        stats = METRICS.load_ccache_stats('{"stats":{"cache_hit":7,"cache_miss":2}}')
+
+        self.assertEqual(stats["cache_hit"], 7)
+        self.assertEqual(stats["cache_miss"], 2)
+
+    def test_ccache_machine_stats_support_ubuntu_version(self) -> None:
+        stats = METRICS.load_ccache_stats(
+            "direct_cache_hit\t5\npreprocessed_cache_hit\t2\ncache_miss\t3\n"
+        )
+
+        self.assertEqual(stats["cache_hit"], 7)
+        self.assertEqual(stats["cache_miss"], 3)
+
+    def test_collector_writes_json_markdown_and_summary_reports(self) -> None:
+        previous_directory = Path.cwd()
+        with tempfile.TemporaryDirectory() as directory:
+            try:
+                os.chdir(directory)
+                args = SimpleNamespace(
+                    build_dir="build",
+                    output_dir="metrics",
+                    jobs=3,
+                    base_sha="base",
+                    commit_sha="commit",
+                    compiler="gcc-12",
+                    compiler_cache_key="compiler-key",
+                    dependency_cache_key="dependency-key",
+                    dependency_preparation_seconds=1.25,
+                    clear_ccache=True,
+                )
+                collector = METRICS.Collector(args)
+                collector.phases = [
+                    {
+                        "name": "configure",
+                        "elapsed_seconds": 2.5,
+                        "peak_rss_kib": 1024,
+                        "ccache": {"cache_hit": 0, "cache_miss": 0},
+                    }
+                ]
+                collector.write_reports()
+
+                report = json.loads(Path("metrics/build-metrics.json").read_text())
+                summary = Path("metrics/job-summary.md").read_text()
+            finally:
+                os.chdir(previous_directory)
+
+        self.assertEqual(report["base_sha"], "base")
+        self.assertIn("\n| Phase | Wall time", summary)
+        self.assertTrue(summary.endswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change Type

- [x] Improvement/Refactor
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2776

## What Changed

- Split the existing ASan Make target into reusable configure and build phases without changing its build configuration.
- Measure dependency preparation, CMake configure, an isolated cold build, a warm-ccache rebuild, and a no-op incremental build in the existing Linux ASan job.
- Parse Ninja and ccache data for production/test/dependency/link timing, cache hits and misses, slow translation units, scheduling statistics, and peak RSS where GNU time is available.
- Upload detailed JSON, Markdown, raw timing, Ninja, and command logs for 14 days, and append a concise Markdown table to `GITHUB_STEP_SUMMARY` with real newlines.
- Collect metrics only; no regression thresholds are introduced.

Development started from freshly fetched `origin/main` at base SHA `81fefe7b30c63f1d47fcd62b9b235882a6d0c982`.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint` (no C++ source or header changes)
- [ ] `make test` (no production or test-binary changes)
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
make fmt
make test-cmake
python3 tests/scripts/test_collect_build_metrics.py
python3 -m py_compile scripts/collect_build_metrics.py tests/scripts/test_collect_build_metrics.py
PyYAML workflow parse and focused structure assertions
actionlint v1.7.12 .github/workflows/pr-ci.yml
git diff --check
```

All checks passed. The focused Python suite contains five tests covering Ninja classification, ccache formats, report-file generation, Markdown newlines, and summary rendering.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: the Linux ASan build job now publishes observational build metrics and performs one additional warm-cache rebuild plus a no-op build

## Performance and Concurrency Impact

- Performance impact: production runtime is unchanged; CI runtime increases by the warm-cache rebuild, while report storage is limited by a 14-day retention period
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed; this is CI-only instrumentation and uses GitHub's documented job-summary environment file

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert the single commit to restore the prior one-pass ASan build step

## Checklist

- [x] I have linked the relevant issue
- [x] I have added focused tests for report generation and parsing
- [x] I have considered API compatibility impact
- [x] I have considered documentation impact
- [x] My commit message follows project conventions
