### PR TITLE
refactor(build): reuse library object files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ if (ENABLE_EXAMPLES)
 endif ()
 if (ENABLE_TESTS)
     add_subdirectory (tests)
+    # Preserve the shared target's existing private definition and apply it to the common
+    # compilation. Production sources do not branch on ENABLE_TESTS.
+    target_compile_definitions (vsag_objects PRIVATE ENABLE_TESTS)
     target_compile_definitions (vsag PRIVATE ENABLE_TESTS)
 endif ()
 

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ test:                    ## Build and run unit tests.
 test-cmake:              ## Run focused CMake helper tests.
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/thirdparty_override_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/release_build_modes_test.cmake
+	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/object_library_test.cmake
 
 .PHONY: asan configure-asan build-asan
 asan:                    ## Build with AddressSanitizer option.

--- a/mockimpl/CMakeLists.txt
+++ b/mockimpl/CMakeLists.txt
@@ -26,13 +26,22 @@ set (MOCK_SRCS
   ../src/json_wrapper.cpp
 )
 
-add_library (vsag_mockimpl SHARED ${MOCK_SRCS})
-add_library (vsag_mockimpl_static STATIC ${MOCK_SRCS})
+add_library (vsag_mockimpl_objects OBJECT ${MOCK_SRCS})
+add_library (vsag_mockimpl SHARED $<TARGET_OBJECTS:vsag_mockimpl_objects>)
+add_library (vsag_mockimpl_static STATIC $<TARGET_OBJECTS:vsag_mockimpl_objects>)
 
+target_link_libraries (vsag_mockimpl_objects PRIVATE
+                       roaring fmt::fmt-header-only simd vsag_src_common)
 target_link_libraries (vsag_mockimpl PRIVATE roaring fmt::fmt-header-only simd vsag_src_common)
 target_link_libraries (vsag_mockimpl_static PRIVATE roaring fmt::fmt-header-only simd vsag_src_common)
+add_dependencies (vsag_mockimpl_objects version_mockimpl roaring)
 add_dependencies (vsag_mockimpl version_mockimpl roaring)
 add_dependencies (vsag_mockimpl_static version_mockimpl roaring)
