### PR TITLE
fix(hgraph): traverse non-finite distance bridges on 1.0

### DIFF
--- a/src/algorithm/hgraph/hgraph_build.cpp
+++ b/src/algorithm/hgraph/hgraph_build.cpp
@@ -467,7 +467,9 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
     for (auto j = this->route_graphs_.size() - 1; j > level; --j) {
         result = search_one_graph(
             data, route_graphs_[j], flatten_codes, param, (VisitedListPtr) nullptr, nullptr);
-        param.ep = result->Top().second;
+        if (not result->Empty()) {
+            param.ep = result->Top().second;
+        }
     }
 
     param.ef = this->ef_construct_;
@@ -500,13 +502,17 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
             }
         }
         LockGuard cur_lock(neighbors_mutex_, inner_id);
-        mutually_connect_new_element(inner_id,
-                                     filtered_result,
-                                     this->bottom_graph_,
-                                     flatten_codes,
-                                     neighbors_mutex_,
-                                     allocator_,
-                                     alpha_);
+        if (not filtered_result->Empty()) {
+            mutually_connect_new_element(inner_id,
+                                         filtered_result,
+                                         this->bottom_graph_,
+                                         flatten_codes,
+                                         neighbors_mutex_,
+                                         allocator_,
+                                         alpha_);
+        } else {
+            bottom_graph_->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
+        }
     } else {
         LockGuard cur_lock(neighbors_mutex_, inner_id);
         bottom_graph_->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
@@ -530,13 +536,17 @@ HGraph::graph_add_one(const void* data, int level, InnerIdType inner_id) {
                 }
             }
             LockGuard cur_lock(neighbors_mutex_, inner_id);
-            mutually_connect_new_element(inner_id,
-                                         filtered_result,
-                                         route_graphs_[j],
-                                         flatten_codes,
-                                         neighbors_mutex_,
-                                         allocator_,
-                                         alpha_);
+            if (not filtered_result->Empty()) {
+                mutually_connect_new_element(inner_id,
+                                             filtered_result,
+                                             route_graphs_[j],
+                                             flatten_codes,
+                                             neighbors_mutex_,
+                                             allocator_,
+                                             alpha_);
+            } else {
+                route_graphs_[j]->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));
+            }
         } else {
             LockGuard cur_lock(neighbors_mutex_, inner_id);
             route_graphs_[j]->InsertNeighborsById(inner_id, Vector<InnerIdType>(allocator_));

--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -454,7 +454,9 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
         auto result = this->search_one_graph(
             raw_query, this->route_graphs_[i], this->basic_flatten_codes_, search_param, vt, &ctx);
-        search_param.ep = result->Top().second;
+        if (not result->Empty()) {
+            search_param.ep = result->Top().second;
+        }
     }
 
     FilterPtr ft = this->create_search_filter(request.filter_, params.use_extra_info_filter);

--- a/src/impl/searcher/CMakeLists.txt
+++ b/src/impl/searcher/CMakeLists.txt
@@ -19,6 +19,7 @@ set (SEARCHER_SRC
     basic_searcher.h
     parallel_searcher.cpp
     parallel_searcher.h
+    searcher_utils.h
 )
 
 add_library (searcher OBJECT ${SEARCHER_SRC})

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -24,6 +24,7 @@
 #include "impl/filter/iterator_filter.h"
 #include "impl/heap/standard_heap.h"
 #include "impl/reasoning/search_reasoning.h"
+#include "impl/searcher/searcher_utils.h"
 #include "utils/filter_search_skip_strategy.h"
 #include "vsag/allocator.h"
 
@@ -177,8 +178,10 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                 flatten->Query(&cur_dist, computer, &cur_inner_id, 1, ctx);
                 // Sign convention: top_candidates stores positive distances (nearest = smallest);
                 // candidate_set is a max-heap, so distances are negated (nearest = largest, popped first).
