### PR TITLE
feat: add k-medoids clustering with data-point centers

### DIFF
--- a/src/impl/cluster/CMakeLists.txt
+++ b/src/impl/cluster/CMakeLists.txt
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 
-add_library (cluster OBJECT kmeans_cluster.cpp)
+add_library (cluster OBJECT kmeans_cluster.cpp nearest_centroid_assign.cpp kmedoids_cluster.cpp)
 target_link_libraries (cluster PRIVATE vsag_src_common)

--- a/src/impl/cluster/kmeans_cluster.cpp
+++ b/src/impl/cluster/kmeans_cluster.cpp
@@ -22,13 +22,15 @@
 #include "algorithm/inner_index_interface.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/blas/blas_function.h"
-#include "simd/amx_bf16_matmul.h"
+#include "nearest_centroid_assign.h"
 #include "simd/fp32_simd.h"
-#include "simd/simd_status.h"
-#include "utils/byte_buffer.h"
 #include "utils/util_functions.h"
 
 namespace vsag {
+namespace {
+constexpr uint64_t QUERY_BS = 65536ULL;
+}  // namespace
+
 KMeansCluster::KMeansCluster(int32_t dim, Allocator* allocator, SafeThreadPoolPtr thread_pool)
     : dim_(dim), allocator_(allocator), thread_pool_(std::move(thread_pool)) {
     if (thread_pool_ == nullptr) {
@@ -85,10 +87,6 @@ KMeansCluster::Run(uint32_t k,
     double last_err = std::numeric_limits<double>::max();
     Vector<int32_t> labels(count, -1, this->allocator_);
     std::vector<std::future<void>> futures;
-    ByteBuffer y_sqr_buffer(static_cast<uint64_t>(k) * sizeof(float), allocator_);
-    ByteBuffer distances_buffer(static_cast<uint64_t>(k) * QUERY_BS * sizeof(float), allocator_);
-    auto* y_sqr = reinterpret_cast<float*>(y_sqr_buffer.data);
-    auto* distances = reinterpret_cast<float*>(distances_buffer.data);
 
     logger::trace("KMeansCluster::Run k: {}, count: {}, iter: {}", k, count, iter);
     if (k < THRESHOLD_FOR_HGRAPH) {
@@ -99,7 +97,14 @@ KMeansCluster::Run(uint32_t k,
 
     for (int it = 0; it < iter; ++it) {
         if (k < THRESHOLD_FOR_HGRAPH) {
-            total_err = this->find_nearest_one_with_blas(datas, count, k, y_sqr, distances, labels);
+            total_err = NearestCentroidAssign(k_centroids_,
+                                              k,
+                                              datas,
+                                              count,
+                                              static_cast<uint64_t>(dim_),
+                                              thread_pool_,
+                                              allocator_,
+                                              labels.data());
         } else {
             total_err = this->find_nearest_one_with_hgraph(datas, count, k, labels);
         }
@@ -187,121 +192,6 @@ KMeansCluster::Run(uint32_t k,
         *err = total_err;
     }
     return labels;
-}
-
-double
-KMeansCluster::find_nearest_one_with_blas(const float* query,
-                                          const uint64_t query_count,
-                                          const uint64_t k,
-                                          float* y_sqr,
-                                          float* distances,
-                                          Vector<int32_t>& labels) {
-    double error = 0.0;
-    std::mutex error_mutex;
-    if (k_centroids_ == nullptr) {
-        throw VsagException(ErrorType::INTERNAL_ERROR, "k_centroids_ is nullptr");
-    }
-
-    auto& thread_pool = this->thread_pool_;
-    auto bs = 1024;
-    std::vector<std::future<void>> futures;
-
-    auto wait_futures_and_clear = [&]() {
-        for (auto& future : futures) {
-            future.wait();
-        }
-        futures.clear();
-    };
-
-    auto compute_ip_func = [&](uint64_t start, uint64_t end) -> void {
-        for (uint64_t i = start; i < end; ++i) {
-            y_sqr[i] = FP32ComputeIP(k_centroids_ + i * dim_, k_centroids_ + i * dim_, dim_);
-        }
-    };
-    for (uint64_t i = 0; i < static_cast<uint64_t>(k); i += bs) {
-        futures.emplace_back(thread_pool->GeneralEnqueue(
-            compute_ip_func, i, std::min(i + bs, static_cast<uint64_t>(k))));
-    }
-    wait_futures_and_clear();
-
-    for (uint64_t i = 0; i < query_count; i += QUERY_BS) {
-        auto end = std::min(i + QUERY_BS, query_count);
-        auto cur_query_count = end - i;
-        auto* cur_label = labels.data() + i;
-
-        // Try the AMX BF16 GEMM fast path first.  It returns false if
-        // AMX-BF16 isn't available at runtime; in that case (or when the
-        // shape is too small to amortize tile-config / packing overhead)
-        // fall back to the BLAS SGEMM path.
-        //
-        // Math equivalence:
-        //   SGEMM(ColMajor, Trans, NoTrans, M=k, N=cur_query_count, K=dim,
-        //         alpha=-2, A=k_centroids_ (lda=dim), B=query+i*dim (ldb=dim),
-        //         beta=0, C=distances (ldc=k))
-        //   produces  distances[m + n*k] = -2 * < centroid_m, query_{i+n} >
-        // The AMX kernel takes the same inputs interpreted as row-major
-        // (k x dim) and (cur_query_count x dim) and writes the same
-        // column-major output.
-        constexpr uint64_t amx_bf16_min_dim = 32;
-        constexpr uint64_t amx_bf16_min_m = 16;
-        constexpr uint64_t amx_bf16_min_n = 16;
-        bool used_amx = false;
-        if (static_cast<uint64_t>(dim_) >= amx_bf16_min_dim &&
-            static_cast<uint64_t>(k) >= amx_bf16_min_m && cur_query_count >= amx_bf16_min_n &&
-            SimdStatus::SupportAMXBF16()) {
-            used_amx = amx::SgemmBF16IPColMajorOut(static_cast<int64_t>(k),
-                                                   static_cast<int64_t>(cur_query_count),
-                                                   static_cast<int64_t>(dim_),
-                                                   -2.0F,
-                                                   k_centroids_,
-                                                   query + i * dim_,
-                                                   distances,
-                                                   static_cast<int64_t>(k));
-        }
-        if (!used_amx) {
-            BlasFunction::Sgemm(BlasFunction::ColMajor,
-                                BlasFunction::Trans,
-                                BlasFunction::NoTrans,
-                                static_cast<int32_t>(k),
-                                static_cast<int32_t>(cur_query_count),
-                                dim_,
-                                -2.0F,
-                                k_centroids_,
-                                dim_,
-                                query + i * dim_,
-                                dim_,
-                                0.0F,
-                                distances,
-                                static_cast<int32_t>(k));
-        }
-
-        auto batch_offset = i;
-        auto assign_labels_func = [&, batch_offset](uint64_t start, uint64_t end) -> void {
-            omp_set_num_threads(1);
-            double thread_local_error = 0.0;
-            for (uint64_t i = start; i < end; ++i) {
-                BlasFunction::Saxpy(static_cast<int32_t>(k), 1.0, y_sqr, 1, distances + i * k, 1);
-                auto* min_elem = std::min_element(distances + i * k, distances + i * k + k);
-                auto x_sqr = FP32ComputeIP(
-                    query + (batch_offset + i) * dim_, query + (batch_offset + i) * dim_, dim_);
-                auto min_index = std::distance(distances + i * k, min_elem);
-                thread_local_error += static_cast<double>(*min_elem + x_sqr);
-                if (min_index != cur_label[i]) {
-                    cur_label[i] = static_cast<int>(min_index);
-                }
-            }
-            {
-                std::lock_guard<std::mutex> lock(error_mutex);
-                error += thread_local_error;
-            }
-        };
-        for (uint64_t j = 0; j < cur_query_count; j += bs) {
-            futures.emplace_back(thread_pool->GeneralEnqueue(
-                assign_labels_func, j, std::min(j + bs, cur_query_count)));
-        }
-        wait_futures_and_clear();
-    }
-    return error / static_cast<float>(query_count);
 }
 
 double

--- a/src/impl/cluster/kmeans_cluster.h
+++ b/src/impl/cluster/kmeans_cluster.h
@@ -51,14 +51,6 @@ public:
 
 private:
     double
-    find_nearest_one_with_blas(const float* query,
-                               const uint64_t query_count,
-                               const uint64_t k,
-                               float* y_sqr,
-                               float* distances,
-                               Vector<int32_t>& labels);
-
-    double
     find_nearest_one_with_hgraph(const float* query,
                                  const uint64_t query_count,
                                  const uint64_t k,
@@ -84,8 +76,6 @@ private:
     const int32_t dim_{0};
 
     static constexpr uint64_t THRESHOLD_FOR_HGRAPH = 10000ULL;
-
-    static constexpr uint64_t QUERY_BS = 65536ULL;
 };
 
 }  // namespace vsag

--- a/src/impl/cluster/kmedoids_cluster.cpp
+++ b/src/impl/cluster/kmedoids_cluster.cpp
@@ -1,0 +1,333 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kmedoids_cluster.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <future>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "nearest_centroid_assign.h"
+#include "simd/fp32_simd.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+KMedoidsCluster::KMedoidsCluster(int32_t dim, Allocator* allocator, SafeThreadPoolPtr thread_pool)
+    : allocator_(allocator),
+      thread_pool_(std::move(thread_pool)),
+      dim_(dim),
+      medoid_ids_(allocator) {
+    if (thread_pool_ == nullptr) {
+        thread_pool_ = SafeThreadPool::FactoryDefaultThreadPool();
+    }
+}
+
+KMedoidsCluster::~KMedoidsCluster() {
+    if (k_centroids_ != nullptr) {
+        allocator_->Deallocate(k_centroids_);
+        k_centroids_ = nullptr;
+    }
+}
+
+Vector<int>
+KMedoidsCluster::Run(uint32_t k,
+                     const float* datas,
+                     uint64_t count,
+                     int iter,
+                     double* err,
+                     float threshold,
+                     KMeansInitMethod init_method,
+                     uint64_t seed) {
+    if (allocator_ == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "allocator cannot be null");
+    }
+    if (dim_ <= 0) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "dim must be positive");
+    }
+    if (k == 0) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "k must be positive");
+    }
+    if (count == 0) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "count must be positive");
+    }
+    if (datas == nullptr) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "datas cannot be null");
+    }
+    if (k > count) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT, "k cannot be larger than count");
+    }
+
+    if (k_centroids_ != nullptr) {
+        allocator_->Deallocate(k_centroids_);
+        k_centroids_ = nullptr;
+    }
+    const auto centroid_size = static_cast<uint64_t>(k) * static_cast<uint64_t>(dim_);
+    k_centroids_ = static_cast<float*>(allocator_->Allocate(centroid_size * sizeof(float)));
+    medoid_ids_ = Vector<int64_t>(k, -1, allocator_);
+
+    std::mt19937 gen;
+    if (seed == 0) {
+        std::random_device rd;
+        gen.seed(rd());
+    } else {
+        std::seed_seq seed_sequence{static_cast<uint32_t>(seed), static_cast<uint32_t>(seed >> 32)};
+        gen.seed(seed_sequence);
+    }
+    if (init_method == KMeansInitMethod::KMEANS_PLUS_PLUS) {
+        select_initial_medoids_kmeans_plus_plus(datas, count, k, gen);
+    } else {
+        select_initial_medoids_random(datas, count, k, gen);
+    }
+
+    Vector<int32_t> labels(count, -1, allocator_);
+    double total_err = NearestCentroidAssign(k_centroids_,
+                                             k,
+                                             datas,
+                                             count,
+                                             static_cast<uint64_t>(dim_),
+                                             thread_pool_,
+                                             allocator_,
+                                             labels.data());
+    double last_err = total_err;
+
+    for (int it = 0; it < iter; ++it) {
+        const bool changed = update_medoids(datas, count, labels);
+        if (!changed) {
+            break;
+        }
+        for (uint32_t c = 0; c < k; ++c) {
+            const auto dst_offset = static_cast<uint64_t>(c) * static_cast<uint64_t>(dim_);
+            const auto src_offset =
+                static_cast<uint64_t>(medoid_ids_[c]) * static_cast<uint64_t>(dim_);
+            std::memcpy(k_centroids_ + dst_offset,
+                        datas + src_offset,
+                        static_cast<uint64_t>(dim_) * sizeof(float));
+        }
+        const double new_err = NearestCentroidAssign(k_centroids_,
+                                                     k,
+                                                     datas,
+                                                     count,
+                                                     static_cast<uint64_t>(dim_),
+                                                     thread_pool_,
+                                                     allocator_,
+                                                     labels.data());
+        if (it > 0 && std::fabs(last_err - new_err) < threshold) {
+            total_err = new_err;
+            break;
+        }
+        last_err = new_err;
+        total_err = new_err;
+    }
+
+    if (err != nullptr) {
+        *err = total_err;
+    }
+    return labels;
+}
+
+void
+KMedoidsCluster::select_initial_medoids_random(const float* datas,
+                                               uint64_t count,
+                                               uint32_t k,
+                                               std::mt19937& gen) {
+    std::vector<uint64_t> indices(count);
+    std::iota(indices.begin(), indices.end(), 0);
+    std::shuffle(indices.begin(), indices.end(), gen);
+    for (uint32_t c = 0; c < k; ++c) {
+        const auto index = indices[c];
+        medoid_ids_[c] = static_cast<int64_t>(index);
+        std::memcpy(k_centroids_ + static_cast<uint64_t>(c) * static_cast<uint64_t>(dim_),
+                    datas + index * static_cast<uint64_t>(dim_),
+                    static_cast<uint64_t>(dim_) * sizeof(float));
+    }
+}
+
+void
+KMedoidsCluster::select_initial_medoids_kmeans_plus_plus(const float* datas,
+                                                         uint64_t count,
+                                                         uint32_t k,
+                                                         std::mt19937& gen) {
+    std::uniform_int_distribution<uint64_t> first_dis(0, count - 1);
+    const auto first_idx = first_dis(gen);
+    std::vector<uint8_t> selected(count, 0);
+    selected[first_idx] = 1;
+    medoid_ids_[0] = static_cast<int64_t>(first_idx);
+    std::memcpy(k_centroids_,
+                datas + first_idx * static_cast<uint64_t>(dim_),
+                static_cast<uint64_t>(dim_) * sizeof(float));
+
+    Vector<float> min_distances(count, std::numeric_limits<float>::max(), allocator_);
+    for (uint32_t c = 1; c < k; ++c) {
+        const float* centroid =
+            k_centroids_ + static_cast<uint64_t>(c - 1) * static_cast<uint64_t>(dim_);
+        for (uint64_t i = 0; i < count; ++i) {
+            const float dist = FP32ComputeL2Sqr(
+                datas + i * static_cast<uint64_t>(dim_), centroid, static_cast<uint64_t>(dim_));
+            min_distances[i] = std::min(min_distances[i], dist);
+        }
+        double total_weight = 0.0;
+        for (uint64_t i = 0; i < count; ++i) {
+            if (selected[i] == 0) {
+                total_weight += min_distances[i];
+            }
+        }
+
+        uint64_t selected_idx = count - 1;
+        if (total_weight <= 0.0) {
+            std::vector<uint64_t> candidates;
+            candidates.reserve(count - c);
+            for (uint64_t i = 0; i < count; ++i) {
+                if (selected[i] == 0) {
+                    candidates.push_back(i);
+                }
+            }
+            std::uniform_int_distribution<uint64_t> dis(0, candidates.size() - 1);
+            selected_idx = candidates[dis(gen)];
+        } else {
+            std::uniform_real_distribution<double> prob_dis(0.0, total_weight);
+            const double threshold = prob_dis(gen);
+            double cumulative = 0.0;
+            for (uint64_t i = 0; i < count; ++i) {
+                if (selected[i] == 0) {
+                    cumulative += min_distances[i];
+                    if (cumulative >= threshold) {
+                        selected_idx = i;
+                        break;
+                    }
+                }
+            }
+        }
+        selected[selected_idx] = 1;
+        medoid_ids_[c] = static_cast<int64_t>(selected_idx);
+        std::memcpy(k_centroids_ + static_cast<uint64_t>(c) * static_cast<uint64_t>(dim_),
+                    datas + selected_idx * static_cast<uint64_t>(dim_),
+                    static_cast<uint64_t>(dim_) * sizeof(float));
+    }
+}
+
+bool
+KMedoidsCluster::update_medoids(const float* datas, uint64_t count, const Vector<int32_t>& labels) {
+    const auto k = static_cast<uint64_t>(medoid_ids_.size());
+    Vector<uint64_t> bucket_sizes(k + 1, 0, allocator_);
+    for (uint64_t i = 0; i < count; ++i) {
+        const auto label = labels[i];
+        if (label >= 0 && label < static_cast<int32_t>(k)) {
+            ++bucket_sizes[static_cast<uint64_t>(label) + 1];
+        }
+    }
+    for (uint64_t c = 0; c < k; ++c) {
+        bucket_sizes[c + 1] += bucket_sizes[c];
+    }
+    Vector<uint64_t> cursors(k, 0, allocator_);
+    for (uint64_t c = 0; c < k; ++c) {
+        cursors[c] = bucket_sizes[c];
+    }
+    Vector<uint64_t> members(count, 0, allocator_);
+    for (uint64_t i = 0; i < count; ++i) {
+        const auto label = labels[i];
+        if (label >= 0 && label < static_cast<int32_t>(k)) {
+            members[cursors[static_cast<uint64_t>(label)]++] = i;
+        }
+    }
+
+    Vector<int64_t> new_ids(k, -1, allocator_);
+    Vector<uint8_t> used_indices(count, 0, allocator_);
+    for (uint64_t c = 0; c < k; ++c) {
+        const auto medoid = medoid_ids_[c];
+        if (medoid >= 0 && static_cast<uint64_t>(medoid) < count) {
+            used_indices[static_cast<uint64_t>(medoid)] = 1;
+        }
+    }
+    for (uint64_t c = 0; c < k; ++c) {
+        if (bucket_sizes[c] != bucket_sizes[c + 1]) {
+            continue;
+        }
+        for (uint64_t index = 0; index < count; ++index) {
+            if (used_indices[index] == 0) {
+                new_ids[c] = static_cast<int64_t>(index);
+                used_indices[index] = 1;
+                break;
+            }
+        }
+        if (new_ids[c] < 0) {
+            new_ids[c] = medoid_ids_[c];
+        }
+    }
+    const uint64_t batch_size = CLUSTER_BATCH;
+    std::vector<std::future<void>> futures;
+    for (uint64_t start = 0; start < k; start += batch_size) {
+        const auto end = std::min(start + batch_size, k);
+        futures.emplace_back(thread_pool_->GeneralEnqueue([&, start, end]() {
+            Vector<double> sums(static_cast<uint64_t>(dim_), 0.0, allocator_);
+            Vector<float> mean(static_cast<uint64_t>(dim_), 0.0F, allocator_);
+            for (uint64_t c = start; c < end; ++c) {
+                const auto member_start = bucket_sizes[c];
+                const auto member_end = bucket_sizes[c + 1];
+                if (member_start == member_end) {
+                    continue;
+                }
+                std::fill(sums.begin(), sums.end(), 0.0);
+                const auto member_count = member_end - member_start;
+                for (uint64_t p = member_start; p < member_end; ++p) {
+                    const auto index = members[p];
+                    const auto* data = datas + index * static_cast<uint64_t>(dim_);
+                    for (int32_t d = 0; d < dim_; ++d) {
+                        sums[static_cast<uint64_t>(d)] += data[d];
+                    }
+                }
+                for (int32_t d = 0; d < dim_; ++d) {
+                    mean[static_cast<uint64_t>(d)] = static_cast<float>(
+                        sums[static_cast<uint64_t>(d)] / static_cast<double>(member_count));
+                }
+                uint64_t best_index = members[member_start];
+                float best_distance =
+                    FP32ComputeL2Sqr(datas + best_index * static_cast<uint64_t>(dim_),
+                                     mean.data(),
+                                     static_cast<uint64_t>(dim_));
+                for (uint64_t p = member_start + 1; p < member_end; ++p) {
+                    const auto index = members[p];
+                    const auto distance =
+                        FP32ComputeL2Sqr(datas + index * static_cast<uint64_t>(dim_),
+                                         mean.data(),
+                                         static_cast<uint64_t>(dim_));
+                    if (distance < best_distance) {
+                        best_distance = distance;
+                        best_index = index;
+                    }
+                }
+                new_ids[c] = static_cast<int64_t>(best_index);
+            }
+        }));
+    }
+    for (auto& future : futures) {
+        future.wait();
+    }
+
+    bool changed = false;
+    for (uint64_t c = 0; c < k; ++c) {
+        if (new_ids[c] != medoid_ids_[c]) {
+            changed = true;
+        }
+        medoid_ids_[c] = new_ids[c];
+    }
+    return changed;
+}
+
+}  // namespace vsag

