### PR TITLE
perf(build): separate cached Release builds

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -24,14 +24,14 @@ jobs:
         run: pip3 install -r ./scripts/perf_reports/requirements.txt
       - name: Download Datasets
         run: bash ./scripts/download_annbench_datasets.sh
-      - name: Build Release
+      - name: Build Performance Release
         # Performance benchmarks already run against OpenBLAS (the default
         # backend). Use the pre-installed system OpenBLAS so the BLAS build
         # itself doesn't eat into the daily perf window.
-        run: EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON" make release VSAG_ENABLE_TOOLS=ON
+        run: EXTRA_DEFINED="-DUSE_SYSTEM_OPENBLAS=ON" make release-perf VSAG_ENABLE_TOOLS=ON
       - name: Run Perf - Recall 90%, 95%, 99%
         run:  |
-          ./build-release/tools/eval/eval_performance .github/perf-mini.yml
+          ./build-release-perf/tools/eval/eval_performance .github/perf-mini.yml
       - name: Send Report
         run:  |
           python3 scripts/perf_reports/dingding.py /tmp/github-perf.json || echo "send report to dingding failed"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,8 @@ test_asan_parallel: asan ## Run unit tests parallel with AddressSanitizer option
 test_tsan_parallel: tsan ## Run unit tests parallel with ThreadSanitizer option.
 ##
 ## ================ distribution ================
-release:                 ## Build vsag with release options.
+release:                 ## Build reproducible release/package output (ccache off by default).
+release-perf:            ## Build optimized output for iteration/benchmarks (ccache on by default).
 run-dist-tests:          ## Run distribution tests.
 dist-pre-cxx11-abi:      ## Build vsag with distribution options (pre C++11 ABI).
 dist-cxx11-abi:          ## Build vsag with distribution options (C++11 ABI).
@@ -82,6 +83,7 @@ dist-libcxx:             ## Build vsag using libc++.
 pyvsag:                  ## Build a specific Python version wheel. Usage: make pyvsag PY_VERSION=3.10
 pyvsag-all:              ## Build wheels for all supported versions.
 clean-release:           ## Clear build-release/ directory.
