### PR TITLE
perf(hgraph): optimize RaBitQ split search hot path

### DIFF
--- a/src/algorithm/hgraph/hgraph_search.cpp
+++ b/src/algorithm/hgraph/hgraph_search.cpp
@@ -22,6 +22,7 @@
 #include "hgraph.h"  // IWYU pragma: keep
 #include "impl/filter/iterator_filter.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/query_computer_pool.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "utils/search_threshold.h"
 #include "utils/util_functions.h"
@@ -33,12 +34,6 @@ make_empty_dataset_with_stats(const SearchStatistics& stats) {
     auto dataset_result = DatasetImpl::MakeEmptyDataset();
     dataset_result->Statistics(stats.Dump());
     return dataset_result;
-}
-
-static DatasetPtr
-make_empty_dataset_with_stats() {
-    SearchStatistics stats;
-    return make_empty_dataset_with_stats(stats);
 }
 
 DatasetPtr
@@ -80,7 +75,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
     }
 
     if (GetNumElements() == 0) {
-        return DatasetImpl::MakeEmptyDataset();
+        return make_empty_dataset_with_stats(stats);
     }
     this->validate_knn_args(query, k);
 
@@ -107,7 +102,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
         auto cur_count = this->total_count_.load();
 
         if (cur_count == 0) {
-            return make_empty_dataset_with_stats();
+            return make_empty_dataset_with_stats(stats);
         }
         auto* new_ctx = new IteratorFilterContext();
         if (auto ret = new_ctx->init(cur_count, params.ef_search, ctx.alloc); not ret.has_value()) {
@@ -120,6 +115,8 @@ HGraph::KnnSearch(const DatasetPtr& query,
 
     auto* iter_filter_ctx = static_cast<IteratorFilterContext*>(iter_ctx);
     const auto* query_data = get_data(query);
+    QueryComputerPool query_computer_pool(query_data, &stats);
+    ctx.computer_pool = &query_computer_pool;
     // Note: brute_force_threshold is intentionally not applied here. The
     // iterator KnnSearch API pages results across multiple calls via
     // iter_filter_ctx; a single brute-force sweep would either need to drive
@@ -143,7 +140,7 @@ HGraph::KnnSearch(const DatasetPtr& query,
             search_param.is_inner_id_allowed = nullptr;
             search_param.enable_rabitq_one_bit_search = params.rabitq_one_bit_search;
             if (search_param.ep == INVALID_ENTRY_POINT) {
-                return make_empty_dataset_with_stats();
+                return make_empty_dataset_with_stats(stats);
             }
             if (iter_filter_ctx->IsFirstUsed()) {
                 ScopedDistancePhase routing_phase(ctx, DistanceEvaluationPhase::ROUTING);
@@ -282,7 +279,10 @@ HGraph::search_one_graph(const void* query,
         visited_list->Reset();
     }
     DistHeapPtr result = nullptr;
-    if (inner_search_param.parallel_search_thread_count > 1) {
+    const bool parallel_search_requested = inner_search_param.parallel_search_thread_count > 1;
+    const bool has_parallel_search_executor =
+        this->thread_pool_ != nullptr and this->parallel_searcher_ != nullptr;
+    if (parallel_search_requested and has_parallel_search_executor) {
         result = this->parallel_searcher_->Search(graph,
                                                   flatten,
                                                   visited_list,
@@ -292,6 +292,9 @@ HGraph::search_one_graph(const void* query,
                                                   ctx,
                                                   rabitq_lower_bound_candidates);
     } else {
+        if (parallel_search_requested and ctx != nullptr and ctx->stats != nullptr) {
+            ctx->stats->parallel_search_fallback_count.fetch_add(1, std::memory_order_relaxed);
+        }
         result = this->searcher_->Search(graph,
                                          flatten,
                                          visited_list,
@@ -317,6 +320,10 @@ HGraph::search_one_graph(const void* query,
                          QueryContext* ctx,
                          DistanceRecordVector* rabitq_lower_bound_candidates) const {
     auto visited_list = this->pool_->TakeOne();
+    if (inner_search_param.parallel_search_thread_count > 1 and ctx != nullptr and
+        ctx->stats != nullptr) {
+        ctx->stats->parallel_search_fallback_count.fetch_add(1, std::memory_order_relaxed);
+    }
     auto result = this->searcher_->Search(graph,
                                           flatten,
                                           visited_list,
@@ -366,7 +373,8 @@ HGraph::brute_force_search(const void* query,
         return result;
     }
 
-    auto computer = flatten->FactoryComputer(query);
+    auto computer_lease = AcquireQueryComputer(flatten, query, ctx);
+    const auto& computer = computer_lease.computer;
 
     constexpr InnerIdType brute_force_batch_size = 64;
     Vector<InnerIdType> batch_ids(brute_force_batch_size, alloc);
@@ -475,9 +483,17 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     }
     const auto element_count = GetNumElements();
     if (element_count == 0) {
-        return make_empty_dataset_with_stats();
+        return make_empty_dataset_with_stats(stats);
     }
     k = std::min(k, element_count);
+    const auto* raw_query = use_custom_distance ? nullptr : get_data(query);
+    QueryComputerPool query_computer_pool(raw_query, &stats);
+    if (not use_custom_distance) {
+        ctx.computer_pool = &query_computer_pool;
+    }
+    if (this->entry_point_id_ == INVALID_ENTRY_POINT) {
+        return make_empty_dataset_with_stats(stats);
+    }
 
     // Setup reasoning context (KNN only)
     std::shared_ptr<ReasoningContext> reasoning_ctx;
@@ -499,16 +515,12 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         reasoning_ctx->InitializeExpectedTargets(expected_labels_vec, label_to_inner_id);
 
         FlattenInterfacePtr precise_flatten = nullptr;
+        ComputerLease computer_lease;
         ComputerInterfacePtr computer = nullptr;
         if (not use_custom_distance) {
-            precise_flatten = this->basic_flatten_codes_;
-            if (use_reorder_) {
-                precise_flatten = this->high_precise_codes_;
-            }
-            if (create_new_raw_vector_) {
-                precise_flatten = this->raw_vector_;
-            }
-            computer = precise_flatten->FactoryComputer(get_data(query));
+            precise_flatten = this->get_precise_codes();
+            computer_lease = AcquireQueryComputer(precise_flatten, raw_query, &ctx);
+            computer = computer_lease.computer;
         }
         for (const auto& pair : label_to_inner_id) {
             float dist = 0.0F;
@@ -537,10 +549,6 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     search_param.distance_batch_func = request.distance_batch_func_;
     search_param.distance_batch_size = request.distance_batch_size_;
 
-    if (search_param.ep == INVALID_ENTRY_POINT) {
-        return make_empty_dataset_with_stats();
-    }
-
     struct HGraphVisitedListGuard {
         std::shared_ptr<VisitedListPool> pool;
         VisitedListPtr visited_list;
@@ -560,7 +568,6 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
     HGraphVisitedListGuard vt_guard{this->pool_, this->pool_->TakeOne()};
     auto& vt = vt_guard.visited_list;
 
-    const auto* raw_query = use_custom_distance ? nullptr : get_data(query);
     ctx.distance_phase = DistanceEvaluationPhase::ROUTING;
     for (auto i = static_cast<int64_t>(this->route_graphs_.size() - 1); i >= 0; --i) {
         auto result = this->search_one_graph(
@@ -727,7 +734,12 @@ HGraph::SearchWithRequest(const SearchRequest& request) const {
         }
 
         const auto flatten = use_custom_distance ? nullptr : this->get_precise_codes();
-        const auto computer = use_custom_distance ? nullptr : flatten->FactoryComputer(raw_query);
+        ComputerLease computer_lease;
+        ComputerInterfacePtr computer = nullptr;
+        if (not use_custom_distance) {
+            computer_lease = AcquireQueryComputer(flatten, raw_query, &ctx);
+            computer = computer_lease.computer;
+        }
         Filter* attribute_filter = nullptr;
         if (not search_param.executors.empty() and search_param.executors[0] != nullptr) {
             search_param.executors[0]->Clear();

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -38,6 +38,7 @@
 #include "index_common_param.h"
 #include "quantization/rabitq_quantization/rabitq_quantizer.h"
 #include "quantization/transform_quantization/transform_quantizer.h"
+#include "rabitq_split_datacell.h"
 #include "unittest.h"
 
 using namespace vsag;
@@ -163,6 +164,52 @@ TEST_CASE("FlattenDataCell only reports a stride for contiguous raw data",
     uint64_t row_stride = 123;
     REQUIRE(flatten->TryGetContiguousRawFloatData(&row_stride) == nullptr);
     REQUIRE(row_stride == 0);
+}
+
+TEST_CASE("RaBitQSplitDataCell adapts prefetch bytes to split record sizes",
+          "[ut][RaBitQSplitDataCell]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto param = std::make_shared<FlattenDataCellParameter>();
+    param->FromJson(JsonType::Parse(R"({
+        "codes_type": "rabitq_split",
+        "io_params": {"type": "memory_io"},
+        "quantization_params": {
+            "type": "rabitq",
+            "rabitq_version": "split",
+            "rabitq_bits_per_dim_query": 32,
+            "rabitq_bits_per_dim_base": 8,
+            "rabitq_bits_per_dim_filter": 1
+        }
+    })"));
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.dim_ = 960;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+
+    auto flatten = FlattenInterface::MakeInstance(param, common_param);
+    using SplitCell = RaBitQSplitDataCell<MetricType::METRIC_TYPE_L2SQR, MemoryIO, MemoryIO>;
+    auto split_cell = std::dynamic_pointer_cast<SplitCell>(flatten);
+    REQUIRE(split_cell != nullptr);
+    REQUIRE(split_cell->one_bit_code_size_ == 132);
+    REQUIRE(split_cell->supplement_code_size_ == 860);
+    REQUIRE(split_cell->GetOneBitPrefetchBytes() == 64);
+    REQUIRE(split_cell->GetSupplementPrefetchBytes() == 64);
+
+    UnorderedMap<std::string, float> runtime_params(allocator.get());
+    runtime_params[PREFETCH_DEPTH_CODE] = 16;
+    REQUIRE(split_cell->SetRuntimeParameters(runtime_params));
+    REQUIRE(split_cell->GetOneBitPrefetchBytes() == 3 * 64);
+    REQUIRE(split_cell->GetSupplementPrefetchBytes() == 14 * 64);
+
+    runtime_params[PREFETCH_DEPTH_CODE] = 2;
+    REQUIRE(split_cell->SetRuntimeParameters(runtime_params));
+    REQUIRE(split_cell->GetOneBitPrefetchBytes() == 2 * 64);
+    REQUIRE(split_cell->GetSupplementPrefetchBytes() == 2 * 64);
+
+    runtime_params[PREFETCH_DEPTH_CODE] = 0;
+    REQUIRE(split_cell->SetRuntimeParameters(runtime_params));
+    REQUIRE(split_cell->GetOneBitPrefetchBytes() == 0);
+    REQUIRE(split_cell->GetSupplementPrefetchBytes() == 0);
 }
 
 TEST_CASE("RaBitQSplitDataCell direct split compute", "[ut][RaBitQSplitDataCell]") {

--- a/src/datacell/rabitq_split_datacell.h
+++ b/src/datacell/rabitq_split_datacell.h
@@ -493,6 +493,7 @@ public:
         this->optimized_build_scalar_layout_ = build_codes;
         this->optimized_build_code_sums_ = std::move(code_sums);
         this->optimized_build_record_size_ = this->bottom_quantizer().GetScalarCodeSize();
+        this->refresh_prefetch_bytes();
         this->optimized_build_context_ = context;
         this->optimized_build_active_ = true;
         return true;
@@ -594,6 +595,7 @@ public:
         this->optimized_build_scalar_layout_.reset();
         this->optimized_build_code_sums_.reset();
         this->optimized_build_record_size_ = 0;
+        this->refresh_prefetch_bytes();
         this->optimized_build_context_ = {};
     }
 
@@ -603,6 +605,7 @@ public:
         this->optimized_build_scalar_layout_.reset();
         this->optimized_build_code_sums_.reset();
         this->optimized_build_record_size_ = 0;
+        this->refresh_prefetch_bytes();
         this->optimized_build_context_ = {};
     }
 
@@ -715,10 +718,30 @@ public:
     void
     Prefetch(InnerIdType id) override {
         if (this->optimized_build_active_) {
-            this->optimized_build_scalar_layout_->Prefetch(id, this->optimized_build_record_size_);
+            this->optimized_build_scalar_layout_->Prefetch(id,
+                                                           this->optimized_build_prefetch_bytes_);
             return;
         }
         this->prefetch_one_bit(id);
+    }
+
+    bool
+    SetRuntimeParameters(const UnorderedMap<std::string, float>& new_params) override {
+        const bool changed = FlattenInterface::SetRuntimeParameters(new_params);
+        if (new_params.find(PREFETCH_DEPTH_CODE) != new_params.end()) {
+            this->refresh_prefetch_bytes();
+        }
+        return changed;
+    }
+
+    [[nodiscard]] uint64_t
+    GetOneBitPrefetchBytes() const {
+        return this->one_bit_prefetch_bytes_;
+    }
+
+    [[nodiscard]] uint64_t
+    GetSupplementPrefetchBytes() const {
+        return this->supplement_prefetch_bytes_;
     }
 
     void
@@ -965,6 +988,9 @@ public:
     std::string supplement_io_type_{};
     bool optimized_build_active_{false};
     uint64_t optimized_build_record_size_{0};
+    uint64_t one_bit_prefetch_bytes_{0};
+    uint64_t supplement_prefetch_bytes_{0};
+    uint64_t optimized_build_prefetch_bytes_{0};
 
 private:
     BottomQuantizer&
@@ -1066,6 +1092,26 @@ private:
         this->supplement_code_size_ = this->bottom_quantizer().GetSupplementCodeSize();
         this->x_bit_layout_->SetCodeSize(one_bit_code_size_);
         this->supplement_layout_->SetCodeSize(supplement_code_size_);
+        this->refresh_prefetch_bytes();
+    }
+
+    [[nodiscard]] static uint64_t
+    calculate_prefetch_bytes(uint64_t record_size, uint32_t max_cache_lines) {
+        constexpr uint64_t cache_line_size = 64;
+        const uint64_t record_cache_lines =
+            record_size / cache_line_size +
+            static_cast<uint64_t>(record_size % cache_line_size != 0);
+        return std::min<uint64_t>(record_cache_lines, max_cache_lines) * cache_line_size;
+    }
+
+    void
+    refresh_prefetch_bytes() {
+        this->one_bit_prefetch_bytes_ =
+            calculate_prefetch_bytes(this->one_bit_code_size_, this->prefetch_depth_code_);
+        this->supplement_prefetch_bytes_ =
+            calculate_prefetch_bytes(this->supplement_code_size_, this->prefetch_depth_code_);
+        this->optimized_build_prefetch_bytes_ = calculate_prefetch_bytes(
+            this->optimized_build_record_size_, this->prefetch_depth_code_);
     }
 
     void
@@ -1140,12 +1186,13 @@ private:
                                      const InnerIdType* idx,
                                      InnerIdType id_count) const {
         for (uint32_t i = 0; i < this->prefetch_stride_code_ and i < id_count; ++i) {
-            this->optimized_build_scalar_layout_->Prefetch(idx[i], this->prefetch_depth_code_ * 64);
+            this->optimized_build_scalar_layout_->Prefetch(idx[i],
+                                                           this->optimized_build_prefetch_bytes_);
         }
         for (InnerIdType i = 0; i < id_count; ++i) {
             if (i + this->prefetch_stride_code_ < id_count) {
-                this->optimized_build_scalar_layout_->Prefetch(idx[i + this->prefetch_stride_code_],
-                                                               this->prefetch_depth_code_ * 64);
+                this->optimized_build_scalar_layout_->Prefetch(
+                    idx[i + this->prefetch_stride_code_], this->optimized_build_prefetch_bytes_);
             }
             bool need_release = false;
             const auto* base_code =
@@ -1171,12 +1218,12 @@ private:
 
     void
     prefetch_one_bit(InnerIdType id) {
-        this->x_bit_layout_->Prefetch(id, this->prefetch_depth_code_ * 64);
+        this->x_bit_layout_->Prefetch(id, this->one_bit_prefetch_bytes_);
     }
 
     void
     prefetch_supplement(InnerIdType id) {
-        this->supplement_layout_->Prefetch(id, this->prefetch_depth_code_ * 64);
+        this->supplement_layout_->Prefetch(id, this->supplement_prefetch_bytes_);
     }
 
     void

--- a/src/impl/query_computer_pool.h
+++ b/src/impl/query_computer_pool.h
@@ -1,0 +1,119 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <utility>
+
+#include "datacell/flatten_interface.h"
+#include "query_context.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+struct ComputerLease {
+    FlattenInterfacePtr owner;
+    ComputerInterfacePtr computer;
+    const void* query{nullptr};
+
+    void
+    Validate(const FlattenInterfacePtr& expected_owner, const void* expected_query) const {
+        if (owner == nullptr or computer == nullptr or owner.get() != expected_owner.get() or
+            query != expected_query) {
+            throw VsagException(ErrorType::INTERNAL_ERROR, "invalid query computer lease");
+        }
+    }
+};
+
+inline void
+RecordQueryComputerCreation(SearchStatistics* stats) {
+    if (stats != nullptr) {
+        stats->query_computer_count.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+class QueryComputerPool {
+public:
+    explicit QueryComputerPool(const void* query, SearchStatistics* stats = nullptr)
+        : query_(query), stats_(stats) {
+    }
+
+    [[nodiscard]] ComputerLease
+    Acquire(const FlattenInterfacePtr& cell, const void* query) {
+        if (cell == nullptr) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "cannot acquire a query computer for a null data cell");
+        }
+        if (query != query_) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "query computer pool used with a different query");
+        }
+        for (uint64_t i = 0; i < size_; ++i) {
+            const auto& entry = entries_[i];
+            if (entry.owner.get() == cell.get()) {
+                entry.Validate(cell, query);
+                return entry;
+            }
+        }
+        if (size_ == kCapacity) {
+            throw VsagException(
+                ErrorType::INTERNAL_ERROR,
+                "query computer pool capacity exceeded: HGraph supports at most base, precise, "
+                "and raw cells");
+        }
+
+        auto computer = cell->FactoryComputer(query);
+        RecordQueryComputerCreation(stats_);
+        ComputerLease lease{cell, std::move(computer), query};
+        lease.Validate(cell, query);
+        entries_[size_] = lease;
+        ++size_;
+        return lease;
+    }
+
+    [[nodiscard]] uint64_t
+    Size() const {
+        return size_;
+    }
+
+private:
+    static constexpr uint64_t kCapacity = 3;
+
+    const void* query_{nullptr};
+    SearchStatistics* stats_{nullptr};
+    std::array<ComputerLease, kCapacity> entries_;
+    uint64_t size_{0};
+};
+
+[[nodiscard]] inline ComputerLease
+AcquireQueryComputer(const FlattenInterfacePtr& cell, const void* query, QueryContext* ctx) {
+    if (ctx != nullptr and ctx->computer_pool != nullptr) {
+        return ctx->computer_pool->Acquire(cell, query);
+    }
+    if (cell == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "cannot acquire a query computer for a null data cell");
+    }
+
+    auto computer = cell->FactoryComputer(query);
+    RecordQueryComputerCreation(ctx == nullptr ? nullptr : ctx->stats);
+    ComputerLease lease{cell, std::move(computer), query};
+    lease.Validate(cell, query);
+    return lease;
+}
+
+}  // namespace vsag

--- a/src/impl/query_computer_pool_test.cpp
+++ b/src/impl/query_computer_pool_test.cpp
@@ -1,0 +1,175 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "query_computer_pool.h"
+
+#include <fmt/format.h>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+#include "datacell/flatten_datacell.h"
+#include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
+#include "io/common/io_parameter.h"
+#include "io/memory_io/memory_io.h"
+#include "layout/fixed_layout.h"
+#include "quantization/fp32_quantizer.h"
+#include "quantization/quantizer_parameter.h"
+#include "unittest.h"
+
+namespace {
+
+using TestQuantizer = vsag::FP32Quantizer<vsag::MetricType::METRIC_TYPE_L2SQR>;
+using TestFlatten = vsag::FlattenDataCell<TestQuantizer, vsag::FixedLayout<vsag::MemoryIO>>;
+
+class CountingFlattenDataCell final : public TestFlatten {
+public:
+    using TestFlatten::TestFlatten;
+
+    vsag::ComputerInterfacePtr
+    FactoryComputer(const void* query) override {
+        factory_count.fetch_add(1, std::memory_order_relaxed);
+        return TestFlatten::FactoryComputer(query);
+    }
+
+    std::atomic<uint64_t> factory_count{0};
+};
+
+std::shared_ptr<CountingFlattenDataCell>
+MakeCountingFlatten(uint64_t dim) {
+    constexpr const char* kParamTemplate = R"({{"type": "{}"}})";
+    auto quantizer_param = vsag::QuantizerParameter::GetQuantizerParameterByJson(
+        vsag::JsonType::Parse(fmt::format(kParamTemplate, "fp32")));
+    auto io_param = vsag::IOParameter::GetIOParameterByJson(
+        vsag::JsonType::Parse(fmt::format(kParamTemplate, "memory_io")));
+
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::IndexCommonParam common;
+    common.dim_ = dim;
+    common.metric_ = vsag::MetricType::METRIC_TYPE_L2SQR;
+    common.allocator_ = allocator;
+
+    auto flatten = std::make_shared<CountingFlattenDataCell>(quantizer_param, io_param, common);
+    flatten->SetQuantizer(std::make_shared<TestQuantizer>(dim, allocator.get()));
+    flatten->SetIO(std::make_shared<vsag::MemoryIO>(allocator.get()));
+    return flatten;
+}
+
+}  // namespace
+
+TEST_CASE("QueryComputerPool reuses computers by cell identity", "[ut][query_computer_pool]") {
+    constexpr uint64_t kDim = 8;
+    std::vector<float> query_a(kDim, 1.0F);
+    std::vector<float> query_b(kDim, 2.0F);
+
+    SECTION("same cell is prepared once") {
+        auto cell = MakeCountingFlatten(kDim);
+        vsag::SearchStatistics stats;
+        vsag::QueryComputerPool pool(query_a.data(), &stats);
+
+        auto first = pool.Acquire(cell, query_a.data());
+        auto second = pool.Acquire(cell, query_a.data());
+
+        REQUIRE(first.computer.get() == second.computer.get());
+        REQUIRE(first.owner.get() == cell.get());
+        REQUIRE_NOTHROW(first.Validate(cell, query_a.data()));
+        REQUIRE(pool.Size() == 1);
+        REQUIRE(cell->factory_count.load(std::memory_order_relaxed) == 1);
+        REQUIRE(stats.query_computer_count.load(std::memory_order_relaxed) == 1);
+    }
+
+    SECTION("different cells with the same model shape stay isolated") {
+        auto first_cell = MakeCountingFlatten(kDim);
+        auto second_cell = MakeCountingFlatten(kDim);
+        vsag::SearchStatistics stats;
+        vsag::QueryComputerPool pool(query_a.data(), &stats);
+
+        auto first = pool.Acquire(first_cell, query_a.data());
+        auto second = pool.Acquire(second_cell, query_a.data());
+
+        REQUIRE(first.computer.get() != second.computer.get());
+        REQUIRE(pool.Size() == 2);
+        REQUIRE(first_cell->factory_count.load(std::memory_order_relaxed) == 1);
+        REQUIRE(second_cell->factory_count.load(std::memory_order_relaxed) == 1);
+        REQUIRE(stats.query_computer_count.load(std::memory_order_relaxed) == 2);
+        REQUIRE_THROWS_AS(first.Validate(second_cell, query_a.data()), vsag::VsagException);
+        REQUIRE_THROWS_AS(second.Validate(first_cell, query_a.data()), vsag::VsagException);
+    }
+
+    SECTION("a pool rejects a different query") {
+        auto cell = MakeCountingFlatten(kDim);
+        vsag::SearchStatistics stats;
+        vsag::QueryComputerPool pool(query_a.data(), &stats);
+
+        REQUIRE_THROWS_AS(pool.Acquire(cell, query_b.data()), vsag::VsagException);
+        REQUIRE(pool.Size() == 0);
+        REQUIRE(cell->factory_count.load(std::memory_order_relaxed) == 0);
+        REQUIRE(stats.query_computer_count.load(std::memory_order_relaxed) == 0);
+    }
+
+    SECTION("the pool owns the cell for the computer lifetime") {
+        auto cell = MakeCountingFlatten(kDim);
+        std::weak_ptr<CountingFlattenDataCell> weak_cell = cell;
+        auto pool = std::make_unique<vsag::QueryComputerPool>(query_a.data());
+        {
+            auto lease = pool->Acquire(cell, query_a.data());
+            REQUIRE_NOTHROW(lease.Validate(cell, query_a.data()));
+        }
+
+        cell.reset();
+        REQUIRE_FALSE(weak_cell.expired());
+        pool.reset();
+        REQUIRE(weak_cell.expired());
+    }
+
+    SECTION("the fixed-capacity pool rejects a fourth cell before construction") {
+        auto first_cell = MakeCountingFlatten(kDim);
+        auto second_cell = MakeCountingFlatten(kDim);
+        auto third_cell = MakeCountingFlatten(kDim);
+        auto fourth_cell = MakeCountingFlatten(kDim);
+        vsag::SearchStatistics stats;
+        vsag::QueryComputerPool pool(query_a.data(), &stats);
+
+        static_cast<void>(pool.Acquire(first_cell, query_a.data()));
+        static_cast<void>(pool.Acquire(second_cell, query_a.data()));
+        static_cast<void>(pool.Acquire(third_cell, query_a.data()));
+
+        REQUIRE_THROWS_AS(pool.Acquire(fourth_cell, query_a.data()), vsag::VsagException);
+        REQUIRE(pool.Size() == 3);
+        REQUIRE(fourth_cell->factory_count.load(std::memory_order_relaxed) == 0);
+        REQUIRE(stats.query_computer_count.load(std::memory_order_relaxed) == 3);
+    }
+
+    SECTION("fallback without a pool records and owns a valid computer") {
+        auto cell = MakeCountingFlatten(kDim);
+        std::weak_ptr<CountingFlattenDataCell> weak_cell = cell;
+        vsag::SearchStatistics stats;
+        vsag::QueryContext ctx{.stats = &stats};
+
+        {
+            auto lease = vsag::AcquireQueryComputer(cell, query_a.data(), &ctx);
+            REQUIRE(ctx.computer_pool == nullptr);
+            REQUIRE_NOTHROW(lease.Validate(cell, query_a.data()));
+            REQUIRE(lease.computer != nullptr);
+            REQUIRE(cell->factory_count.load(std::memory_order_relaxed) == 1);
+            REQUIRE(stats.query_computer_count.load(std::memory_order_relaxed) == 1);
+
+            cell.reset();
+            REQUIRE_FALSE(weak_cell.expired());
+        }
+        REQUIRE(weak_cell.expired());
+    }
+}

--- a/src/impl/reorder/flatten_reorder.cpp
+++ b/src/impl/reorder/flatten_reorder.cpp
@@ -24,6 +24,7 @@
 #include "datacell/flatten_interface.h"
 #include "impl/filter/iterator_filter.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/query_computer_pool.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "query_context.h"
 
@@ -76,7 +77,8 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
     if (rabitq_lower_bound_candidates == nullptr) {
         topk = std::min(topk, static_cast<int64_t>(heap_candidate_size));
         auto reorder_heap = std::make_shared<StandardHeap<true, false>>(query_allocator, topk);
-        auto computer = flatten_->FactoryComputer(query);
+        auto computer_lease = AcquireQueryComputer(flatten_, query, &ctx);
+        const auto& computer = computer_lease.computer;
         Vector<InnerIdType> ids(heap_candidate_size, query_allocator);
         Vector<float> dists(heap_candidate_size, query_allocator);
         const auto* candidate_result = input == nullptr ? nullptr : input->GetData();
@@ -119,7 +121,8 @@ FlattenReorder::Reorder(const vsag::DistHeapPtr& input,
     if (topk <= 0) {
         topk = static_cast<int64_t>(max_candidate_size);
     }
-    auto computer = flatten_->FactoryComputer(query);
+    auto computer_lease = AcquireQueryComputer(flatten_, query, &ctx);
+    const auto& computer = computer_lease.computer;
     if (topk == 0 || max_candidate_size == 0) {
         return std::make_shared<StandardHeap<true, false>>(query_allocator, 0);
     }

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -24,6 +24,7 @@
 #include "datacell/flatten_interface.h"
 #include "impl/filter/iterator_filter.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/query_computer_pool.h"
 #include "impl/reasoning/search_reasoning.h"
 #include "impl/searcher/searcher_utils.h"
 #include "utils/filter_search_skip_strategy.h"
@@ -337,7 +338,8 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         return top_candidates;
     }
 
-    auto computer = flatten->FactoryComputer(query);
+    auto computer_lease = AcquireQueryComputer(flatten, query, ctx);
+    const auto& computer = computer_lease.computer;
 
     auto is_id_allowed = inner_search_param.is_inner_id_allowed;
     auto ep = inner_search_param.ep;
@@ -469,7 +471,6 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             flatten->Query(
                 line_dists.data(), computer, to_be_visited_id.data(), count_no_visited, ctx);
         }
-
         for (uint32_t i = 0; i < count_no_visited; i++) {
             dist = line_dists[i];
             const auto cur_id = to_be_visited_id[i];
@@ -568,9 +569,11 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
         return top_candidates;
     }
 
-    ComputerInterfacePtr computer = nullptr;
-    if (not use_custom_distance) {
-        computer = preset_computer != nullptr ? preset_computer : flatten->FactoryComputer(query);
+    ComputerLease computer_lease;
+    ComputerInterfacePtr computer = preset_computer;
+    if (not use_custom_distance and computer == nullptr) {
+        computer_lease = AcquireQueryComputer(flatten, query, ctx);
+        computer = computer_lease.computer;
     }
 
     auto is_id_allowed = inner_search_param.is_inner_id_allowed;

--- a/src/impl/searcher/mci_searcher.cpp
+++ b/src/impl/searcher/mci_searcher.cpp
@@ -24,6 +24,7 @@
 
 #include "impl/heap/search_candidate_queue.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/query_computer_pool.h"
 #include "impl/searcher/searcher_utils.h"
 #include "index_common_param.h"
 #include "simd/fp32_simd.h"
@@ -285,7 +286,8 @@ MCISearcher::Search(const CliqueDataCellPtr& cliques,
         *mci_param.used_precise_float_csr = false;
     }
 
-    auto computer = flatten->FactoryComputer(query);
+    auto computer_lease = AcquireQueryComputer(flatten, query, ctx);
+    const auto& computer = computer_lease.computer;
     thread_local MCIEpochMarks visited_nodes;
     thread_local MCIEpochMarks visited_cliques;
     visited_nodes.Reset(total);

--- a/src/impl/searcher/parallel_searcher.cpp
+++ b/src/impl/searcher/parallel_searcher.cpp
@@ -25,9 +25,11 @@
 
 #include "datacell/flatten_interface.h"
 #include "impl/heap/standard_heap.h"
+#include "impl/query_computer_pool.h"
 #include "impl/searcher/searcher_utils.h"
 #include "utils/filter_search_skip_strategy.h"
 #include "utils/spsc_queue.h"
+#include "vsag_exception.h"
 
 namespace vsag {
 
@@ -127,8 +129,17 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
     if (not graph or not flatten) {
         return top_candidates;
     }
+    if (inner_search_param.parallel_search_thread_count <= 0) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "parallel search thread count must be positive");
+    }
+    if (inner_search_param.parallel_search_thread_count > 1 and this->pool == nullptr) {
+        throw VsagException(ErrorType::INTERNAL_ERROR,
+                            "parallel search requires a non-null thread pool");
+    }
 
-    auto computer = flatten->FactoryComputer(query);
+    auto computer_lease = AcquireQueryComputer(flatten, query, ctx);
+    const auto& computer = computer_lease.computer;
 
     auto is_id_allowed = inner_search_param.is_inner_id_allowed;
     auto ep = inner_search_param.ep;
@@ -214,6 +225,7 @@ ParallelSearcher::search_impl(const GraphInterfacePtr& graph,
 
     auto task = [&](uint64_t thread_id) {
         auto worker_computer = flatten->FactoryComputer(query);
+        RecordQueryComputerCreation(ctx == nullptr ? nullptr : ctx->stats);
         SearchTask item;
         while (true) {
             if (queues[thread_id].Pop(item)) {

--- a/src/impl/searcher/parallel_searcher_test.cpp
+++ b/src/impl/searcher/parallel_searcher_test.cpp
@@ -82,6 +82,47 @@ TEST_CASE("ParallelSearcher matches BasicSearcher on a generic graph", "[ut][Par
         REQUIRE(run_search(parallel, graph) == run_search(basic, graph));
     }
 
+    SECTION("a missing executor is valid only for serial search") {
+        const auto graph = MakeRingGraph(base_size, 8);
+        auto no_executor = std::make_shared<ParallelSearcher>(common, nullptr);
+        auto serial_param = search_param;
+        serial_param.parallel_search_thread_count = 1;
+
+        auto visited_list = pool->TakeOne();
+        auto serial_result =
+            no_executor->Search(graph, flatten, visited_list, base_vectors.data(), serial_param);
+        pool->ReturnOne(visited_list);
+        REQUIRE(not serial_result->Empty());
+
+        for (const int64_t invalid_parallelism : {0, -1}) {
+            auto invalid_param = search_param;
+            invalid_param.parallel_search_thread_count = invalid_parallelism;
+            visited_list = pool->TakeOne();
+            REQUIRE_THROWS_AS(no_executor->Search(
+                                  graph, flatten, visited_list, base_vectors.data(), invalid_param),
+                              VsagException);
+            pool->ReturnOne(visited_list);
+        }
+
+        visited_list = pool->TakeOne();
+        auto missing_flatten =
+            no_executor->Search(graph, nullptr, visited_list, base_vectors.data(), search_param);
+        pool->ReturnOne(visited_list);
+        REQUIRE(missing_flatten->Empty());
+
+        visited_list = pool->TakeOne();
+        auto missing_graph =
+            no_executor->Search(nullptr, flatten, visited_list, base_vectors.data(), search_param);
+        pool->ReturnOne(visited_list);
+        REQUIRE(missing_graph->Empty());
+
+        visited_list = pool->TakeOne();
+        REQUIRE_THROWS_AS(
+            no_executor->Search(graph, flatten, visited_list, base_vectors.data(), search_param),
+            VsagException);
+        pool->ReturnOne(visited_list);
+    }
+
     auto visited_list = pool->TakeOne();
     auto empty_result =
         parallel->Search(nullptr, flatten, visited_list, base_vectors.data(), search_param);

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.cpp
@@ -87,6 +87,10 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim,
     // distance function related variable
     inv_sqrt_d_ = 1.0F / sqrt(this->dim_);
     rabitq_version_ = std::move(rabitq_version);
+    const bool support_split_code_storage =
+        RaBitQuantizerParameter::IsSplitVersion(rabitq_version_) && num_bits_per_dim_query_ == 32 &&
+        num_bits_per_dim_base_ >= 1 && num_bits_per_dim_filter_ >= 1 &&
+        num_bits_per_dim_filter_ <= num_bits_per_dim_base_;
     rabitq_error_rate_ = rabitq_error_rate;
     fast_encode_rabitq_ = fast_encode_rabitq;
     fast_encode_rabitq_rounds_ = fast_encode_rabitq_rounds;
@@ -175,13 +179,14 @@ RaBitQuantizer<metric>::RaBitQuantizer(int dim,
         this->query_code_size_ += ((sizeof(norm_type) + align_size - 1) / align_size) * align_size;
     }
 
-    if (SupportSplitCodeStorage()) {
+    if (support_split_code_storage) {
         offset_low_bound_error_ = this->code_size_;
         this->code_size_ += ((sizeof(error_type) + align_size - 1) / align_size) * align_size;
 
         offset_one_bit_error_ = this->code_size_;
         this->code_size_ += ((sizeof(error_type) + align_size - 1) / align_size) * align_size;
     }
+    RefreshSplitLayout(support_split_code_storage);
 }
 
 template <MetricType metric>
@@ -298,7 +303,6 @@ RaBitQuantizer<metric>::ComputeFilterCodeNorm(const uint8_t* filter_code,
         return 1.0F;
     }
 
-    const uint64_t plane_bytes = PlaneBytes();
     const float center = 0.5F * static_cast<float>((1U << filter_bits) - 1U);
     double norm_sqr = 0.0;
     for (uint64_t d = 0; d < this->dim_; ++d) {
@@ -306,7 +310,7 @@ RaBitQuantizer<metric>::ComputeFilterCodeNorm(const uint8_t* filter_code,
         const auto bit_mask = static_cast<uint8_t>(1U << (d & 7));
         uint32_t code = 0;
         for (uint32_t bit = 0; bit < filter_bits; ++bit) {
-            const auto* plane = filter_code + static_cast<uint64_t>(bit) * plane_bytes;
+            const auto* plane = filter_code + split_layout_.sequential_plane_offsets[bit];
             if ((plane[byte_idx] & bit_mask) != 0U) {
                 code += 1U << (filter_bits - bit - 1);
             }
@@ -325,14 +329,7 @@ RaBitQuantizer<metric>::ComputeFilterCodeNorm(const uint8_t* filter_code,
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::StoredPlaneIndex(uint32_t logical_bit) const {
-    if (not SupportSplitCodeStorage()) {
-        return logical_bit;
-    }
-    const auto first_filter_bit = num_bits_per_dim_base_ - FilterBits();
-    if (logical_bit >= first_filter_bit) {
-        return static_cast<uint64_t>(num_bits_per_dim_base_ - 1 - logical_bit);
-    }
-    return static_cast<uint64_t>(FilterBits()) + logical_bit;
+    return split_layout_.stored_plane_indices[logical_bit];
 }
 
 template <MetricType metric>
@@ -340,7 +337,10 @@ const uint8_t*
 RaBitQuantizer<metric>::GetStoredPlane(const uint8_t* planes,
                                        uint32_t logical_bit,
                                        uint64_t plane_bytes) const {
-    return planes + StoredPlaneIndex(logical_bit) * plane_bytes;
+    const auto plane_offset = plane_bytes == split_layout_.plane_bytes
+                                  ? split_layout_.stored_plane_offsets[logical_bit]
+                                  : split_layout_.stored_plane_indices[logical_bit] * plane_bytes;
+    return planes + plane_offset;
 }
 
 template <MetricType metric>
@@ -348,7 +348,10 @@ uint8_t*
 RaBitQuantizer<metric>::GetStoredPlane(uint8_t* planes,
                                        uint32_t logical_bit,
                                        uint64_t plane_bytes) const {
-    return planes + StoredPlaneIndex(logical_bit) * plane_bytes;
+    const auto plane_offset = plane_bytes == split_layout_.plane_bytes
+                                  ? split_layout_.stored_plane_offsets[logical_bit]
+                                  : split_layout_.stored_plane_indices[logical_bit] * plane_bytes;
+    return planes + plane_offset;
 }
 
 template <MetricType metric>
@@ -356,7 +359,7 @@ float
 RaBitQuantizer<metric>::RaBitQFloatSQIPByPlanes(const float* query,
                                                 const uint8_t* planes,
                                                 float query_sum) const {
-    uint64_t plane_bytes = (this->dim_ + 7) / 8;
+    const uint64_t plane_bytes = PlaneBytes();
     const auto filter_bits = SupportSplitCodeStorage() ? FilterBits() : static_cast<uint32_t>(1);
     const auto supplement_bits = SupportSplitCodeStorage()
                                      ? ReorderBits()
@@ -393,7 +396,6 @@ RaBitQuantizer<metric>::RaBitQFloatSQIPBySplitCode(const float* query,
         return 0.0F;
     }
 
-    const uint64_t plane_bytes = PlaneBytes();
     if (filter_bits == 2 or filter_bits == 3) {
         const float centered_filter_ip =
             filter_bits == 2 ? RaBitQFloatTwoBitCenteredIP(query, filter_code, this->dim_)
@@ -410,14 +412,14 @@ RaBitQuantizer<metric>::RaBitQFloatSQIPBySplitCode(const float* query,
         const auto bit_mask = static_cast<uint8_t>(1U << (d & 7));
         uint32_t code = 0;
         for (uint32_t bit = 0; bit < filter_bits; ++bit) {
-            const auto* plane = filter_code + static_cast<uint64_t>(bit) * plane_bytes;
+            const auto* plane = filter_code + split_layout_.sequential_plane_offsets[bit];
             if ((plane[byte_idx] & bit_mask) != 0) {
                 code += 1U << (supplement_bits + filter_bits - bit - 1);
             }
         }
         if (supplement_code != nullptr) {
             for (uint32_t bit = 0; bit < supplement_bits; ++bit) {
-                const auto* plane = supplement_code + static_cast<uint64_t>(bit) * plane_bytes;
+                const auto* plane = supplement_code + split_layout_.sequential_plane_offsets[bit];
                 if ((plane[byte_idx] & bit_mask) != 0) {
                     code += 1U << bit;
                 }
@@ -431,7 +433,7 @@ RaBitQuantizer<metric>::RaBitQFloatSQIPBySplitCode(const float* query,
 template <MetricType metric>
 void
 RaBitQuantizer<metric>::PackIntoPlanes(const uint8_t* src, uint8_t* dst) const {
-    uint64_t plane_size = (this->dim_ + 7) / 8;
+    const uint64_t plane_size = PlaneBytes();
     memset(dst, 0, plane_size * num_bits_per_dim_base_);
 
     const uint8_t mask_n =
@@ -946,21 +948,97 @@ RaBitQuantizer<metric>::AlignCodeField(uint64_t size) const {
 }
 
 template <MetricType metric>
+void
+RaBitQuantizer<metric>::RefreshSplitLayout(bool is_split) {
+    SplitLayout layout;
+    layout.is_split = is_split;
+    layout.filter_bits = layout.is_split ? num_bits_per_dim_filter_ : 1;
+    layout.reorder_bits = layout.is_split ? num_bits_per_dim_base_ - layout.filter_bits : 0;
+    layout.has_multi_bit_filter =
+        layout.is_split && layout.filter_bits > 1 && num_bits_per_dim_base_ > 1;
+
+    layout.plane_bytes = (this->dim_ + 7) / 8;
+    layout.code_planes_size = AlignCodeField(layout.plane_bytes * num_bits_per_dim_base_);
+    layout.code_meta_offset = offset_code_ + layout.code_planes_size;
+    layout.code_meta_size = this->code_size_ - layout.code_meta_offset;
+    layout.filter_planes_size = layout.plane_bytes * layout.filter_bits;
+    layout.supplement_planes_size = layout.plane_bytes * layout.reorder_bits;
+    layout.supplement_meta_offset = layout.supplement_planes_size;
+
+    const auto aligned_norm_size = AlignCodeField(sizeof(norm_type));
+    const auto aligned_error_size = AlignCodeField(sizeof(error_type));
+    layout.one_bit_record_norm_offset = AlignCodeField(layout.filter_planes_size);
+    uint64_t one_bit_record_offset = layout.one_bit_record_norm_offset + aligned_norm_size;
+    layout.one_bit_record_norm_code_offset = one_bit_record_offset;
+    if (layout.has_multi_bit_filter) {
+        one_bit_record_offset += aligned_norm_size;
+    }
+    layout.one_bit_record_mrq_norm_offset = one_bit_record_offset;
+    if (pca_dim_ != original_dim_ && use_mrq_) {
+        one_bit_record_offset += aligned_norm_size;
+    }
+    layout.one_bit_record_raw_norm_offset = one_bit_record_offset;
+    if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                  metric == MetricType::METRIC_TYPE_COSINE) {
+        one_bit_record_offset += aligned_norm_size;
+    }
+    layout.one_bit_record_low_bound_error_offset = one_bit_record_offset;
+    layout.one_bit_record_one_bit_error_offset = one_bit_record_offset + aligned_error_size;
+    layout.one_bit_record_size = layout.one_bit_record_one_bit_error_offset + aligned_error_size;
+    layout.one_bit_code_size = layout.is_split ? layout.one_bit_record_size : this->code_size_;
+    layout.supplement_code_size =
+        layout.is_split ? layout.supplement_meta_offset + layout.code_meta_size : 0;
+
+    for (uint32_t bit = 0; bit < layout.sequential_plane_offsets.size(); ++bit) {
+        layout.sequential_plane_offsets[bit] = static_cast<uint64_t>(bit) * layout.plane_bytes;
+    }
+    for (uint32_t logical_bit = 0; logical_bit < num_bits_per_dim_base_; ++logical_bit) {
+        uint64_t stored_plane_index = logical_bit;
+        if (layout.is_split) {
+            const auto first_filter_bit = num_bits_per_dim_base_ - layout.filter_bits;
+            stored_plane_index = logical_bit >= first_filter_bit
+                                     ? num_bits_per_dim_base_ - 1 - logical_bit
+                                     : layout.filter_bits + logical_bit;
+        }
+        layout.stored_plane_indices[logical_bit] = stored_plane_index;
+        layout.stored_plane_offsets[logical_bit] = stored_plane_index * layout.plane_bytes;
+    }
+
+    auto supplement_field_offset = [&layout](uint64_t full_code_offset) {
+        return layout.supplement_meta_offset + full_code_offset - layout.code_meta_offset;
+    };
+    if (num_bits_per_dim_base_ != 1) {
+        layout.supplement_norm_code_offset = supplement_field_offset(offset_norm_code_);
+    }
+    layout.supplement_norm_offset = supplement_field_offset(offset_norm_);
+    layout.supplement_error_offset = supplement_field_offset(offset_error_);
+    if (pca_dim_ != original_dim_ && use_mrq_) {
+        layout.supplement_mrq_norm_offset = supplement_field_offset(offset_mrq_norm_);
+    }
+    if constexpr (metric == MetricType::METRIC_TYPE_IP or
+                  metric == MetricType::METRIC_TYPE_COSINE) {
+        layout.supplement_raw_norm_offset = supplement_field_offset(offset_raw_norm_);
+    }
+
+    split_layout_ = layout;
+}
+
+template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::PlaneBytes() const {
-    return (this->dim_ + 7) / 8;
+    return split_layout_.plane_bytes;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::CodePlanesSize() const {
-    return AlignCodeField(PlaneBytes() * num_bits_per_dim_base_);
+    return split_layout_.code_planes_size;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::CodeMetaOffset() const {
-    return offset_code_ + CodePlanesSize();
+    return split_layout_.code_meta_offset;
 }
 
 template <MetricType metric>
@@ -1067,133 +1145,97 @@ RaBitQuantizer<metric>::UnpackScalarCode(const uint8_t* codes, uint8_t* scalar_c
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::SupplementPlanesSize() const {
-    if (ReorderBits() == 0) {
-        return 0;
-    }
-    return PlaneBytes() * ReorderBits();
+    return split_layout_.supplement_planes_size;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::SupplementMetaOffset() const {
-    return SupplementPlanesSize();
+    return split_layout_.supplement_meta_offset;
 }
 
 template <MetricType metric>
 bool
 RaBitQuantizer<metric>::SupportSplitCodeStorage() const {
-    return RaBitQuantizerParameter::IsSplitVersion(rabitq_version_) &&
-           num_bits_per_dim_query_ == 32 && num_bits_per_dim_base_ >= 1 &&
-           num_bits_per_dim_filter_ >= 1 && num_bits_per_dim_filter_ <= num_bits_per_dim_base_;
+    return split_layout_.is_split;
 }
 
 template <MetricType metric>
 uint32_t
 RaBitQuantizer<metric>::FilterBits() const {
-    return SupportSplitCodeStorage() ? num_bits_per_dim_filter_ : 1;
+    return split_layout_.filter_bits;
 }
 
 template <MetricType metric>
 uint32_t
 RaBitQuantizer<metric>::ReorderBits() const {
-    if (not SupportSplitCodeStorage()) {
-        return 0;
-    }
-    return num_bits_per_dim_base_ - num_bits_per_dim_filter_;
+    return split_layout_.reorder_bits;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::FilterPlanesSize() const {
-    return PlaneBytes() * FilterBits();
+    return split_layout_.filter_planes_size;
 }
 
 template <MetricType metric>
 bool
 RaBitQuantizer<metric>::HasMultiBitFilter() const {
-    return SupportSplitCodeStorage() && FilterBits() > 1 && num_bits_per_dim_base_ > 1;
+    return split_layout_.has_multi_bit_filter;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::OneBitRecordNormOffset() const {
-    return AlignCodeField(FilterPlanesSize());
+    return split_layout_.one_bit_record_norm_offset;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::OneBitRecordNormCodeOffset() const {
-    return OneBitRecordNormOffset() + AlignCodeField(sizeof(norm_type));
+    return split_layout_.one_bit_record_norm_code_offset;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::OneBitRecordMrqNormOffset() const {
-    uint64_t offset = OneBitRecordNormOffset() + AlignCodeField(sizeof(norm_type));
-    if (HasMultiBitFilter()) {
-        offset += AlignCodeField(sizeof(norm_type));
-    }
-    return offset;
+    return split_layout_.one_bit_record_mrq_norm_offset;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::OneBitRecordRawNormOffset() const {
-    uint64_t offset = OneBitRecordNormOffset() + AlignCodeField(sizeof(norm_type));
-    if (HasMultiBitFilter()) {
-        offset += AlignCodeField(sizeof(norm_type));
-    }
-    if (pca_dim_ != original_dim_ && use_mrq_) {
-        offset += AlignCodeField(sizeof(norm_type));
-    }
-    return offset;
+    return split_layout_.one_bit_record_raw_norm_offset;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::OneBitRecordLowBoundErrorOffset() const {
-    uint64_t offset = OneBitRecordNormOffset() + AlignCodeField(sizeof(norm_type));
-    if (HasMultiBitFilter()) {
-        offset += AlignCodeField(sizeof(norm_type));
-    }
-    if (pca_dim_ != original_dim_ && use_mrq_) {
-        offset += AlignCodeField(sizeof(norm_type));
-    }
-    if constexpr (metric == MetricType::METRIC_TYPE_IP or
-                  metric == MetricType::METRIC_TYPE_COSINE) {
-        offset += AlignCodeField(sizeof(norm_type));
-    }
-    return offset;
+    return split_layout_.one_bit_record_low_bound_error_offset;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::OneBitRecordOneBitErrorOffset() const {
-    return OneBitRecordLowBoundErrorOffset() + AlignCodeField(sizeof(error_type));
+    return split_layout_.one_bit_record_one_bit_error_offset;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::OneBitRecordSize() const {
-    return OneBitRecordOneBitErrorOffset() + AlignCodeField(sizeof(error_type));
+    return split_layout_.one_bit_record_size;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::GetOneBitCodeSize() const {
-    if (not SupportSplitCodeStorage()) {
-        return this->code_size_;
-    }
-    return OneBitRecordSize();
+    return split_layout_.one_bit_code_size;
 }
 
 template <MetricType metric>
 uint64_t
 RaBitQuantizer<metric>::GetSupplementCodeSize() const {
-    if (not SupportSplitCodeStorage()) {
-        return 0;
-    }
-    return SupplementMetaOffset() + (this->code_size_ - CodeMetaOffset());
+    return split_layout_.supplement_code_size;
 }
 
 template <MetricType metric>
@@ -1568,11 +1610,6 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCode(Computer<RaBitQuantizer>& compu
     }
 
     const auto* query = computer.buf_;
-    const auto* split_meta = supplement_code + SupplementMetaOffset();
-    const auto code_meta_offset = CodeMetaOffset();
-    auto meta_field = [split_meta, code_meta_offset](uint64_t offset) {
-        return split_meta + (offset - code_meta_offset);
-    };
 
     float ip_bq_estimate = 0.0F;
     if (num_bits_per_dim_base_ == 1) {
@@ -1587,7 +1624,9 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCode(Computer<RaBitQuantizer>& compu
                                                ReorderBits());
 
         norm_type base_norm_code = 0;
-        memcpy(&base_norm_code, meta_field(offset_norm_code_), sizeof(base_norm_code));
+        memcpy(&base_norm_code,
+               supplement_code + split_layout_.supplement_norm_code_offset,
+               sizeof(base_norm_code));
         ip_bq_estimate = ip_obar_q(ip_yu_q, query_raw_sum, base_norm_code, num_bits_per_dim_base_);
     } else {
         sum_type query_raw_sum = *((sum_type*)(query + query_offset_sum_));
@@ -1613,24 +1652,29 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCode(Computer<RaBitQuantizer>& compu
         }
 
         norm_type base_norm_code = 0;
-        memcpy(&base_norm_code, meta_field(offset_norm_code_), sizeof(base_norm_code));
+        memcpy(&base_norm_code,
+               supplement_code + split_layout_.supplement_norm_code_offset,
+               sizeof(base_norm_code));
         ip_bq_estimate = ip_obar_q(ip_yu_q, query_raw_sum, base_norm_code, num_bits_per_dim_base_);
     }
 
     norm_type query_norm = *((norm_type*)(query + query_offset_norm_));
     norm_type base_norm = 0;
-    memcpy(&base_norm, meta_field(offset_norm_), sizeof(base_norm));
+    memcpy(&base_norm, supplement_code + split_layout_.supplement_norm_offset, sizeof(base_norm));
 
     norm_type query_raw_norm = 0;
     norm_type base_raw_norm = 0;
     if constexpr (metric == MetricType::METRIC_TYPE_IP or
                   metric == MetricType::METRIC_TYPE_COSINE) {
         query_raw_norm = *((norm_type*)(query + query_offset_raw_norm_));
-        memcpy(&base_raw_norm, meta_field(offset_raw_norm_), sizeof(base_raw_norm));
+        memcpy(&base_raw_norm,
+               supplement_code + split_layout_.supplement_raw_norm_offset,
+               sizeof(base_raw_norm));
     }
 
     error_type base_error = 0;
-    memcpy(&base_error, meta_field(offset_error_), sizeof(base_error));
+    memcpy(
+        &base_error, supplement_code + split_layout_.supplement_error_offset, sizeof(base_error));
     if (std::abs(base_error) < 1e-5) {
         base_error = (base_error >= 0) ? 1.0F : -1.0F;
     }
@@ -1641,7 +1685,9 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCode(Computer<RaBitQuantizer>& compu
     if (pca_dim_ != this->original_dim_ and use_mrq_) {
         norm_type query_mrq_norm_sqr = *(norm_type*)(query + query_offset_mrq_norm_);
         norm_type base_mrq_norm_sqr = 0;
-        memcpy(&base_mrq_norm_sqr, meta_field(offset_mrq_norm_), sizeof(base_mrq_norm_sqr));
+        memcpy(&base_mrq_norm_sqr,
+               supplement_code + split_layout_.supplement_mrq_norm_offset,
+               sizeof(base_mrq_norm_sqr));
         result += (query_mrq_norm_sqr + base_mrq_norm_sqr);
     }
     if constexpr (metric == MetricType::METRIC_TYPE_COSINE) {
@@ -1684,11 +1730,6 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCodeAndFilterDist(Computer<RaBitQuan
     }
 
     const auto* query = computer.buf_;
-    const auto* split_meta = supplement_code + SupplementMetaOffset();
-    const auto code_meta_offset = CodeMetaOffset();
-    auto meta_field = [split_meta, code_meta_offset](uint64_t offset) {
-        return split_meta + (offset - code_meta_offset);
-    };
 
     const norm_type query_norm = *((norm_type*)(query + query_offset_norm_));
     const norm_type base_norm = *((norm_type*)(one_bit_code + OneBitRecordNormOffset()));
@@ -1730,7 +1771,9 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCodeAndFilterDist(Computer<RaBitQuan
     }
 
     norm_type full_norm_code = 0;
-    memcpy(&full_norm_code, meta_field(offset_norm_code_), sizeof(full_norm_code));
+    memcpy(&full_norm_code,
+           supplement_code + split_layout_.supplement_norm_code_offset,
+           sizeof(full_norm_code));
     if (full_norm_code <= 0.0F) {
         return false;
     }
@@ -1747,7 +1790,8 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCodeAndFilterDist(Computer<RaBitQuan
                                            num_bits_per_dim_base_);
 
     error_type base_error = 0;
-    memcpy(&base_error, meta_field(offset_error_), sizeof(base_error));
+    memcpy(
+        &base_error, supplement_code + split_layout_.supplement_error_offset, sizeof(base_error));
     if (std::abs(base_error) < 1e-5F) {
         base_error = (base_error >= 0) ? 1.0F : -1.0F;
     }
@@ -1756,7 +1800,9 @@ RaBitQuantizer<metric>::ComputeDistWithSplitCodeAndFilterDist(Computer<RaBitQuan
     if (pca_dim_ != this->original_dim_ and use_mrq_) {
         const norm_type query_mrq_norm_sqr = *(norm_type*)(query + query_offset_mrq_norm_);
         norm_type base_mrq_norm_sqr = 0;
-        memcpy(&base_mrq_norm_sqr, meta_field(offset_mrq_norm_), sizeof(base_mrq_norm_sqr));
+        memcpy(&base_mrq_norm_sqr,
+               supplement_code + split_layout_.supplement_mrq_norm_offset,
+               sizeof(base_mrq_norm_sqr));
         result += query_mrq_norm_sqr + base_mrq_norm_sqr;
     }
 
@@ -2260,6 +2306,10 @@ RaBitQuantizer<metric>::DeserializeImpl(StreamReader& reader) {
     if (pca_dim_ != this->original_dim_) {
         this->pca_->Deserialize(reader);
     }
+    RefreshSplitLayout(RaBitQuantizerParameter::IsSplitVersion(rabitq_version_) &&
+                       num_bits_per_dim_query_ == 32 && num_bits_per_dim_base_ >= 1 &&
+                       num_bits_per_dim_filter_ >= 1 &&
+                       num_bits_per_dim_filter_ <= num_bits_per_dim_base_);
 }
 
 TEMPLATE_QUANTIZER(RaBitQuantizer)

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <array>
 #include <limits>
 #include <string>
 
@@ -335,6 +336,40 @@ private:
     uint64_t
     UnpackScalarCode(const uint8_t* codes, uint8_t* scalar_code) const;
 
+    struct SplitLayout {
+        bool is_split{false};
+        bool has_multi_bit_filter{false};
+        uint32_t filter_bits{1};
+        uint32_t reorder_bits{0};
+        uint64_t plane_bytes{0};
+        uint64_t code_planes_size{0};
+        uint64_t code_meta_offset{0};
+        uint64_t code_meta_size{0};
+        uint64_t filter_planes_size{0};
+        uint64_t supplement_planes_size{0};
+        uint64_t supplement_meta_offset{0};
+        uint64_t one_bit_record_norm_offset{0};
+        uint64_t one_bit_record_norm_code_offset{0};
+        uint64_t one_bit_record_mrq_norm_offset{0};
+        uint64_t one_bit_record_raw_norm_offset{0};
+        uint64_t one_bit_record_low_bound_error_offset{0};
+        uint64_t one_bit_record_one_bit_error_offset{0};
+        uint64_t one_bit_record_size{0};
+        uint64_t one_bit_code_size{0};
+        uint64_t supplement_code_size{0};
+        uint64_t supplement_norm_code_offset{0};
+        uint64_t supplement_norm_offset{0};
+        uint64_t supplement_error_offset{0};
+        uint64_t supplement_mrq_norm_offset{0};
+        uint64_t supplement_raw_norm_offset{0};
+        std::array<uint64_t, 8> sequential_plane_offsets{};
+        std::array<uint64_t, 8> stored_plane_indices{};
+        std::array<uint64_t, 8> stored_plane_offsets{};
+    };
+
+    void
+    RefreshSplitLayout(bool is_split);
+
     [[nodiscard]] norm_type
     ComputeScalarCodeNorm(const uint8_t* scalar_codes,
                           uint32_t code_bits,
@@ -388,6 +423,7 @@ private:
     uint64_t offset_raw_norm_{0};
     uint64_t offset_low_bound_error_{0};
     uint64_t offset_one_bit_error_{0};
+    SplitLayout split_layout_{};
 };
 
 }  // namespace vsag

--- a/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer_test.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstring>
 #include <numeric>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -33,6 +34,129 @@ using namespace vsag;
 
 const auto dims = fixtures::get_common_used_dims(6, 129);
 const auto counts = {100};
+
+template <MetricType metric>
+void
+TestRaBitQSplitLayoutCacheRoundTrip(uint64_t pca_dim, bool use_mrq) {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr uint64_t dim = 64;
+    constexpr uint64_t count = 32;
+    constexpr uint64_t base_bits = 8;
+    constexpr uint64_t filter_bits = 3;
+    auto vecs = fixtures::generate_vectors(count, dim);
+
+    auto make_quantizer = [&]() {
+        return RaBitQuantizer<metric>(dim,
+                                      pca_dim,
+                                      32,
+                                      base_bits,
+                                      false,
+                                      use_mrq,
+                                      allocator.get(),
+                                      RaBitQuantizerParameter::RABITQ_VERSION_SPLIT,
+                                      RaBitQuantizerParameter::DEFAULT_RABITQ_ERROR_RATE,
+                                      filter_bits);
+    };
+    auto source = make_quantizer();
+    auto restored = make_quantizer();
+    REQUIRE(source.TrainImpl(vecs.data(), count));
+
+    auto require_same_layout = [](const auto& expected, const auto& actual) {
+        REQUIRE(actual.SupportSplitCodeStorage() == expected.SupportSplitCodeStorage());
+        REQUIRE(actual.FilterBits() == expected.FilterBits());
+        REQUIRE(actual.ReorderBits() == expected.ReorderBits());
+        REQUIRE(actual.HasMultiBitFilter() == expected.HasMultiBitFilter());
+        REQUIRE(actual.PlaneBytes() == expected.PlaneBytes());
+        REQUIRE(actual.CodePlanesSize() == expected.CodePlanesSize());
+        REQUIRE(actual.CodeMetaOffset() == expected.CodeMetaOffset());
+        REQUIRE(actual.FilterPlanesSize() == expected.FilterPlanesSize());
+        REQUIRE(actual.SupplementPlanesSize() == expected.SupplementPlanesSize());
+        REQUIRE(actual.SupplementMetaOffset() == expected.SupplementMetaOffset());
+        REQUIRE(actual.OneBitRecordNormOffset() == expected.OneBitRecordNormOffset());
+        REQUIRE(actual.OneBitRecordNormCodeOffset() == expected.OneBitRecordNormCodeOffset());
+        REQUIRE(actual.OneBitRecordMrqNormOffset() == expected.OneBitRecordMrqNormOffset());
+        REQUIRE(actual.OneBitRecordRawNormOffset() == expected.OneBitRecordRawNormOffset());
+        REQUIRE(actual.OneBitRecordLowBoundErrorOffset() ==
+                expected.OneBitRecordLowBoundErrorOffset());
+        REQUIRE(actual.OneBitRecordOneBitErrorOffset() == expected.OneBitRecordOneBitErrorOffset());
+        REQUIRE(actual.OneBitRecordSize() == expected.OneBitRecordSize());
+        REQUIRE(actual.GetOneBitCodeSize() == expected.GetOneBitCodeSize());
+        REQUIRE(actual.GetSupplementCodeSize() == expected.GetSupplementCodeSize());
+
+        std::vector<uint8_t> planes(expected.CodePlanesSize());
+        for (uint32_t logical_bit = 0; logical_bit < base_bits; ++logical_bit) {
+            REQUIRE(actual.StoredPlaneIndex(logical_bit) == expected.StoredPlaneIndex(logical_bit));
+            const auto actual_offset = static_cast<uint64_t>(
+                actual.GetStoredPlane(planes.data(), logical_bit, actual.PlaneBytes()) -
+                planes.data());
+            REQUIRE(actual_offset == actual.StoredPlaneIndex(logical_bit) * actual.PlaneBytes());
+        }
+    };
+
+    std::stringstream serialized;
+    IOStreamWriter writer(serialized);
+    source.Serialize(writer);
+    const auto serialized_bytes = serialized.str();
+    IOStreamReader reader(serialized);
+    restored.Deserialize(reader);
+    require_same_layout(source, restored);
+
+    std::stringstream reserialized;
+    IOStreamWriter restored_writer(reserialized);
+    restored.Serialize(restored_writer);
+    REQUIRE(reserialized.str() == serialized_bytes);
+
+    std::vector<uint8_t> source_full(source.GetCodeSize());
+    std::vector<uint8_t> source_filter(source.GetOneBitCodeSize());
+    std::vector<uint8_t> source_supplement(source.GetSupplementCodeSize());
+    std::vector<uint8_t> restored_full(restored.GetCodeSize());
+    std::vector<uint8_t> restored_filter(restored.GetOneBitCodeSize());
+    std::vector<uint8_t> restored_supplement(restored.GetSupplementCodeSize());
+    REQUIRE(source.EncodeOne(vecs.data(), source_full.data()));
+    REQUIRE(restored.EncodeOne(vecs.data(), restored_full.data()));
+    source.SplitCode(source_full.data(), source_filter.data(), source_supplement.data());
+    restored.SplitCode(restored_full.data(), restored_filter.data(), restored_supplement.data());
+    REQUIRE(restored_full == source_full);
+    REQUIRE(restored_filter == source_filter);
+    REQUIRE(restored_supplement == source_supplement);
+
+    struct DistanceSnapshot {
+        float full{0.0F};
+        float filter{0.0F};
+        float lower_bound{0.0F};
+        float split{0.0F};
+        float hinted{0.0F};
+    };
+    auto evaluate = [&](auto& quantizer,
+                        const auto& full_code,
+                        const auto& filter_code,
+                        const auto& supplement_code) {
+        DistanceSnapshot snapshot;
+        auto computer = quantizer.FactoryComputer();
+        computer->SetQuery(vecs.data() + 8 * dim);
+        snapshot.full = quantizer.ComputeDist(*computer, full_code.data());
+        REQUIRE(quantizer.ComputeDistWithOneBitLowerBound(
+            *computer, filter_code.data(), &snapshot.filter, &snapshot.lower_bound));
+        REQUIRE(quantizer.ComputeDistWithSplitCode(
+            *computer, filter_code.data(), supplement_code.data(), &snapshot.split));
+        REQUIRE(quantizer.ComputeDistWithSplitCodeAndFilterDist(*computer,
+                                                                filter_code.data(),
+                                                                supplement_code.data(),
+                                                                snapshot.filter,
+                                                                &snapshot.hinted));
+        return snapshot;
+    };
+    const auto source_distances = evaluate(source, source_full, source_filter, source_supplement);
+    const auto restored_distances =
+        evaluate(restored, restored_full, restored_filter, restored_supplement);
+    REQUIRE(std::abs(source_distances.full - restored_distances.full) <= 1e-6F);
+    REQUIRE(std::abs(source_distances.filter - restored_distances.filter) <= 1e-6F);
+    REQUIRE(std::abs(source_distances.lower_bound - restored_distances.lower_bound) <= 1e-6F);
+    REQUIRE(std::abs(source_distances.split - restored_distances.split) <= 1e-6F);
+    REQUIRE(std::abs(source_distances.hinted - restored_distances.hinted) <= 1e-6F);
+    REQUIRE(std::abs(restored_distances.full - restored_distances.split) <= 1e-6F);
+    REQUIRE(std::abs(restored_distances.split - restored_distances.hinted) <= 1e-5F);
+}
 
 TEST_CASE("RaBitQ Basic Test", "[ut][RaBitQuantizer]") {
     bool use_fht = GENERATE(true, false);
@@ -674,6 +798,18 @@ TEST_CASE("RaBitQ Split Code Storage", "[ut][RaBitQuantizer]") {
                 REQUIRE(std::abs(batch_lower_bounds[i] - single_lower_bounds[i]) <= 1e-5F);
             }
         }
+    }
+}
+
+TEST_CASE("RaBitQ Split Layout Cache Round Trip", "[ut][RaBitQuantizer][split_layout]") {
+    SECTION("L2") {
+        TestRaBitQSplitLayoutCacheRoundTrip<MetricType::METRIC_TYPE_L2SQR>(64, false);
+    }
+    SECTION("IP") {
+        TestRaBitQSplitLayoutCacheRoundTrip<MetricType::METRIC_TYPE_IP>(64, false);
+    }
+    SECTION("L2 with MRQ") {
+        TestRaBitQSplitLayoutCacheRoundTrip<MetricType::METRIC_TYPE_L2SQR>(32, true);
     }
 }
 

--- a/src/query_context.h
+++ b/src/query_context.h
@@ -52,6 +52,7 @@ enum class DistanceEvaluationBackend : uint8_t {
 
 class SearchStatistics;
 class ReasoningContext;
+class QueryComputerPool;
 template <typename QuantTmpl, MetricType metric>
 class TransformQuantizer;
 
@@ -62,6 +63,7 @@ struct QueryContext {
     float rabitq_error_rate = std::numeric_limits<float>::quiet_NaN();
     DistanceEvaluationPhase distance_phase = DistanceEvaluationPhase::APPROXIMATE;
     bool track_distance_evaluations = true;
+    QueryComputerPool* computer_pool = nullptr;
 };
 
 class ScopedDistancePhase {
@@ -231,6 +233,9 @@ public:
             rabitq_reorder_hint_full_count.load(std::memory_order_relaxed));
         j["rabitq_reorder_fallback_full_count"].SetInt(
             rabitq_reorder_fallback_full_count.load(std::memory_order_relaxed));
+        j["query_computer_count"].SetInt(query_computer_count.load(std::memory_order_relaxed));
+        j["parallel_search_fallback_count"].SetInt(
+            parallel_search_fallback_count.load(std::memory_order_relaxed));
         j["distance_evaluations"].SetUint64(distance_evaluations.load(std::memory_order_relaxed));
         for (size_t i = 0; i < 3; ++i) {
             j["distance_evaluations_by_phase"][PhaseName(static_cast<DistancePhase>(i))].SetUint64(
@@ -263,6 +268,8 @@ public:
     std::atomic<uint32_t> rabitq_filter_fallback_full_count{0};
     std::atomic<uint32_t> rabitq_reorder_hint_full_count{0};
     std::atomic<uint32_t> rabitq_reorder_fallback_full_count{0};
+    std::atomic<uint32_t> query_computer_count{0};
+    std::atomic<uint32_t> parallel_search_fallback_count{0};
     std::atomic<uint64_t> distance_evaluations{0};
     std::array<std::atomic<uint64_t>, 3> distance_evaluations_by_phase{};
     std::array<std::atomic<uint64_t>, 16> distance_evaluations_by_backend{};

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -23,6 +23,7 @@
 #include <random>
 #include <sstream>
 #include <thread>
+#include <vector>
 
 #include "functest.h"
 #include "impl/filter/iterator_filter.h"
@@ -802,6 +803,24 @@ TEST_CASE("HGraph conjugate graph does not widen range reorder",
     REQUIRE(statistics["distance_evaluations_by_phase"]["rerank"].GetUint64() == 2);
 }
 
+std::string
+MakeHGraphQueryComputerCountParam(const std::string& quantization,
+                                  const std::string& reorder_source,
+                                  bool store_raw_vector = false,
+                                  int build_thread_count = 4) {
+    using namespace fixtures;
+    HGraphTestIndex::HGraphBuildParam build_param("l2", 16, quantization);
+    build_param.thread_count = build_thread_count;
+    build_param.graph_io_type = "memory_io";
+    build_param.store_raw_vector = store_raw_vector;
+
+    auto param =
+        vsag::JsonType::Parse(HGraphTestIndex::GenerateHGraphBuildParametersString(build_param));
+    param["index_param"]["use_reorder"].SetBool(true);
+    param["index_param"]["reorder_source"].SetString(reorder_source);
+    return param.Dump();
+}
+
 #define HGRAPH_PR_DAILY_CASE(title, tags, helper)                        \
     TEST_CASE("(PR) " title, tags "[pr]") {                              \
         auto test_index = std::make_shared<fixtures::HGraphTestIndex>(); \
@@ -815,6 +834,230 @@ TEST_CASE("HGraph conjugate graph does not widen range reorder",
     }
 
 }  // namespace
+
+TEST_CASE("(PR) HGraph query computer count follows cell identity",
+          "[ft][hgraph][query_computer][pr]") {
+    using namespace fixtures;
+    constexpr int64_t kDim = 16;
+    // HGraph's fixed level RNG samples route-layer nodes within this prefix.
+    constexpr uint64_t kBaseCount = 200;
+    constexpr int64_t kResultSize = 10;
+    const bool precise_reorder = GENERATE(false, true);
+    INFO(fmt::format("reorder_source={}", precise_reorder ? "precise" : "base"));
+
+    auto param = MakeHGraphQueryComputerCountParam(precise_reorder ? "fp32,fp32,memory_io" : "fp32",
+                                                   precise_reorder ? "precise" : "base");
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(kDim, kBaseCount, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+
+    constexpr const char* kSearchParam = R"({
+        "hgraph": {
+            "ef_search": 32,
+            "parallelism": 1,
+            "enable_reorder": true,
+            "brute_force_threshold": 0.0
+        }
+    })";
+    constexpr const char* kParallelSearchParam = R"({
+        "hgraph": {
+            "ef_search": 32,
+            "parallelism": 4,
+            "enable_reorder": true,
+            "brute_force_threshold": 0.0
+        }
+    })";
+    constexpr const char* kBruteForceSearchParam = R"({
+        "hgraph": {
+            "ef_search": 32,
+            "parallelism": 1,
+            "enable_reorder": true,
+            "brute_force_threshold": 1.0
+        }
+    })";
+    const uint64_t expected_count = precise_reorder ? 2 : 1;
+    auto require_count = [](const auto& result, uint64_t expected) {
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() > 0);
+        auto values = result.value()->GetStatistics({"query_computer_count"});
+        REQUIRE(values.size() == 1);
+        REQUIRE(std::stoull(values.front()) == expected);
+    };
+
+    auto knn_result = index->KnnSearch(query, kResultSize, kSearchParam);
+    require_count(knn_result, expected_count);
+
+    auto range_result =
+        index->RangeSearch(query, std::numeric_limits<float>::max(), kSearchParam, kResultSize);
+    require_count(range_result, expected_count);
+
+    auto parallel_knn_result = index->KnnSearch(query, kResultSize, kParallelSearchParam);
+    require_count(parallel_knn_result, precise_reorder ? 5 : 4);
+    auto parallel_stats = vsag::JsonType::Parse(parallel_knn_result.value()->GetStatistics());
+    REQUIRE(parallel_stats["parallel_search_fallback_count"].GetInt() == 0);
+
+    auto brute_force_result = index->KnnSearch(query, kResultSize, kBruteForceSearchParam);
+    require_count(brute_force_result, expected_count);
+
+    vsag::SearchRequest reasoning_request;
+    reasoning_request.topk_ = kResultSize;
+    reasoning_request.params_str_ = kSearchParam;
+    reasoning_request.query_ = query;
+    reasoning_request.expected_labels_ = {dataset->base_->GetIds()[0]};
+    auto reasoning_result = index->SearchWithRequest(reasoning_request);
+    require_count(reasoning_result, expected_count);
+    REQUIRE_FALSE(reasoning_result.value()->GetReasoning().empty());
+
+    vsag::FilterPtr filter = nullptr;
+    vsag::IteratorContext* iter_ctx = nullptr;
+    auto first_page = index->KnnSearch(query, kResultSize, kSearchParam, filter, iter_ctx, false);
+    require_count(first_page, expected_count);
+    auto second_page = index->KnnSearch(query, kResultSize, kSearchParam, filter, iter_ctx, false);
+    require_count(second_page, expected_count);
+    delete iter_ctx;
+
+    auto reject_all_filter = std::make_shared<RejectAllFilter>();
+    vsag::IteratorContext* empty_iter_ctx = nullptr;
+    auto empty_page = index->KnnSearch(
+        query, kResultSize, kSearchParam, reject_all_filter, empty_iter_ctx, false);
+    REQUIRE(empty_page.has_value());
+    REQUIRE(empty_page.value()->GetDim() == 0);
+    auto empty_page_stats = vsag::JsonType::Parse(empty_page.value()->GetStatistics());
+    REQUIRE(empty_page_stats.Contains("query_computer_count"));
+    REQUIRE(empty_page_stats["query_computer_count"].GetInt() ==
+            static_cast<int64_t>(expected_count));
+    delete empty_iter_ctx;
+}
+
+TEST_CASE("(PR) HGraph reasoning query computer count follows raw cell identity",
+          "[ft][hgraph][query_computer][reasoning][pr]") {
+    using namespace fixtures;
+    constexpr int64_t kDim = 16;
+    constexpr uint64_t kBaseCount = 200;
+    constexpr int64_t kResultSize = 10;
+    constexpr const char* kSearchParam = R"({
+        "hgraph": {
+            "ef_search": 32,
+            "parallelism": 1,
+            "enable_reorder": true,
+            "brute_force_threshold": 0.0
+        }
+    })";
+
+    struct TestCase {
+        const char* quantization;
+        const char* reorder_source;
+        uint64_t expected_count;
+    };
+    const TestCase test_cases[] = {
+        {"sq8", "base", 2},
+        {"sq8,sq8,memory_io", "precise", 3},
+        {"sq8,fp32,memory_io", "precise", 2},
+    };
+
+    for (const auto& test_case : test_cases) {
+        DYNAMIC_SECTION("quantization=" << test_case.quantization
+                                        << ", reorder_source=" << test_case.reorder_source) {
+            auto param = MakeHGraphQueryComputerCountParam(
+                test_case.quantization, test_case.reorder_source, true);
+            auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+            auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(kDim, kBaseCount, "l2");
+            TestIndex::TestBuildIndex(index, dataset, true);
+            auto query = fixtures::get_one_query(dataset->query_, 0);
+
+            vsag::SearchRequest request;
+            request.topk_ = kResultSize;
+            request.params_str_ = kSearchParam;
+            request.query_ = query;
+            request.expected_labels_ = {dataset->base_->GetIds()[0]};
+
+            auto result = index->SearchWithRequest(request);
+            REQUIRE(result.has_value());
+            REQUIRE(result.value()->GetDim() > 0);
+            REQUIRE_FALSE(result.value()->GetReasoning().empty());
+            auto values = result.value()->GetStatistics({"query_computer_count"});
+            REQUIRE(values.size() == 1);
+            REQUIRE(std::stoull(values.front()) == test_case.expected_count);
+        }
+    }
+}
+
+TEST_CASE("(PR) HGraph parallel search falls back without an executor",
+          "[ft][hgraph][parallel_fallback][pr]") {
+    using namespace fixtures;
+    constexpr int64_t kDim = 16;
+    constexpr uint64_t kBaseCount = 200;
+    constexpr int64_t kResultSize = 10;
+    const bool precise_reorder = GENERATE(false, true);
+    INFO(fmt::format("reorder_source={}", precise_reorder ? "precise" : "base"));
+
+    auto param = MakeHGraphQueryComputerCountParam(precise_reorder ? "fp32,fp32,memory_io" : "fp32",
+                                                   precise_reorder ? "precise" : "base",
+                                                   false,
+                                                   1);
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto dataset = HGraphTestIndex::pool.GetDatasetAndCreate(kDim, kBaseCount, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+    auto query = fixtures::get_one_query(dataset->query_, 0);
+
+    constexpr const char* kSerialSearchParam = R"({
+        "hgraph": {
+            "ef_search": 32,
+            "parallelism": 1,
+            "enable_reorder": true,
+            "brute_force_threshold": 0.0
+        }
+    })";
+    constexpr const char* kParallelSearchParam = R"({
+        "hgraph": {
+            "ef_search": 32,
+            "parallelism": 4,
+            "enable_reorder": true,
+            "brute_force_threshold": 0.0
+        }
+    })";
+    const uint64_t expected_computer_count = precise_reorder ? 2 : 1;
+    auto require_fallback = [expected_computer_count](const auto& result) {
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() > 0);
+        auto values = result.value()->GetStatistics(
+            {"parallel_search_fallback_count", "query_computer_count"});
+        REQUIRE(values.size() == 2);
+        REQUIRE(std::stoull(values[0]) == 1);
+        REQUIRE(std::stoull(values[1]) == expected_computer_count);
+    };
+
+    auto serial_result = index->KnnSearch(query, kResultSize, kSerialSearchParam);
+    auto fallback_result = index->KnnSearch(query, kResultSize, kParallelSearchParam);
+    require_fallback(fallback_result);
+    REQUIRE(serial_result.has_value());
+    REQUIRE(serial_result.value()->GetDim() == fallback_result.value()->GetDim());
+    for (int64_t i = 0; i < serial_result.value()->GetDim(); ++i) {
+        REQUIRE(serial_result.value()->GetIds()[i] == fallback_result.value()->GetIds()[i]);
+        REQUIRE(serial_result.value()->GetDistances()[i] ==
+                fallback_result.value()->GetDistances()[i]);
+    }
+
+    auto range_result = index->RangeSearch(
+        query, std::numeric_limits<float>::max(), kParallelSearchParam, kResultSize);
+    require_fallback(range_result);
+
+    vsag::FilterPtr filter = nullptr;
+    vsag::IteratorContext* iter_ctx = nullptr;
+    auto iterator_result =
+        index->KnnSearch(query, kResultSize, kParallelSearchParam, filter, iter_ctx, false);
+    require_fallback(iterator_result);
+    delete iter_ctx;
+
+    auto binary_set = index->Serialize();
+    REQUIRE(binary_set.has_value());
+    auto reloaded = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    auto deserialize_result = reloaded->Deserialize(binary_set.value());
+    REQUIRE(deserialize_result.has_value());
+    auto reloaded_result = reloaded->KnnSearch(query, kResultSize, kParallelSearchParam);
+    require_fallback(reloaded_result);
+}
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::HGraphTestIndex,
                              "HGraph Factory Test With Exceptions",


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Not required for `kind/improvement`.

## What Changed

- Cache the RaBitQ split-storage mode, filter/reorder bit counts, plane sizes, and metadata offsets when the quantizer is constructed or deserialized.
- Replace split search hot-path version-string checks and recursive offset calculations with cached constant reads.
- Reuse quantizer `Computer` instances across routing, bottom-layer search, reorder, brute-force, reasoning, MCI, and conjugate search within one HGraph request.
- Key the request-scoped pool by the actual flatten data-cell identity and query pointer. Parallel workers keep independent computers; the coordinator reuses the request-scoped one.
- Fall back to serial search when an HGraph has no parallel executor, and expose construction/fallback counters for verification.
- Adapt one-bit, supplement, and optimized-build prefetch lengths to their actual split record sizes, with `prefetch_depth_codes` retained as the upper bound.
- Keep the public API and serialized representation unchanged.

The branch was rebased onto latest `origin/main` at `5096a0a6` before final verification.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [x] Focused unit and functional tests
- [x] Release build and GIST1M benchmark

```text
make fmt
  clang-format 15, passed; no tracked diff

Focused unittests after rebase
  QueryComputerPool, ParallelSearcher, RaBitQSplitDataCell,
  and RaBitQ split-layout round trip
  13 test cases, 9,816 assertions, passed

Focused functests after rebase
  HGraph/Pyramid RaBitQ split
  12 test cases, 13,118 assertions, passed

Release benchmark builds
  latest main 5096a0a6 and optimized 025a7c34
  -O3 -DNDEBUG, passed

GIST1M result equivalence audit
  600 held-out queries, efSearch 32/64/128/256/512/768/1000
  main and optimized top-10 ID checksums matched at all seven points
```

Earlier full unit-test evidence remains 800 test cases and 85,349,251 assertions passed. The focused suite above was rebuilt and rerun after the rebase.

## Compatibility Impact

- API/ABI: no public API change; only private request context and quantizer layout state change.
- Serialization: no format or size change.
- Search behavior: main and optimized top-10 IDs, recall, and ordering match on the non-relayout GIST1M indices at every tested `efSearch`.

## Performance and Concurrency Impact

GIST1M setup:

- Baseline: latest `origin/main@5096a0a6`.
- Optimized: this branch at `025a7c34`, containing all three commits. The main-to-optimized numbers are branch-level results, not prefetch-only attribution.
- HGraph RaBitQ split `3+5` and `1+7`; same preserved 1M-vector indices.
- 600 held-out queries (`400..999`), `k=10`, external client threads `1/16/32`, and HGraph `parallelism=1` per call.
- `efSearch=32/64/128/256/512/768/1000`; three measured runs per point, median QPS.
- CPUs `0..51`; `OMP_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`.
- TAGL rows use separately relaid-out copies trained from query rows `0..399`. TAGL is not part of this PR; it isolates the additional benefit of locality-aware serialization with the same optimized binary.

Relative QPS ranges across all seven `efSearch` values:

| Threads | Split | main -> optimized | optimized -> TAGL |
| ---: | --- | ---: | ---: |
| 1 | 3+5 | +81.83% to +93.75% | -0.00% to +4.88% |
| 1 | 1+7 | +78.72% to +110.56% | +1.09% to +4.65% |
| 16 | 3+5 | +81.81% to +90.14% | +0.09% to +2.10% |
| 16 | 1+7 | +77.15% to +113.13% | +0.95% to +2.27% |
| 32 | 3+5 | +74.64% to +107.83% | +0.95% to +6.25% |
| 32 | 1+7 | +65.37% to +123.37% | +2.19% to +9.78% |

Selected median-QPS endpoints:

| Threads | Algorithm | ef 32 | ef 256 | ef 1000 |
| ---: | --- | ---: | ---: | ---: |
| 1 | main 3+5 | 1,358.4 | 332.8 | 109.8 |
| 1 | optimized 3+5 | 2,470.1 | 607.6 | 211.3 |
| 1 | optimized 3+5 + TAGL | 2,527.7 | 637.2 | 211.3 |
| 1 | main 1+7 | 1,393.4 | 372.8 | 132.0 |
| 1 | optimized 1+7 | 2,510.7 | 720.6 | 273.7 |
| 1 | optimized 1+7 + TAGL | 2,548.1 | 754.1 | 283.8 |
| 16 | main 3+5 | 21,748.5 | 5,096.8 | 1,712.1 |
| 16 | optimized 3+5 | 39,540.8 | 9,688.7 | 3,222.1 |
| 16 | optimized 3+5 + TAGL | 40,247.7 | 9,697.2 | 3,289.7 |
| 16 | main 1+7 | 22,270.0 | 5,862.5 | 2,040.5 |
| 16 | optimized 1+7 | 39,451.0 | 11,766.8 | 4,278.0 |
| 16 | optimized 1+7 + TAGL | 40,229.1 | 11,883.7 | 4,375.4 |
| 32 | main 3+5 | 39,839.2 | 8,724.5 | 2,925.2 |
| 32 | optimized 3+5 | 69,573.8 | 17,639.5 | 5,974.0 |
| 32 | optimized 3+5 + TAGL | 73,923.0 | 18,177.2 | 6,111.4 |
| 32 | main 1+7 | 41,155.9 | 10,726.9 | 3,682.5 |
| 32 | optimized 1+7 | 68,059.9 | 22,167.1 | 8,057.8 |
| 32 | optimized 1+7 + TAGL | 74,713.3 | 22,686.7 | 8,234.0 |

Concurrency: cached layout and prefetch values are immutable. Query computers are request-local; parallel workers continue to construct and own one computer each.

## Documentation Impact

- [x] No public documentation update needed
- [ ] Updated public docs

## Risk and Rollback

- Risk: medium-low. Cached values are derived from the same fields used by the previous getters; request reuse is identity-checked; adaptive prefetch only changes read-ahead hints.
- Rollback: revert `025a7c34` for adaptive prefetch, `2ed91582` for request-scoped computer reuse, or `2a2d6c00` for split-layout caching.

## Checklist

- [ ] I have linked the relevant issue (required for `kind/bug` and `kind/feature`)
- [x] I have added/updated tests for changed behavior
- [x] I have considered API and serialization compatibility
- [x] My commit messages follow project conventions and retain DCO sign-offs