--- a/src/impl/cluster/kmedoids_cluster.h
+++ b/src/impl/cluster/kmedoids_cluster.h
@@ -1,0 +1,99 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <random>
+
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "kmeans_cluster.h"
+#include "typing.h"
+
+namespace vsag {
+
+class Allocator;
+
+// K-medoids clustering: same alternating scheme as `KMeansCluster`, but every
+// center is constrained to be one of the input data points (a medoid).
+//
+// The medoid update relies on the identity
+//     sum_j ||x_i - x_j||^2 = n_c * ||x_i - mean||^2 + const
+// so the exact squared-L2 medoid of a cluster is its member closest to the
+// cluster mean, which keeps every update exact and linear in the cluster size.
+//
+// Note that `seed == 0` selects a non-deterministic seed from
+// `std::random_device` (matching the default behavior of `KMeansCluster`);
+// pass a non-zero value to obtain reproducible results.
+class KMedoidsCluster {
+public:
+    explicit KMedoidsCluster(int32_t dim,
+                             Allocator* allocator,
+                             SafeThreadPoolPtr thread_pool = nullptr);
+
+    ~KMedoidsCluster();
+
+    // Clusters `count` vectors (`datas`, row-major, `dim_` floats per row) into
+    // `k` groups and returns the label of every input row. After the call the
+    // selected medoids are available through `k_centroids_` (k x dim, row-major,
+    // drop-in compatible with `KMeansCluster::k_centroids_`) and their row
+    // indices in `datas` through `medoid_ids_`.
+    //
+    // The loop stops early either when the medoid set is stable or when the
+    // absolute change of the error between two iterations falls below
+    // `threshold`.
+    Vector<int>
+    Run(uint32_t k,
+        const float* datas,
+        uint64_t count,
+        int iter = 10,
+        double* err = nullptr,
+        float threshold = 1e-6F,
+        KMeansInitMethod init_method = KMeansInitMethod::KMEANS_PLUS_PLUS,
+        uint64_t seed = 0);
+
+public:
+    float* k_centroids_{nullptr};
+
+    Vector<int64_t> medoid_ids_;
+
+private:
+    void
+    select_initial_medoids_random(const float* datas,
+                                  uint64_t count,
+                                  uint32_t k,
+                                  std::mt19937& gen);
+
+    void
+    select_initial_medoids_kmeans_plus_plus(const float* datas,
+                                            uint64_t count,
+                                            uint32_t k,
+                                            std::mt19937& gen);
+
+    // Rebuilds every medoid from its cluster and returns true when at least
+    // one medoid changed.
+    bool
+    update_medoids(const float* datas, uint64_t count, const Vector<int32_t>& labels);
+
+private:
+    Allocator* const allocator_{nullptr};
+
+    SafeThreadPoolPtr thread_pool_{nullptr};
+
+    const int32_t dim_{0};
+
+    static constexpr uint64_t CLUSTER_BATCH = 64ULL;
+};
+
+}  // namespace vsag

