### PR TITLE
fix(ci): harden changed-source lint filtering

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -84,6 +84,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Test changed-source lint filter
+        run: python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py'
       - name: Prepare Host
         run: |
           sudo env VSAG_INSTALL_INTEL_MKL=OFF bash ./scripts/deps/install_deps_ubuntu.sh
@@ -118,36 +120,31 @@ jobs:
           make asan VSAG_ENABLE_EXAMPLES=ON VSAG_ENABLE_TOOLS=ON COMPILE_JOBS=3
       - name: Get changed source files
         id: changed-srcs
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git fetch origin ${{ github.base_ref }} --depth=1
-          if ! CHANGED=$(git diff --name-only origin/${{ github.base_ref }}..HEAD -- 'src/**/*.cpp' ':(exclude)src/**/*_test.cpp'); then
-            echo "Failed to determine changed source files" >&2
+          git fetch origin "$BASE_BRANCH" --depth=1
+          if ! PATTERN=$(python3 ./scripts/linters/changed_source_filter.py "origin/$BASE_BRANCH"); then
+            echo "Failed to build changed-source lint filter" >&2
             exit 1
-          fi
-          PATTERN=""
-          if [ -n "$CHANGED" ]; then
-            if ! PATTERN=$(CHANGED="$CHANGED" python3 - <<'PY'
-          import os
-          import re
-
-          changed = os.environ["CHANGED"].splitlines()
-          print("|".join(f"{re.escape(path)}$" for path in changed))
-          PY
-            ); then
-              echo "Failed to build changed-source lint filter" >&2
-              exit 1
-            fi
-            if [ -z "$PATTERN" ]; then
-              echo "Changed source files were found, but the lint filter is empty" >&2
-              exit 1
-            fi
           fi
           echo "pattern=$PATTERN" >> "$GITHUB_OUTPUT"
       - name: Run Lint
+        id: changed_source_lint
         if: steps.changed-srcs.outputs.pattern != ''
         run: |
           ./scripts/linters/run-clang-tidy-15.sh -p build/ -use-color -source-filter '^.*vsag\/src.*(?<!_test)\.cpp$$' -j 4 '${{ steps.changed-srcs.outputs.pattern }}'
+      - name: Verify changed-source lint execution
+        if: always() && steps.changed-srcs.outcome == 'success'
+        env:
+          LINT_PATTERN: ${{ steps.changed-srcs.outputs.pattern }}
+          LINT_OUTCOME: ${{ steps.changed_source_lint.outcome }}
+        run: |
+          if [ -n "$LINT_PATTERN" ] && [ "$LINT_OUTCOME" != "success" ]; then
+            echo "Changed sources were found, but lint outcome was: $LINT_OUTCOME" >&2
+            exit 1
+          fi
       - name: Clean
         run: |
           find ./build -type f -name "*.o" -exec rm -f {} +

--- a/scripts/linters/changed_source_filter.py
+++ b/scripts/linters/changed_source_filter.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+
+
+def get_changed_sources(base: str, head: str) -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "-z",
+            f"{base}..{head}",
+            "--",
+            "src/**/*.cpp",
+            ":(exclude)src/**/*_test.cpp",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return [path.decode("utf-8") for path in result.stdout.split(b"\0") if path]
+
+
+def build_filter(paths: Sequence[str]) -> str:
+    return "|".join(f"{re.escape(path)}$" for path in paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a clang-tidy file filter for changed production C++ sources."
+    )
+    parser.add_argument("base", help="Base Git revision")
+    parser.add_argument("head", nargs="?", default="HEAD", help="Head Git revision")
+    args = parser.parse_args()
+
+    try:
+        paths = get_changed_sources(args.base, args.head)
+    except subprocess.CalledProcessError as error:
+        print(f"Failed to determine changed source files: {error}", file=sys.stderr)
+        return 1
+
+    if paths:
+        print(f"Linting {len(paths)} changed source file(s):", file=sys.stderr)
+        for path in paths:
+            print(f"  {path}", file=sys.stderr)
+    else:
+        print("No changed production C++ source files to lint.", file=sys.stderr)
+
+    pattern = build_filter(paths)
+    if paths and not pattern:
+        print("Changed source files were found, but the lint filter is empty.", file=sys.stderr)
+        return 1
+
+    print(pattern)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linters/test_changed_source_filter.py
+++ b/scripts/linters/test_changed_source_filter.py
@@ -1,0 +1,64 @@
+import re
+import subprocess
+import unittest
+from unittest import mock
+
+import changed_source_filter
+
+
+class ChangedSourceFilterTest(unittest.TestCase):
+    def test_build_filter_returns_empty_pattern_for_no_sources(self):
+        self.assertEqual(changed_source_filter.build_filter([]), "")
+
+    def test_build_filter_escapes_paths_and_anchors_them(self):
+        paths = [
+            "src/factory/factory.cpp",
+            "src/storage/file+[draft].cpp",
+        ]
+
+        pattern = changed_source_filter.build_filter(paths)
+
+        self.assertIsNotNone(re.search(pattern, "/workspace/src/factory/factory.cpp"))
+        self.assertIsNotNone(re.search(pattern, "/workspace/src/storage/file+[draft].cpp"))
+        self.assertIsNone(re.search(pattern, "/workspace/src/factory/factory.cpp.tmp"))
+        self.assertIsNone(re.search(pattern, "/workspace/src/storage/fileeeeeed.cpp"))
+
+    @mock.patch("changed_source_filter.subprocess.run")
+    def test_get_changed_sources_uses_nul_delimited_git_diff(self, run):
+        run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=b"src/factory/factory.cpp\0src/storage/tlv_section.cpp\0",
+        )
+
+        paths = changed_source_filter.get_changed_sources("origin/main", "HEAD")
+
+        self.assertEqual(
+            paths,
+            ["src/factory/factory.cpp", "src/storage/tlv_section.cpp"],
+        )
+        run.assert_called_once_with(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "-z",
+                "origin/main..HEAD",
+                "--",
+                "src/**/*.cpp",
+                ":(exclude)src/**/*_test.cpp",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+
+    @mock.patch("changed_source_filter.subprocess.run")
+    def test_get_changed_sources_propagates_git_failure(self, run):
+        run.side_effect = subprocess.CalledProcessError(128, ["git", "diff"])
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            changed_source_filter.get_changed_sources("origin/main", "HEAD")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- move changed-source discovery and regex generation into a tested Python helper
- use NUL-delimited `git diff` output and propagate discovery failures
- fail the job when changed sources exist but the lint step does not succeed
- run focused regression tests before the expensive X86 build setup

## Scope

PR CI continues to lint only production `.cpp` files directly modified by the PR. Header-induced translation-unit changes and full-repository linting remain intentionally out of scope.

## Testing

- `python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py' -v`
- historical-commit integration check found the expected seven changed production sources
- workflow YAML parse check
- `git diff --check`

Fixes: #2432