-                top_candidates->Push(cur_dist, cur_inner_id);
-                candidate_set->Push(-cur_dist, cur_inner_id);
+                if (is_result_distance_eligible(cur_dist)) {
+                    top_candidates->Push(cur_dist, cur_inner_id);
+                }
+                candidate_set->Push(traversal_priority(cur_dist), cur_inner_id);
                 if constexpr (mode == InnerSearchMode::RANGE_SEARCH) {
                     if (cur_dist > inner_search_param.radius and not top_candidates->Empty()) {
                         top_candidates->Pop();
@@ -205,11 +208,12 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         } else {
             flatten->Query(&dist, computer, &ep, 1, ctx);
         }
-        if (not is_id_allowed || is_id_allowed->CheckValid(ep)) {
+        if (is_result_distance_eligible(dist) and
+            (not is_id_allowed || is_id_allowed->CheckValid(ep))) {
             top_candidates->Push(dist, ep);
             lower_bound = top_candidates->Top().first;
         }
-        candidate_set->Push(-dist, ep);
+        candidate_set->Push(traversal_priority(dist), ep);
         vl->Set(ep);
     }
 
@@ -276,14 +280,14 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                     rabitq_lower_bound_candidates->emplace_back(lower_bound_dists[i], cur_id);
                 }
             }
-            if (top_candidates->Size() < ef || lower_bound > dist ||
+            if (not std::isfinite(dist) || top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == RANGE_SEARCH && dist <= inner_search_param.radius)) {
                 if (!iter_ctx->CheckPoint(cur_id)) {
                     continue;
                 }
-                candidate_set->Push(-dist, cur_id);
+                candidate_set->Push(traversal_priority(dist), cur_id);
                 flatten->Prefetch(candidate_set->Top().second);
-                if (id_allowed) {
+                if (is_result_distance_eligible(dist) and id_allowed) {
                     top_candidates->Push(dist, cur_id);
                 }
 
@@ -381,7 +385,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         flatten->Query(&dist, computer, &ep, 1, ctx);
     }
     ++dist_cmp;
-    if (check_func(ep)) {
+    if (is_result_distance_eligible(dist) and check_func(ep)) {
         top_candidates->Push(dist, ep);
         lower_bound = top_candidates->Top().first;
     }
@@ -390,7 +394,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             top_candidates->Pop();
         }
     }
-    candidate_set->Push(-dist, ep);
+    candidate_set->Push(traversal_priority(dist), ep);
     vl->Set(ep);
 
     while (not candidate_set->Empty()) {
@@ -474,11 +478,11 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                     rabitq_lower_bound_candidates->emplace_back(lower_bound_dists[i], cur_id);
                 }
             }