--- a/src/impl/cluster/kmedoids_cluster_test.cpp
+++ b/src/impl/cluster/kmedoids_cluster_test.cpp
@@ -1,0 +1,143 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kmedoids_cluster.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "impl/allocator/safe_allocator.h"
+#include "unittest.h"
+#include "vsag_exception.h"
+
+namespace {
+std::vector<float>
+GenerateBlobs(uint64_t blob_count, uint64_t dim, uint64_t per_blob, float distance, float noise) {
+    std::vector<float> result(blob_count * per_blob * dim, 0.0F);
+    std::mt19937 gen(1234);
+    std::normal_distribution<float> distribution(0.0F, noise);
+    for (uint64_t blob = 0; blob < blob_count; ++blob) {
+        for (uint64_t point = 0; point < per_blob; ++point) {
+            const auto row = blob * per_blob + point;
+            for (uint64_t d = 0; d < dim; ++d) {
+                result[row * dim + d] = (d == blob ? distance : 0.0F) + distribution(gen);
+            }
+        }
+    }
+    return result;
+}
+
+void
+RequireDataPointCentroids(const vsag::KMedoidsCluster& cluster,
+                          const std::vector<float>& datas,
+                          uint64_t dim) {
+    for (uint64_t c = 0; c < cluster.medoid_ids_.size(); ++c) {
+        REQUIRE(cluster.medoid_ids_[c] >= 0);
+        const auto id = static_cast<uint64_t>(cluster.medoid_ids_[c]);
+        REQUIRE(std::memcmp(cluster.k_centroids_ + c * dim,
+                            datas.data() + id * dim,
+                            dim * sizeof(float)) == 0);
+    }
+}
+}  // namespace
+
+TEST_CASE("KMedoids returns input data points", "[ut][KMedoidsCluster]") {
+    constexpr uint64_t k = 3;
+    constexpr uint64_t dim = 16;
+    constexpr uint64_t count_per_cluster = 200;
+    auto datas = GenerateBlobs(k, dim, count_per_cluster, 20.0F, 0.5F);
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::KMedoidsCluster cluster(static_cast<int32_t>(dim), allocator.get());
+    double error = 0.0;
+    auto labels = cluster.Run(k,
+                              datas.data(),
+                              datas.size() / dim,
+                              10,
+                              &error,
+                              1e-6F,
+                              vsag::KMeansInitMethod::KMEANS_PLUS_PLUS,
+                              12345);
+    REQUIRE(labels.size() == datas.size() / dim);
+    REQUIRE(error >= 0.0);
+    RequireDataPointCentroids(cluster, datas, dim);
+}
+
+TEST_CASE("KMedoids is deterministic with a seed", "[ut][KMedoidsCluster]") {
+    constexpr uint64_t k = 3;
+    constexpr uint64_t dim = 16;
+    auto datas = GenerateBlobs(k, dim, 100, 20.0F, 0.75F);
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::KMedoidsCluster first(static_cast<int32_t>(dim), allocator.get());
+    vsag::KMedoidsCluster second(static_cast<int32_t>(dim), allocator.get());
+    double first_error = 0.0;
+    double second_error = 0.0;
+    auto first_labels = first.Run(k,
+                                  datas.data(),
+                                  datas.size() / dim,
+                                  10,
+                                  &first_error,
+                                  1e-6F,
+                                  vsag::KMeansInitMethod::KMEANS_PLUS_PLUS,
+                                  7);
+    auto second_labels = second.Run(k,
+                                    datas.data(),
+                                    datas.size() / dim,
+                                    10,
+                                    &second_error,
+                                    1e-6F,
+                                    vsag::KMeansInitMethod::KMEANS_PLUS_PLUS,
+                                    7);
+    REQUIRE(first_labels == second_labels);
+    REQUIRE(first.medoid_ids_ == second.medoid_ids_);
+    REQUIRE(std::fabs(first_error - second_error) <= 1e-6 * std::max(1.0, first_error));
+}
+
+TEST_CASE("KMedoids validates input", "[ut][KMedoidsCluster]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::KMedoidsCluster cluster(2, allocator.get());
+    const float data[] = {0.0F, 0.0F, 1.0F, 1.0F};
+    REQUIRE_THROWS_AS(cluster.Run(0, data, 2), vsag::VsagException);
+    REQUIRE_THROWS_AS(cluster.Run(1, data, 0), vsag::VsagException);
+    REQUIRE_THROWS_AS(cluster.Run(1, nullptr, 2), vsag::VsagException);
+    REQUIRE_THROWS_AS(cluster.Run(3, data, 2), vsag::VsagException);
+}
+
+TEST_CASE("KMedoids handles one and all-point clusters", "[ut][KMedoidsCluster]") {
+    constexpr uint64_t dim = 2;
+    constexpr uint64_t count = 6;
+    const std::vector<float> datas = {
+        0.0F, 0.0F, 1.0F, 0.0F, 2.0F, 0.0F, 3.0F, 0.0F, 4.0F, 0.0F, 5.0F, 0.0F};
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::KMedoidsCluster one(static_cast<int32_t>(dim), allocator.get());
+    auto one_labels = one.Run(
+        1, datas.data(), count, 5, nullptr, 1e-6F, vsag::KMeansInitMethod::KMEANS_PLUS_PLUS, 11);
+    REQUIRE(one_labels.size() == count);
+    RequireDataPointCentroids(one, datas, dim);
+
+    vsag::KMedoidsCluster all(static_cast<int32_t>(dim), allocator.get());
+    auto all_labels = all.Run(count,
+                              datas.data(),
+                              count,
+                              5,
+                              nullptr,
+                              1e-6F,
+                              vsag::KMeansInitMethod::KMEANS_PLUS_PLUS,
+                              11);
+    REQUIRE(all_labels.size() == count);
+    RequireDataPointCentroids(all, datas, dim);
+}