+clean-release-perf:      ## Clear build-release-perf/ directory.
 install:                 ## Build and install the release version of vsag.
 ```
 
@@ -90,7 +92,9 @@ Build target behavior:
 - `make debug` builds the default minimal configuration. It does not enable tests, examples, tools, Python bindings, or `mockimpl` unless they are explicitly turned on.
 - `make dev` builds the full developer configuration with tests, examples, tools, Python bindings, and `mockimpl` enabled.
 - `make test`, `make asan`, `make tsan`, and the related parallel test targets automatically enable tests and `mockimpl`.
-- `make release` follows the same minimal defaults as `make debug`. Enable optional components explicitly when needed, for example `make release VSAG_ENABLE_TOOLS=ON`.
+- `make release` is the reproducible release/package path. It uses the minimal configuration, Release optimization semantics, and disables ccache by default. Enable optional components explicitly when needed, for example `make release VSAG_ENABLE_TOOLS=ON`.
+- `make release-perf` uses the same Release optimization semantics and minimal configuration in `build-release-perf/`, but enables ccache by default for iterative development and benchmarking.
+- Override either cache default explicitly with `VSAG_ENABLE_CCACHE=ON` or `VSAG_ENABLE_CCACHE=OFF`.
 - Linux and macOS use the same dependency-script plus `make` entry points for the core C++ build. Use `./scripts/deps/install_deps.sh` first, then run the usual `make` target. The current macOS validation scope is `make debug`, `make release`, and `make test` on arm64; Python wheel packaging remains Linux-focused.
 
 ## CMake Build Options

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CMAKE_INSTALL_PREFIX ?= "/usr/local/"
 COMPILE_JOBS ?= 6
 DEBUG_BUILD_DIR ?= "./build/"
 RELEASE_BUILD_DIR ?= "./build-release/"
+PERF_RELEASE_BUILD_DIR ?= "./build-release-perf/"
 VSAG_ENABLE_TESTS ?= OFF
 VSAG_ENABLE_PYBINDS ?= OFF
 VSAG_ENABLE_TOOLS ?= OFF
@@ -105,6 +106,7 @@ test:                    ## Build and run unit tests.
 .PHONY: test-cmake
 test-cmake:              ## Run focused CMake helper tests.
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/thirdparty_override_test.cmake
+	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/release_build_modes_test.cmake
 
 .PHONY: asan
 asan:                    ## Build with AddressSanitizer option.
@@ -170,10 +172,18 @@ test_tsan_parallel: tsan ## Run unit tests parallel with ThreadSanitizer option.
 
 ##
 ## ================ distribution ================
+release dist-pre-cxx11-abi dist-cxx11-abi dist-libcxx: VSAG_ENABLE_CCACHE ?= OFF
+
 .PHONY: release
-release:                 ## Build vsag with release options.
-	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
+release:                 ## Build reproducible release/package output (ccache off by default).
+	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_CCACHE=${VSAG_ENABLE_CCACHE}
 	cmake --build ${RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
+
+.PHONY: release-perf
+release-perf: VSAG_ENABLE_CCACHE ?= ON
+release-perf:            ## Build optimized output for iteration/benchmarks (ccache on by default).
+	cmake ${VSAG_CMAKE_ARGS} -B${PERF_RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_CCACHE=${VSAG_ENABLE_CCACHE}
+	cmake --build ${PERF_RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
 
 .PHONY: run-dist-tests
 run-dist-tests:          ## Run distribution tests.
@@ -185,20 +195,20 @@ run-dist-tests:          ## Run distribution tests.
 .PHONY: dist-pre-cxx11-abi
 dist-pre-cxx11-abi:      ## Build vsag with distribution options.
 	echo "building dist-pre-cxx11-abi..."
-	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_INTEL_MKL=off -DENABLE_CXX11_ABI=off -DENABLE_LIBCXX=off -DENABLE_TESTS=ON -DENABLE_MOCKIMPL=ON
+	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_CCACHE=${VSAG_ENABLE_CCACHE} -DENABLE_INTEL_MKL=off -DENABLE_CXX11_ABI=off -DENABLE_LIBCXX=off -DENABLE_TESTS=ON -DENABLE_MOCKIMPL=ON
 	cmake --build ${RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
 	$(MAKE) run-dist-tests
 
 .PHONY: dist-cxx11-abi
 dist-cxx11-abi:          ## Build vsag with distribution options.
 	echo "building dist-cxx11-abi..."
-	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_INTEL_MKL=off -DENABLE_CXX11_ABI=on -DENABLE_LIBCXX=off -DENABLE_TESTS=ON -DENABLE_MOCKIMPL=ON
+	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_CCACHE=${VSAG_ENABLE_CCACHE} -DENABLE_INTEL_MKL=off -DENABLE_CXX11_ABI=on -DENABLE_LIBCXX=off -DENABLE_TESTS=ON -DENABLE_MOCKIMPL=ON
 	cmake --build ${RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
 	$(MAKE) run-dist-tests
 
 .PHONY: dist-libcxx
 dist-libcxx:             ## Build vsag using libc++.
-	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_LIBCXX=on
+	cmake ${VSAG_CMAKE_ARGS} -B${RELEASE_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DENABLE_CCACHE=${VSAG_ENABLE_CCACHE} -DENABLE_LIBCXX=on
 	cmake --build ${RELEASE_BUILD_DIR} --parallel ${COMPILE_JOBS}
 
 PY_VERSION ?= 3.10
@@ -216,6 +226,10 @@ pyvsag-all:              ## Build wheels for all supported versions. Usage: make
 .PHONY: clean-release
 clean-release:           ## Clear build-release/ directory.
 	rm -rf ${RELEASE_BUILD_DIR} && mkdir -p ${RELEASE_BUILD_DIR}
+
+.PHONY: clean-release-perf
+clean-release-perf:      ## Clear build-release-perf/ directory.
+	rm -rf ${PERF_RELEASE_BUILD_DIR} && mkdir -p ${PERF_RELEASE_BUILD_DIR}
 
 .PHONY: install
 install:                 ## Build and install the release version of vsag.

--- a/tests/cmake/release_build_modes_test.cmake
+++ b/tests/cmake/release_build_modes_test.cmake
@@ -1,0 +1,61 @@
+# Copyright 2026-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (NOT DEFINED VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+
+function (get_make_commands output_var)
+    execute_process (
+        COMMAND ${CMAKE_COMMAND} -E env --unset=VSAG_ENABLE_CCACHE
+                make --no-print-directory --dry-run ${ARGN}
+        WORKING_DIRECTORY "${VSAG_SOURCE_DIR}"
+        RESULT_VARIABLE make_result
+        OUTPUT_VARIABLE make_output
+        ERROR_VARIABLE make_error
+    )
+    if (NOT make_result EQUAL 0)
+        message (FATAL_ERROR "make ${ARGN} failed:\n${make_error}")
+    endif ()
+    set (${output_var} "${make_output}" PARENT_SCOPE)
+endfunction ()
+
+function (assert_command_contains commands expected)
+    string (FIND "${commands}" "${expected}" match_position)
+    if (match_position EQUAL -1)
+        message (FATAL_ERROR "Expected command fragment '${expected}' in:\n${commands}")
+    endif ()
+endfunction ()
+
+get_make_commands (release_commands release)
+assert_command_contains ("${release_commands}" "-B\"./build-release/\"")
+assert_command_contains ("${release_commands}" "-DCMAKE_BUILD_TYPE=Release")
+assert_command_contains ("${release_commands}" "-DENABLE_CCACHE=OFF")
+
+get_make_commands (perf_release_commands release-perf)
+assert_command_contains ("${perf_release_commands}" "-B\"./build-release-perf/\"")
+assert_command_contains ("${perf_release_commands}" "-DCMAKE_BUILD_TYPE=Release")
+assert_command_contains ("${perf_release_commands}" "-DENABLE_CCACHE=ON")
+
+get_make_commands (release_override_commands release VSAG_ENABLE_CCACHE=ON)
+assert_command_contains ("${release_override_commands}" "-DENABLE_CCACHE=ON")
+
+get_make_commands (perf_release_override_commands release-perf VSAG_ENABLE_CCACHE=OFF)
+assert_command_contains ("${perf_release_override_commands}" "-DENABLE_CCACHE=OFF")
+
+get_make_commands (distribution_commands dist-cxx11-abi)
+assert_command_contains ("${distribution_commands}" "-DCMAKE_BUILD_TYPE=Release")
+assert_command_contains ("${distribution_commands}" "-DENABLE_CCACHE=OFF")
+
+message (STATUS "Release build mode checks passed")


### PR DESCRIPTION
## Change Type

- [x] Improvement/Refactor
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2772

## What Changed

- Keep `make release` as the true release/package path: `CMAKE_BUILD_TYPE=Release` with ccache explicitly disabled by default.
- Add `make release-perf` in `build-release-perf/`: the same Release optimization semantics with ccache enabled by default for iterative development and benchmarks.
- Preserve explicit `VSAG_ENABLE_CCACHE=ON|OFF` overrides for both intents, and make all `dist-*` packaging targets explicitly cache-off by default.
- Move only the performance benchmark workflow to `make release-perf`; release packaging, compatibility, index generation, and lint workflows remain on the true release path.
- Add a focused CMake script test that inspects Make configure commands for build type, cache defaults, packaging behavior, separate build directories, and overrides.

## Test Evidence

- [x] Other (described below)

Test details:

```text
make test-cmake
-- Third-party pinned-variable tests passed
-- Release build mode checks passed