-            if (top_candidates->Size() < ef || lower_bound > dist ||
+            if (not std::isfinite(dist) || top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == RANGE_SEARCH && dist <= inner_search_param.radius)) {
-                candidate_set->Push(-dist, cur_id);
+                candidate_set->Push(traversal_priority(dist), cur_id);
                 //                flatten->Prefetch(candidate_set->Top().second);
-                if (check_func(cur_id)) {
+                if (is_result_distance_eligible(dist) and check_func(cur_id)) {
                     top_candidates->Push(dist, cur_id);
                 } else if (reasoning != nullptr) {
                     reasoning->RecordFilterReject(cur_id);
@@ -486,7 +490,7 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
                 if (inner_search_param.consider_duplicate) {
                     const auto duplicate_ids = graph->GetDuplicateIds(cur_id);
                     for (const auto& item : duplicate_ids) {
-                        if (check_func(item)) {
+                        if (is_result_distance_eligible(dist) and check_func(item)) {
                             top_candidates->Push(dist, item);
                         }
                     }

--- a/src/impl/searcher/basic_searcher_test.cpp
+++ b/src/impl/searcher/basic_searcher_test.cpp
@@ -15,6 +15,8 @@
 
 #include "basic_searcher.h"
 
+#include <cmath>
+#include <limits>
 #include <set>
 #include <vector>
 
@@ -24,6 +26,57 @@
 #include "unittest.h"
 #include "utils/visited_list.h"
 using namespace vsag;
+
+TEST_CASE("BasicSearcher traverses through a non-finite-distance bridge",
+          "[ut][BasicSearcher][nonfinite]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 1;
+    common.allocator_ = allocator;
+    common.metric_ = MetricType::METRIC_TYPE_L2SQR;
+
+    constexpr const char* param_temp = R"({{"type": "{}"}})";
+    auto quantizer_param = QuantizerParameter::GetQuantizerParameterByJson(
+        JsonType::Parse(fmt::format(param_temp, "fp32")));
+    auto io_param =
+        IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
+    auto flatten =
+        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+            quantizer_param, io_param, common);
+    flatten->SetQuantizer(
+        std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>>(1, allocator.get()));
+    flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));
+
+    const auto bridge_value =
+        GENERATE(std::numeric_limits<float>::max(), std::numeric_limits<float>::quiet_NaN());
+    std::vector<float> vectors = {
+        10.0F, bridge_value, bridge_value, bridge_value, bridge_value, 1.0F};
+    std::vector<InnerIdType> ids = {0, 1, 2, 3, 4, 5};
+    flatten->Train(vectors.data(), ids.size());
+    flatten->BatchInsertVector(vectors.data(), ids.size(), ids.data());
+
+    auto graph = std::make_shared<MockGraphDataCell>(
+        std::vector<std::vector<InnerIdType>>{{1}, {2}, {3}, {4}, {5}, {}});
+    auto pool = std::make_shared<VisitedListPool>(1, allocator.get(), ids.size(), allocator.get());
+    InnerSearchParam param;
+    param.ep = 0;
+    param.ef = 2;
+    param.topk = 2;
+    float query = 0.0F;
+    auto visited = pool->TakeOne();
+    QueryContext* ctx = nullptr;
+    auto result =
+        BasicSearcher(common).Search(graph, flatten, visited, &query, param, LabelTablePtr{}, ctx);
+    pool->ReturnOne(visited);
+
+    bool found_target = false;
+    while (not result->Empty()) {
+        REQUIRE_FALSE(std::isnan(result->Top().first));
+        found_target = found_target or result->Top().second == 5;
+        result->Pop();
+    }
+    REQUIRE(found_target);
+}
 
 TEST_CASE("Basic Usage for GraphDataCell (adapter of hnsw)", "[ut][GraphDataCell]") {
     uint32_t M = 32;

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -24,6 +24,7 @@
 
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/searcher/searcher_utils.h"
 #include "utils/filter_search_skip_strategy.h"
 #include "utils/spsc_queue.h"
 
@@ -176,7 +177,7 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
     } else {
         flatten->Query(&dist, computer, &ep, 1, ctx);
     }
-    if (check_func(ep)) {
+    if (is_result_distance_eligible(dist) and check_func(ep)) {
         top_candidates->Push(dist, ep);
         lower_bound = top_candidates->Top().first;
     }
@@ -188,7 +189,7 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
     if (dist < THRESHOLD_ERROR) {
         inner_search_param.duplicate_id = ep;
     }
-    candidate_set->Push(-dist, ep);
+    candidate_set->Push(traversal_priority(dist), ep);
     vl->Set(ep);
 
     auto num_threads = inner_search_param.parallel_search_thread_count - 1;
@@ -320,16 +321,16 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
             if (dist < THRESHOLD_ERROR) {
                 inner_search_param.duplicate_id = cur_id;
             }
-            if (top_candidates->Size() < ef || lower_bound > dist ||
+            if (not std::isfinite(dist) || top_candidates->Size() < ef || lower_bound > dist ||
                 (mode == RANGE_SEARCH && dist <= inner_search_param.radius)) {
-                candidate_set->Push(-dist, cur_id);
-                if (check_func(cur_id)) {
+                candidate_set->Push(traversal_priority(dist), cur_id);
+                if (is_result_distance_eligible(dist) and check_func(cur_id)) {
                     top_candidates->Push(dist, cur_id);
                 }
                 if (inner_search_param.consider_duplicate) {
                     const auto duplicate_ids = graph->GetDuplicateIds(cur_id);
                     for (const auto& item : duplicate_ids) {
-                        if (check_func(item)) {
+                        if (is_result_distance_eligible(dist) and check_func(item)) {
                             top_candidates->Push(dist, item);
                         }
                     }

--- a/src/impl/searcher/parallel_searcher_test.cpp
+++ b/src/impl/searcher/parallel_searcher_test.cpp
@@ -15,9 +15,64 @@
 
 #include "parallel_searcher.h"
 
+#include <cmath>
+#include <limits>
+#include <vector>
+
 #include "searcher_test.h"
 #include "unittest.h"
 using namespace vsag;
+
+TEST_CASE("ParallelSearcher traverses through a non-finite-distance bridge",
+          "[ut][ParallelSearcher][nonfinite]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 1;
+    common.allocator_ = allocator;
+    common.metric_ = MetricType::METRIC_TYPE_L2SQR;
+
+    constexpr const char* param_temp = R"({{"type": "{}"}})";
+    auto quantizer_param = QuantizerParameter::GetQuantizerParameterByJson(
+        JsonType::Parse(fmt::format(param_temp, "fp32")));
+    auto io_param =
+        IOParameter::GetIOParameterByJson(JsonType::Parse(fmt::format(param_temp, "memory_io")));
+    auto flatten =
+        std::make_shared<FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>, MemoryIO>>(
+            quantizer_param, io_param, common);
+    flatten->SetQuantizer(
+        std::make_shared<FP32Quantizer<MetricType::METRIC_TYPE_L2SQR>>(1, allocator.get()));
+    flatten->SetIO(std::make_unique<MemoryIO>(allocator.get()));
+
+    const auto bridge_value =
+        GENERATE(std::numeric_limits<float>::max(), std::numeric_limits<float>::quiet_NaN());
+    std::vector<float> vectors = {
+        10.0F, bridge_value, bridge_value, bridge_value, bridge_value, 1.0F};
+    std::vector<InnerIdType> ids = {0, 1, 2, 3, 4, 5};
+    flatten->Train(vectors.data(), ids.size());
+    flatten->BatchInsertVector(vectors.data(), ids.size(), ids.data());
+
+    auto graph = std::make_shared<MockGraphDataCell>(
+        std::vector<std::vector<InnerIdType>>{{1}, {2}, {3}, {4}, {5}, {}});
+    auto pool = std::make_shared<VisitedListPool>(1, allocator.get(), ids.size(), allocator.get());
+    InnerSearchParam param;
+    param.ep = 0;
+    param.ef = 2;
+    param.topk = 2;
+    param.parallel_search_thread_count = 2;
+    float query = 0.0F;
+    auto visited = pool->TakeOne();
+    auto result = ParallelSearcher(common, SafeThreadPool::FactoryDefaultThreadPool())
+                      .Search(graph, flatten, visited, &query, param);
+    pool->ReturnOne(visited);
+
+    bool found_target = false;
+    while (not result->Empty()) {
+        REQUIRE_FALSE(std::isnan(result->Top().first));
+        found_target = found_target or result->Top().second == 5;
+        result->Pop();
+    }
+    REQUIRE(found_target);
+}
 
 TEST_CASE("Parallel search with HNSW", "[ut][ParallelSearcher]") {
     // data attr

--- a/src/impl/searcher/searcher_utils.h
+++ b/src/impl/searcher/searcher_utils.h
@@ -1,0 +1,34 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+namespace vsag {
+
+inline bool
+is_result_distance_eligible(float distance) {
+    return not std::isnan(distance);
+}
+
+inline float
+traversal_priority(float distance) {
+    // Non-finite nodes can still connect the entry point to valid candidates. Give them a
+    // deterministic priority so NaN does not violate the heap's ordering requirements.
+    return std::isfinite(distance) ? -distance : std::numeric_limits<float>::max();
+}
+
+}  // namespace vsag

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -1702,6 +1702,39 @@ HGRAPH_PR_DAILY_CASE("HGraph Search with Dirty Vector",
                      "[ft][search][hgraph]",
                      TestHGraphSearchWithDirtyVector)
 
+TEST_CASE("HGraph build tolerates empty non-finite graph probes",
+          "[ft][hgraph][build][nonfinite]") {
+    const auto params = R"({
+        "dtype":"float32", "metric_type":"l2", "dim":64,
+        "index_param":{"base_quantization_type":"fp32","max_degree":16,
+        "ef_construction":32,"use_reorder":false}
+    })";
+    auto index = vsag::Factory::CreateIndex("hgraph", params).value();
+    constexpr int64_t count = 128;
+    std::vector<float> vectors(count * 64, std::numeric_limits<float>::quiet_NaN());
+    std::vector<int64_t> ids(count);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto base = vsag::Dataset::Make();
+    base->NumElements(count)
+        ->Dim(64)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->Owner(false);
+    REQUIRE(index->Build(base).has_value());
+
+    std::iota(ids.begin(), ids.end(), count);
+    REQUIRE(index->Add(base).has_value());
+
+    std::vector<float> query_vector(64, 0.0F);
+    auto query = vsag::Dataset::Make();
+    query->NumElements(1)->Dim(64)->Float32Vectors(query_vector.data())->Owner(false);
+    for (uint64_t i = 0; i < 4; ++i) {
+        auto result = index->KnnSearch(query, 1, R"({"hgraph":{"ef_search":8}})");
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == 0);
+    }
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
                              "HGraph Search with Sparse Vector",
                              "[ft][concurrent][hgraph]") {


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2732

## What Changed

- Propagate the non-finite HGraph search semantics from merged PR #2734 to the `1.0` implementation.
- Traverse NaN and overflow-to-Inf bridge nodes with a deterministic heap priority while excluding NaN distances from results.
- Cover both BasicSearcher and ParallelSearcher with focused NaN/Inf bridge regressions.
- Keep the existing `1.0` parallel-worker synchronization unchanged because it already waits on every future.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (focused validation below)

Test details:

```text
# Before the production fix
build/tests/unittests '*Searcher traverses through a non-finite-distance bridge' --reporter compact
2 test cases failed; finite targets were missed and NaN results were returned (exit 42).

# After the production fix
cmake --build build --target unittests --parallel 4
build/tests/unittests '*Searcher traverses through a non-finite-distance bridge' --reporter compact
All tests passed (12 assertions in 2 test cases).

build/tests/unittests '[ut][BasicSearcher],[ut][ParallelSearcher]' --reporter compact
All tests passed (243441 assertions in 6 test cases).

cmake --build build --target functests --parallel 4
build/tests/functests '(PR) HGraph Search with Dirty Vector' --reporter compact --rng-seed 2734
All tests passed (566 assertions in 1 test case).

build/tests/functests 'HGraph build tolerates empty non-finite graph probes' --reporter compact --rng-seed 2734
All tests passed (10 assertions in 1 test case); repeated successfully under five seeds.

clang-format-15 --dry-run --Werror <changed C++ files>
git diff --check
Both passed.
```

## Compatibility Impact

- API/ABI compatibility: no public API or ABI change.
- Behavior changes: HGraph search can traverse non-finite bridge nodes and no longer returns NaN distances.

## Performance and Concurrency Impact

- Performance impact: one finite/NaN classification on candidate admission; no data-structure or allocation change.
- Concurrency/thread-safety impact: none; the existing future wait behavior is preserved.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

No public API, parameter, or workflow changed.

## Risk and Rollback

- Risk level: low; the change is limited to candidate/result admission in HGraph searchers.
- Rollback plan: revert commit `52b0c36e1b76ad0480642891154602c649554403`.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for the bug fix.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed (not applicable).
- [x] My commit message follows project conventions.