--- a/src/impl/cluster/nearest_centroid_assign.cpp
+++ b/src/impl/cluster/nearest_centroid_assign.cpp
@@ -1,0 +1,170 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nearest_centroid_assign.h"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <future>
+#include <limits>
+#include <mutex>
+
+#include "impl/blas/blas_function.h"
+#include "simd/amx_bf16_matmul.h"
+#include "simd/fp32_simd.h"
+#include "simd/simd_status.h"
+#include "utils/byte_buffer.h"
+#include "vsag_exception.h"
+
+namespace vsag {
+
+namespace {
+constexpr uint64_t QUERY_BS = 65536ULL;
+constexpr uint64_t ASSIGN_BS = 1024;
+}  // namespace
+
+double
+NearestCentroidAssign(const float* centroids,
+                      uint64_t centroid_count,
+                      const float* queries,
+                      uint64_t query_count,
+                      uint64_t dim,
+                      const SafeThreadPoolPtr& thread_pool,
+                      Allocator* allocator,
+                      int32_t* labels) {
+    double error = 0.0;
+    std::mutex error_mutex;
+    if (centroids == nullptr || queries == nullptr || labels == nullptr || allocator == nullptr ||
+        thread_pool == nullptr || centroid_count == 0 || query_count == 0 || dim == 0 ||
+        centroid_count > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) ||
+        dim > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            "invalid nearest-centroid assignment input");
+    }
+    const auto& thread_pool_ref = thread_pool;
+    auto bs = ASSIGN_BS;
+    std::vector<std::future<void>> futures;
+
+    auto wait_futures_and_clear = [&]() {
+        for (auto& future : futures) {
+            future.wait();
+        }
+        futures.clear();
+    };
+
+    const auto distance_batch_size = std::min(QUERY_BS, query_count);
+    ByteBuffer y_sqr_buffer(centroid_count * sizeof(float), allocator);
+    ByteBuffer distances_buffer(centroid_count * distance_batch_size * sizeof(float), allocator);
+    auto* y_sqr = reinterpret_cast<float*>(y_sqr_buffer.data);
+    auto* distances = reinterpret_cast<float*>(distances_buffer.data);
+
+    auto compute_ip_func = [&](uint64_t start, uint64_t end) -> void {
+        for (uint64_t i = start; i < end; ++i) {
+            y_sqr[i] = FP32ComputeIP(centroids + i * dim, centroids + i * dim, dim);
+        }
+    };
+    for (uint64_t i = 0; i < centroid_count; i += bs) {
+        futures.emplace_back(
+            thread_pool_ref->GeneralEnqueue(compute_ip_func, i, std::min(i + bs, centroid_count)));
+    }
+    wait_futures_and_clear();
+
+    for (uint64_t i = 0; i < query_count; i += QUERY_BS) {
+        auto end = std::min(i + QUERY_BS, query_count);
+        auto cur_query_count = end - i;
+        auto* cur_label = labels + i;
+
+        // Try the AMX BF16 GEMM fast path first.  It returns false if
+        // AMX-BF16 isn't available at runtime; in that case (or when the
+        // shape is too small to amortize tile-config / packing overhead)
+        // fall back to the BLAS SGEMM path.
+        //
+        // Math equivalence:
+        //   SGEMM(ColMajor, Trans, NoTrans, M=centroid_count, N=cur_query_count, K=dim,
+        //         alpha=-2, A=centroids (lda=dim), B=queries+i*dim (ldb=dim),
+        //         beta=0, C=distances (ldc=centroid_count))
+        //   produces  distances[m + n*centroid_count] = -2 * < centroid_m, query_{i+n} >
+        // The AMX kernel takes the same inputs interpreted as row-major
+        // (centroid_count x dim) and (cur_query_count x dim) and writes the same
+        // column-major output.
+        constexpr uint64_t amx_bf16_min_dim = 32;
+        constexpr uint64_t amx_bf16_min_m = 16;
+        constexpr uint64_t amx_bf16_min_n = 16;
+        bool used_amx = false;
+        if (dim >= amx_bf16_min_dim && centroid_count >= amx_bf16_min_m &&
+            cur_query_count >= amx_bf16_min_n && SimdStatus::SupportAMXBF16()) {
+            used_amx = amx::SgemmBF16IPColMajorOut(static_cast<int64_t>(centroid_count),
+                                                   static_cast<int64_t>(cur_query_count),
+                                                   static_cast<int64_t>(dim),
+                                                   -2.0F,
+                                                   centroids,
+                                                   queries + i * dim,
+                                                   distances,
+                                                   static_cast<int64_t>(centroid_count));
+        }
+        if (!used_amx) {
+            BlasFunction::Sgemm(BlasFunction::ColMajor,
+                                BlasFunction::Trans,
+                                BlasFunction::NoTrans,
+                                static_cast<int32_t>(centroid_count),
+                                static_cast<int32_t>(cur_query_count),
+                                static_cast<int32_t>(dim),
+                                -2.0F,
+                                centroids,
+                                static_cast<int32_t>(dim),
+                                queries + i * dim,
+                                static_cast<int32_t>(dim),
+                                0.0F,
+                                distances,
+                                static_cast<int32_t>(centroid_count));
+        }
+
+        auto batch_offset = i;
+        auto assign_labels_func = [&, batch_offset](uint64_t start, uint64_t end) -> void {
+            omp_set_num_threads(1);
+            double thread_local_error = 0.0;
+            for (uint64_t j = start; j < end; ++j) {
+                BlasFunction::Saxpy(static_cast<int32_t>(centroid_count),
+                                    1.0,
+                                    y_sqr,
+                                    1,
+                                    distances + j * centroid_count,
+                                    1);
+                auto* min_elem = std::min_element(distances + j * centroid_count,
+                                                  distances + j * centroid_count + centroid_count);
+                auto x_sqr = FP32ComputeIP(
+                    queries + (batch_offset + j) * dim, queries + (batch_offset + j) * dim, dim);
+                auto min_index = std::distance(distances + j * centroid_count, min_elem);
+                thread_local_error += static_cast<double>(*min_elem + x_sqr);
+                if (min_index != cur_label[j]) {
+                    cur_label[j] = static_cast<int32_t>(min_index);
+                }
+            }
+            {
+                std::lock_guard<std::mutex> lock(error_mutex);
+                error += thread_local_error;
+            }
+        };
+        for (uint64_t j = 0; j < cur_query_count; j += bs) {
+            futures.emplace_back(thread_pool_ref->GeneralEnqueue(
+                assign_labels_func, j, std::min(j + bs, cur_query_count)));
+        }
+        wait_futures_and_clear();
+    }
+    return error / static_cast<double>(query_count);
+}
+
+}  // namespace vsag