+
+set_target_properties (vsag_mockimpl_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+# Match the definition CMake supplies when these sources belong directly to the shared target.
+# No mock implementation source branches on this internal definition.
+target_compile_definitions (vsag_mockimpl_objects PRIVATE vsag_mockimpl_EXPORTS)
 
 set_target_properties (vsag_mockimpl_static PROPERTIES OUTPUT_NAME "vsag_mockimpl")
 install (TARGETS vsag_mockimpl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,17 +35,28 @@ list (FILTER CPP_INDEX_SRCS EXCLUDE REGEX "_test.cpp")
 
 set (VSAG_SRCS ${CPP_SRCS} ${CPP_INDEX_SRCS})
 
-add_library (vsag SHARED ${VSAG_SRCS})
-add_library (vsag_static STATIC ${VSAG_SRCS})
+set (VSAG_DEP_LIBS antlr4-autogen antlr4-runtime simd io quantizer storage utils factory analyzer
+     datacell rabitq_split_datacell_factory ${IMPL_LIBS} ${ALGORITHM_LIBS} attr pthread m dl
+     ${BLAS_LIBRARIES})
+
+add_library (vsag_objects OBJECT ${VSAG_SRCS})
+add_library (vsag SHARED $<TARGET_OBJECTS:vsag_objects>)
+add_library (vsag_static STATIC $<TARGET_OBJECTS:vsag_objects>)
 
 # Trigger build-time regeneration of src/version.h before vsag's TUs compile.
+add_dependencies (vsag_objects version)
 add_dependencies (vsag version)
 add_dependencies (vsag_static version)
 
-set_target_properties (vsag PROPERTIES
+set_target_properties (vsag_objects vsag PROPERTIES
     C_VISIBILITY_PRESET default
     CXX_VISIBILITY_PRESET default
     VISIBILITY_INLINES_HIDDEN OFF)
+set_target_properties (vsag_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# CMake adds this definition when sources compile directly in the shared target. Keep the
+# common object compilation equivalent. No VSAG source branches on this internal definition.
+target_compile_definitions (vsag_objects PRIVATE vsag_EXPORTS)
 
 if (ENABLE_SOVERSION)
     set_target_properties (vsag PROPERTIES
@@ -63,10 +74,6 @@ foreach (_lib vsag vsag_static)
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 endforeach ()
 
-set (VSAG_DEP_LIBS antlr4-autogen antlr4-runtime simd io quantizer storage utils factory analyzer
-      datacell rabitq_split_datacell_factory ${IMPL_LIBS} ${ALGORITHM_LIBS} attr pthread m dl
-      ${BLAS_LIBRARIES})
-
 # `vsag_src_common` aggregates third-party include paths and link
 # dependencies (fmt::fmt, nlohmann_json::nlohmann_json, tsl::robin_map, and
 # several internal *_headers INTERFACE libraries) that vsag's own source
@@ -77,6 +84,7 @@ set (VSAG_DEP_LIBS antlr4-autogen antlr4-runtime simd io quantizer storage utils
 # directly via add_subdirectory(), since some of those targets transitively
 # rely on, e.g., <nlohmann/json.hpp>. Wrapping the link in BUILD_INTERFACE
 # is what gives us both: PUBLIC propagation in-tree, no leakage on install.
+target_link_libraries (vsag_objects PRIVATE vsag_src_common ${VSAG_DEP_LIBS} coverage_config)
 target_link_libraries (vsag
     PUBLIC $<BUILD_INTERFACE:vsag_src_common>
     PRIVATE ${VSAG_DEP_LIBS} coverage_config)
@@ -88,16 +96,20 @@ if (TARGET vsag_openmp)
     foreach (_vsag_openmp_target IN ITEMS algorithm analyzer cluster factory hgraph odescent pyramid)
         vsag_link_openmp_private (${_vsag_openmp_target})
     endforeach ()
+    vsag_link_openmp_private (vsag_objects)
     vsag_link_openmp_private (vsag)
     vsag_link_openmp_private (vsag_static)
 endif ()
 
 maybe_add_dependencies (vsag antlr4 roaring)
 maybe_add_dependencies (vsag_static antlr4 roaring)
+maybe_add_dependencies (vsag_objects antlr4 roaring)
 if (VSAG_BLAS_BACKEND STREQUAL "openblas")
+    maybe_add_dependencies (vsag_objects openblas)
     maybe_add_dependencies (vsag openblas)
     maybe_add_dependencies (vsag_static openblas)
 elseif (VSAG_BLAS_BACKEND STREQUAL "mkl")
+    maybe_add_dependencies (vsag_objects mkl)
     maybe_add_dependencies (vsag mkl)
     maybe_add_dependencies (vsag_static mkl)
 endif ()

--- a/tests/cmake/object_library_test.cmake
+++ b/tests/cmake/object_library_test.cmake
@@ -1,0 +1,62 @@
+# Copyright 2024-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (NOT VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+
+file (READ "${VSAG_SOURCE_DIR}/src/CMakeLists.txt" _vsag_cmake)
+file (READ "${VSAG_SOURCE_DIR}/mockimpl/CMakeLists.txt" _mock_cmake)
+
+function (require_text content text description)
+    string (FIND "${content}" "${text}" _position)
+    if (_position EQUAL -1)
+        message (FATAL_ERROR "Missing ${description}")
+    endif ()
+endfunction ()
+
+function (reject_text content text description)
+    string (FIND "${content}" "${text}" _position)
+    if (NOT _position EQUAL -1)
+        message (FATAL_ERROR "Found ${description}")
+    endif ()
+endfunction ()
+
+require_text ("${_vsag_cmake}" [=[add_library (vsag_objects OBJECT ${VSAG_SRCS})]=]
+              "single VSAG source-owning OBJECT target")
+require_text ("${_vsag_cmake}" [=[add_library (vsag SHARED $<TARGET_OBJECTS:vsag_objects>)]=]
+              "shared VSAG object consumption")
+require_text ("${_vsag_cmake}"
+              [=[add_library (vsag_static STATIC $<TARGET_OBJECTS:vsag_objects>)]=]
+              "static VSAG object consumption")
+reject_text ("${_vsag_cmake}" [=[add_library (vsag SHARED ${VSAG_SRCS})]=]
+             "duplicate shared VSAG source compilation")
+reject_text ("${_vsag_cmake}" [=[add_library (vsag_static STATIC ${VSAG_SRCS})]=]
+             "duplicate static VSAG source compilation")
+
+require_text ("${_mock_cmake}"
+              [=[add_library (vsag_mockimpl_objects OBJECT ${MOCK_SRCS})]=]
+              "single mock source-owning OBJECT target")
+require_text ("${_mock_cmake}"
+              [=[add_library (vsag_mockimpl SHARED $<TARGET_OBJECTS:vsag_mockimpl_objects>)]=]
+              "shared mock object consumption")
+require_text ("${_mock_cmake}"
+              [=[add_library (vsag_mockimpl_static STATIC $<TARGET_OBJECTS:vsag_mockimpl_objects>)]=]
+              "static mock object consumption")
+reject_text ("${_mock_cmake}" [=[add_library (vsag_mockimpl SHARED ${MOCK_SRCS})]=]
+             "duplicate shared mock source compilation")
+reject_text ("${_mock_cmake}" [=[add_library (vsag_mockimpl_static STATIC ${MOCK_SRCS})]=]
+             "duplicate static mock source compilation")
+
+message (STATUS "VSAG and mock source lists each have one object-library owner")


### PR DESCRIPTION
## Summary

- compile common VSAG sources once in the internal `vsag_objects` target
- compile mock implementation sources once in `vsag_mockimpl_objects`
- preserve existing shared/static target names, link interfaces, visibility, PIC, ABI, generated headers, and install/export behavior
- add a focused CMake ownership check preventing source lists from returning to shared/static targets

Fixes: #2770

## Compatibility and validation

- compile rules owned by the four library targets/object owners: 44 before, 22 after
- comparable clean four-library build: 430.56 s before, 418.31 s after (single observations; no generalized speedup claim)
- normalized source compiler flags and exported shared symbol sets match the baseline
- shared/static VSAG and mock libraries build successfully
- full unit, eval monitor, and mock tests pass
- install plus downstream `find_package(vsag CONFIG REQUIRED)` consumer passes
- clang-format 15 and `git diff --check` pass

The shared-only export definitions and existing test-only definition are applied to the common objects. Repository sources do not branch on these definitions, so shared/static reuse is semantically equivalent.