### PR TITLE
perf(build): narrow datacell Ninja job pool

### DIFF
--- a/src/datacell/CMakeLists.txt
+++ b/src/datacell/CMakeLists.txt
@@ -36,9 +36,6 @@ endif ()
 
 add_library (datacell OBJECT ${DATACELL_SRCS})
 target_link_libraries (datacell PRIVATE transform quantizer io attr coverage_config vsag_src_common)
-if (CMAKE_GENERATOR MATCHES "Ninja")
-    set_property (TARGET datacell PROPERTY JOB_POOL_COMPILE rabitq_split_factory_pool)
-endif ()
 
 if (ENABLE_TESTS)
     file (GLOB_RECURSE DATACELL_TESTS "*_test.cpp")

--- a/tests/cmake/datacell_job_pool_test.cmake
+++ b/tests/cmake/datacell_job_pool_test.cmake
@@ -1,0 +1,59 @@
+if (NOT DEFINED VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+if (NOT DEFINED VSAG_BUILD_DIR)
+    message (FATAL_ERROR "VSAG_BUILD_DIR is required")
+endif ()
+
+set (ninja_file "${VSAG_BUILD_DIR}/build.ninja")
+set (rules_file "${VSAG_BUILD_DIR}/CMakeFiles/rules.ninja")
+if (NOT EXISTS "${ninja_file}" OR NOT EXISTS "${rules_file}")
+    message (FATAL_ERROR "VSAG_BUILD_DIR must contain a Ninja build")
+endif ()
+
+file (READ "${ninja_file}" ninja_content)
+file (READ "${rules_file}" rules_content)
+
+function (assert_object_pool source target expect_pool)
+    set (object_path "src/datacell/CMakeFiles/${target}.dir/${source}.o")
+    string (FIND "${ninja_content}" "build ${object_path}:" block_start)
+    if (block_start EQUAL -1)
+        message (FATAL_ERROR "Ninja object rule not found: ${object_path}")
+    endif ()
+
+    string (SUBSTRING "${ninja_content}" ${block_start} -1 remaining_content)
+    string (FIND "${remaining_content}" "\n\n" block_length)
+    if (block_length EQUAL -1)
+        message (FATAL_ERROR "Ninja object rule is not terminated: ${object_path}")
+    endif ()
+    string (SUBSTRING "${remaining_content}" 0 ${block_length} object_rule)
+    string (FIND "${object_rule}" "pool = rabitq_split_factory_pool" pool_position)
+
+    if (expect_pool AND pool_position EQUAL -1)
+        message (FATAL_ERROR "Serial pool is missing from ${object_path}")
+    elseif (NOT expect_pool AND NOT pool_position EQUAL -1)
+        message (FATAL_ERROR "Ordinary datacell object uses the serial pool: ${object_path}")
+    endif ()
+endfunction ()
+
+set (rabitq_split_factory_sources
+     rabitq_split_datacell_factory_l2.cpp
+     rabitq_split_datacell_factory_ip.cpp
+     rabitq_split_datacell_factory_cosine.cpp)
+foreach (source IN LISTS rabitq_split_factory_sources)
+    assert_object_pool ("${source}" rabitq_split_datacell_factory TRUE)
+endforeach ()
+
+file (GLOB datacell_sources RELATIVE "${VSAG_SOURCE_DIR}/src/datacell"
+      "${VSAG_SOURCE_DIR}/src/datacell/*.cpp")
+list (FILTER datacell_sources EXCLUDE REGEX "_test\\.cpp$")
+list (REMOVE_ITEM datacell_sources ${rabitq_split_factory_sources})
+foreach (source IN LISTS datacell_sources)
+    assert_object_pool ("${source}" datacell FALSE)
+endforeach ()
+
+if (NOT rules_content MATCHES "pool rabitq_split_factory_pool\n  depth = 1")
+    message (FATAL_ERROR "The RaBitQ split factory pool must have capacity one")
+endif ()
+
+message (STATUS "Datacell Ninja job-pool assignments passed")


### PR DESCRIPTION
## What changed

- keep `rabitq_split_factory_pool=1` on the three memory-heavy metric-specific RaBitQ split factory translation units
- remove the serial pool from ordinary `datacell` objects
- add generated-Ninja validation covering every datacell compile edge and the pool capacity

The capacity remains fixed at one. VSAG has no existing convention for making a target-specific Ninja pool configurable, and the observed factory compilation memory cost supports retaining the conservative safeguard. Non-Ninja generators remain unaffected because the pool definition and assignment stay inside the existing Ninja guard.

## Validation

- base: freshly fetched `origin/main` at `81fefe7b30c63f1d47fcd62b9b235882a6d0c982`
- Ninja configure and focused `datacell rabitq_split_datacell_factory` build
- generated-Ninja assignment test: exactly the three RaBitQ split factory objects use the capacity-one pool; all 34 ordinary objects do not
- Unix Makefiles configure: no Ninja job-pool data generated
- `make fmt` with clang-format 15
- `git diff --check`

## Clean module benchmark

GCC 11.4, Debug, Ninja 1.10.1, ccache disabled, 96 logical CPUs, 503 GiB RAM. Dependencies were primed once; each sample deleted only the 37 datacell/factory objects. Peak RSS is the sampled aggregate for Ninja's process tree. These are single runs on a shared host, so they show the parallelism effect but are not presented as general build-performance guarantees.

| Requested parallelism | Before wall / datacell | After wall / datacell | Before peak RSS | After peak RSS |
| --- | ---: | ---: | ---: | ---: |
| `-j1` | 346.4 s / 346.4 s | 358.0 s / 358.0 s | 4.22 GB | 4.22 GB |
| `-j6` | 359.0 s / 359.0 s | 136.8 s / 136.7 s | 4.22 GB | 5.67 GB |
| `-j96` | 342.6 s / 342.6 s | 109.2 s / 109.1 s | 4.22 GB | 9.01 GB |

The slowest translation unit in every sample was `flatten_interface.cpp` (103.8–109.1 s). Other slow ordinary units were the bucket IO variants (roughly 19–27 s). The unchanged `-j1` behavior is the expected control; higher parallelism no longer serializes ordinary datacell compilation, while the three split factory compilations remain mutually exclusive.

Fixes: #2767