--- a/src/impl/cluster/nearest_centroid_assign.h
+++ b/src/impl/cluster/nearest_centroid_assign.h
@@ -1,0 +1,48 @@
+
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "impl/thread_pool/safe_thread_pool.h"
+#include "typing.h"
+
+namespace vsag {
+
+class Allocator;
+
+// Assigns every query vector to its nearest centroid under the squared L2
+// metric (`labels[i] = argmin_c ||queries[i] - centroids[c]||^2`) and returns
+// the mean of the selected minimal squared distances.
+//
+// The batched GEMM formulation relies on the identity
+//     ||q - c||^2 = ||q||^2 + ||c||^2 - 2 <c, q>
+// and first tries the AMX BF16 GEMM fast path when the runtime CPU supports it
+// and the problem shape is large enough to amortize tile setup and packing
+// overhead; otherwise it falls back to BLAS SGEMM. Both paths select the same
+// labels.
+//
+// `labels` must provide room for `query_count` entries; entries that are
+// already equal to the selected label are left untouched.
+double
+NearestCentroidAssign(const float* centroids,
+                      uint64_t centroid_count,
+                      const float* queries,
+                      uint64_t query_count,
+                      uint64_t dim,
+                      const SafeThreadPoolPtr& thread_pool,
+                      Allocator* allocator,
+                      int32_t* labels);
+
+}  // namespace vsag


### PR DESCRIPTION
## Summary
Implement squared-L2 k-medoids clustering with centers constrained to input data points.

## Changes
- Add KMedoidsCluster with random and k-means++ initialization.
- Expose medoid row IDs while retaining the centroid buffer layout for IVF compatibility.
- Use the exact squared-L2 identity that selects the cluster member nearest to its mean, avoiding quadratic pairwise distance updates.
- Extract shared nearest-centroid assignment code from KMeansCluster and retain BLAS/AMX-BF16 acceleration.
- Add unit tests covering data-point centers, deterministic seeds, invalid inputs, and one/all-point clusters.

Fixes: #2815

## Validation
- make debug: passed.
- make release: passed.
- make fmt: passed.
- make lint: passed with clang-format/clang-tidy 15.
- make test: blocked by Catch2 v3.7.1 download timeout from GitHub in the remote environment.