git diff --check
python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/performance.yml", encoding="utf-8"))'

Actual true-release configure cache:
CMAKE_BUILD_TYPE:STRING=Release
ENABLE_CCACHE:BOOL=OFF

Full performance Release build (GNU 11.4, Ninja, 48 requested jobs, isolated ccache):
First configure: 8.7 s
First compile: 1008 s
First total: about 1017 s
First ccache: 0 / 730 hits (0.00%)

Fresh rebuild at the identical build path with the same cache:
Second configure: 2.757 s
Second compile: 22.791 s
Second total: 25.548 s
Second ccache: 436 / 442 hits (98.64%)
```

The benchmark ran on a shared container that exposed 96 CPUs but advanced several template-heavy translation units effectively serially while another worktree benchmark was active. The cold and warm runs used the same source, compiler, options, dependency sources, build path, and requested parallelism. The timings demonstrate this environment only and are not presented as a general speedup guarantee.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: `make release` now explicitly resets ccache off; the new `make release-perf` is the cache-on iterative/benchmark path.

## Performance and Concurrency Impact

- Performance impact: repeated performance Release compilation can reuse ccache; production packaging remains cache-independent by default.
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] Updated docs:
  - [x] `DEVELOPMENT.md`
  - [x] Make help text

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit `300815fb81cffd5dd73790cfa0e016f4a097b7a5`.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added focused validation for the changed build behavior.
- [x] I have considered API compatibility impact.
- [x] I have updated docs for the workflow change.
- [x] My commit message follows project conventions.
