### PR TITLE
fix(ci): trust exact workspace for lint Git calls

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Trust exact workspace for Git tooling
+        run: ./scripts/ci/configure-git-safe-directory.sh
       - name: Prepare FetchContent Sources
         uses: ./.github/actions/prepare-fetchcontent
       - name: Cache ExternalProject Archives

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -84,8 +84,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Trust exact workspace for Git tooling
+        run: ./scripts/ci/configure-git-safe-directory.sh
       - name: Test changed-source lint filter
-        run: python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py'
+        run: |
+          python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py'
+          python3 -m unittest tests/scripts/configure_git_safe_directory_test.py
       - name: Prepare Host
         run: |
           sudo env VSAG_INSTALL_INTEL_MKL=OFF bash ./scripts/deps/install_deps_ubuntu.sh
@@ -168,7 +172,6 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.base_ref }}
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch origin "$BASE_BRANCH" --depth=1
           if ! PATTERN=$(python3 ./scripts/linters/changed_source_filter.py "origin/$BASE_BRANCH"); then
             echo "Failed to build changed-source lint filter" >&2

--- a/scripts/ci/configure-git-safe-directory.sh
+++ b/scripts/ci/configure-git-safe-directory.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+    echo "ERROR: Git workspace trust may only be configured in GitHub Actions." >&2
+    exit 1
+fi
+
+if [[ -z "${GITHUB_WORKSPACE:-}" || "$GITHUB_WORKSPACE" != /* ]]; then
+    echo "ERROR: GITHUB_WORKSPACE must be an absolute path." >&2
+    exit 1
+fi
+
+# actions/checkout records this path while using a temporary HOME. Container
+# steps run with the job HOME instead, so persist the same exact path there.
+git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/tests/scripts/configure_git_safe_directory_test.py
+++ b/tests/scripts/configure_git_safe_directory_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / "scripts/ci/configure-git-safe-directory.sh"
+
+
+class ConfigureGitSafeDirectoryTest(unittest.TestCase):
+    def run_helper(
+        self, workspace: Path, *, github_actions: str | None = "true"
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["GITHUB_WORKSPACE"] = str(workspace)
+        if github_actions is None:
+            environment.pop("GITHUB_ACTIONS", None)
+        else:
+            environment["GITHUB_ACTIONS"] = github_actions
+        return subprocess.run(
+            [str(HELPER)],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+
+    def test_refuses_to_change_local_developer_config(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_helper(Path(directory), github_actions=None)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("may only be configured in GitHub Actions", result.stderr)
+
+    def test_requires_an_absolute_workspace_path(self):
+        result = self.run_helper(Path("relative/workspace"))
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("GITHUB_WORKSPACE must be an absolute path", result.stderr)
+
+    def test_makes_only_the_exact_workspace_safe(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            workspace = temporary / "workspace"
+            home = temporary / "home"
+            workspace.mkdir()
+            home.mkdir()
+            subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+            (workspace / "tracked.txt").write_text("tracked\n")
+            subprocess.run(["git", "-C", str(workspace), "add", "tracked.txt"], check=True)
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "GITHUB_ACTIONS": "true",
+                    "GITHUB_WORKSPACE": str(workspace),
+                    "GIT_CONFIG_GLOBAL": str(home / ".gitconfig"),
+                    "GIT_CONFIG_NOSYSTEM": "1",
+                    "GIT_TEST_ASSUME_DIFFERENT_OWNER": "1",
+                }
+            )
+
+            unsafe = subprocess.run(
+                ["git", "-C", str(workspace), "ls-files"],
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            configured = subprocess.run(
+                [str(HELPER)],
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            safe = subprocess.run(
+                ["git", "-C", str(workspace), "ls-files"],
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            safe_directories = subprocess.run(
+                ["git", "config", "--global", "--get-all", "safe.directory"],
+                text=True,
+                capture_output=True,
+                check=True,
+                env=environment,
+            )
+
+        self.assertEqual(unsafe.returncode, 128)
+        self.assertIn("dubious ownership", unsafe.stderr)
+        self.assertEqual(configured.returncode, 0, configured.stderr)
+        self.assertEqual(safe.returncode, 0, safe.stderr)
+        self.assertEqual(safe.stdout, "tracked.txt\n")
+        self.assertEqual(safe_directories.stdout.splitlines(), [str(workspace)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2795

## What Changed

- add a GitHub-Actions-only helper that trusts exactly `GITHUB_WORKSPACE` in the active step's global Git config
- invoke it after checkout for both container full lint and PR changed-source lint, where checkout's temporary `HOME` config is not visible
- cover the unsafe-before/safe-after behavior and ensure no wildcard or additional path is trusted

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
python3 -m unittest tests/scripts/configure_git_safe_directory_test.py tests/scripts/check_struct_names_test.py
python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py'
# 10 focused/helper tests passed

./scripts/linters/check-struct-names.py
# Checked 936 C/C++ files

python3 ./scripts/linters/changed_source_filter.py origin/main
# No changed production C++ source files to lint

clang-tidy-15 --verify-config
# No config errors detected

actionlint .github/workflows/lint.yml .github/workflows/pr-ci.yml
python3 -c 'import yaml; ...'
bash -n scripts/ci/configure-git-safe-directory.sh
make fmt
git diff --check
```

The regression test uses an isolated global Git config and Git's different-owner test mode. It confirms `git ls-files` returns 128 with `dubious ownership` before the helper, succeeds afterward, and records only the exact workspace.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: CI lint steps trust only their exact `GITHUB_WORKSPACE`; local developer Git configuration is unchanged

## Performance and Concurrency Impact

- Performance impact: none
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the single commit to restore the previous workflow behavior

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed (not applicable; internal CI only)
- [x] My commit messages follow project conventions
