### PR TITLE
ci: use generic OpenBLAS baseline in x86 wheel and daily builds

### DIFF
--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -131,7 +131,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
-          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'TARGET=GENERIC' || '' }}
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'VSAG_OPENBLAS_TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: "pip install numpy pytest && ls -alF /project/ && python /project/tests/python/run_test.py"
 
       - uses: actions/upload-artifact@v5
@@ -165,7 +165,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
-          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'TARGET=GENERIC' || '' }}
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'VSAG_OPENBLAS_TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: |
             pip install numpy pytest && \
             echo "=== Running VSAG Python Tests ===" && \
@@ -213,7 +213,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: "cp36-*"
-          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'TARGET=GENERIC' || '' }}
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'VSAG_OPENBLAS_TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: |
             pip install numpy pytest && \
             echo "=== Running VSAG Python Tests ===" && \

--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -131,6 +131,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: "pip install numpy pytest && ls -alF /project/ && python /project/tests/python/run_test.py"
 
       - uses: actions/upload-artifact@v5
@@ -164,6 +165,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: |
             pip install numpy pytest && \
             echo "=== Running VSAG Python Tests ===" && \
@@ -211,6 +213,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: "cp36-*"
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: |
             pip install numpy pytest && \
             echo "=== Running VSAG Python Tests ===" && \

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -322,7 +322,7 @@ jobs:
           key: build-tsan-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Tsan
         env:
-          TARGET: GENERIC
+          VSAG_OPENBLAS_TARGET: GENERIC
         run: export CMAKE_GENERATOR="Ninja"; make tsan COMPILE_JOBS=3
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -321,6 +321,8 @@ jobs:
           save: false
           key: build-tsan-${{ hashFiles('./CMakeLists.txt') }}-${{ hashFiles('./.circleci/fresh_ci_cache.commit') }}
       - name: Make Tsan
+        env:
+          TARGET: GENERIC
         run: export CMAKE_GENERATOR="Ninja"; make tsan COMPILE_JOBS=3
       - name: Clean
         run: find ./build -type f -name "*.o" -exec rm -f {} +

--- a/.github/workflows/python_build_and_test.yml
+++ b/.github/workflows/python_build_and_test.yml
@@ -32,8 +32,8 @@ jobs:
             sudo apt update
             sudo apt install -y python3-venv
             export CMAKE_GENERATOR="Ninja"
-            export TARGET=GENERIC
-            export CIBW_ENVIRONMENT="${CIBW_ENVIRONMENT:+$CIBW_ENVIRONMENT }TARGET=GENERIC"
+            export VSAG_OPENBLAS_TARGET=GENERIC
+            export CIBW_ENVIRONMENT="${CIBW_ENVIRONMENT:+$CIBW_ENVIRONMENT }VSAG_OPENBLAS_TARGET=GENERIC"
             make pyvsag
       - name: Save Wheel
         uses: actions/upload-artifact@v5

--- a/.github/workflows/python_build_and_test.yml
+++ b/.github/workflows/python_build_and_test.yml
@@ -31,7 +31,10 @@ jobs:
         run: |
             sudo apt update
             sudo apt install -y python3-venv
-            export CMAKE_GENERATOR="Ninja"; make pyvsag
+            export CMAKE_GENERATOR="Ninja"
+            export TARGET=GENERIC
+            export CIBW_ENVIRONMENT="${CIBW_ENVIRONMENT:+$CIBW_ENVIRONMENT }TARGET=GENERIC"
+            make pyvsag
       - name: Save Wheel
         uses: actions/upload-artifact@v5
         with:

--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -195,7 +195,13 @@ if (NOT OPENBLAS_FOUND)
 
     set (_openblas_target_arg)
     if (DEFINED ENV{VSAG_OPENBLAS_TARGET} AND NOT "$ENV{VSAG_OPENBLAS_TARGET}" STREQUAL "")
-        list (APPEND _openblas_target_arg "TARGET=$ENV{VSAG_OPENBLAS_TARGET}")
+        string (STRIP "$ENV{VSAG_OPENBLAS_TARGET}" _openblas_target)
+        if (NOT _openblas_target MATCHES "^[A-Za-z0-9_]+$")
+            message (FATAL_ERROR
+                     "VSAG_OPENBLAS_TARGET must contain only letters, digits, or underscores; "
+                     "got '$ENV{VSAG_OPENBLAS_TARGET}'.")
+        endif ()
+        list (APPEND _openblas_target_arg "TARGET=${_openblas_target}")
     endif ()
 
     ExternalProject_Add (

--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -193,6 +193,11 @@ if (NOT OPENBLAS_FOUND)
     string (STRIP "${_openblas_c_flags}" _openblas_c_flags)
     string (STRIP "${_openblas_cxx_flags}" _openblas_cxx_flags)
 
+    set (_openblas_target_arg)
+    if (DEFINED ENV{VSAG_OPENBLAS_TARGET} AND NOT "$ENV{VSAG_OPENBLAS_TARGET}" STREQUAL "")
+        list (APPEND _openblas_target_arg "TARGET=$ENV{VSAG_OPENBLAS_TARGET}")
+    endif ()
+
     ExternalProject_Add (
         ${name}
         URL ${openblas_urls}
@@ -211,9 +216,11 @@ if (NOT OPENBLAS_FOUND)
             OMP_NUM_THREADS=1
             PATH=/usr/lib/ccache:$ENV{PATH}
             LD_LIBRARY_PATH=/opt/alibaba-cloud-compiler/lib64/:$ENV{LD_LIBRARY_PATH}
-            make USE_THREAD=0 USE_LOCKING=1 DYNAMIC_ARCH=1 NOFORTRAN=1 -j1
+            make USE_THREAD=0 USE_LOCKING=1 ${_openblas_target_arg} DYNAMIC_ARCH=1
+                 NOFORTRAN=1 -j1
         INSTALL_COMMAND
-            make DYNAMIC_ARCH=1 NOFORTRAN=1 PREFIX=${install_dir} install
+            make ${_openblas_target_arg} DYNAMIC_ARCH=1 NOFORTRAN=1 PREFIX=${install_dir}
+                 install
         BUILD_IN_SOURCE 1
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Related to #2439
- Related to #2507
- Follow-up to #2800
- Fixes: #2829

## What Changed

- Set `VSAG_OPENBLAS_TARGET=GENERIC` for the x86 Python push-wheel job and forward it through `CIBW_ENVIRONMENT` into cibuildwheel's manylinux container.
- Set the same namespaced override for Daily TSAN, which still builds bundled OpenBLAS and has recently failed in that source-build step.
- Pass `VSAG_OPENBLAS_TARGET=GENERIC` to the modern, legacy, and Python 3.6 release-wheel matrices only when `matrix.arch == 'x86_64'`.
- Keep OpenBLAS `DYNAMIC_ARCH=1` unchanged, so generated wheels retain runtime-dispatched optimized kernels.
- Trim and validate `VSAG_OPENBLAS_TARGET`, then translate it to OpenBLAS's native `TARGET` argument in `extern/openblas/openblas.cmake` for both build and install.
- Leave AArch64, local build defaults, and jobs using system OpenBLAS or MKL unchanged. When the variable is unset, no `TARGET` argument is emitted.

The original occurrence in [job 98086554071](https://github.com/antgroup/vsag/actions/runs/32939221135/job/98086554071) exposed only the outer bundled-OpenBLAS status 2 because its nested build log was not yet printed. The root cause was later confirmed directly in [job 99716311973](https://github.com/antgroup/vsag/actions/runs/33462789060/job/99716311973): OpenBLAS reported missing `getarch_2nd` configuration macros and `Detecting CPU failed. Please set TARGET explicitly`.

Daily TSAN remains on the same bundled OpenBLAS 0.3.24 build path. [Job 98704202204](https://github.com/antgroup/vsag/actions/runs/33126005498/job/98704202204) and [job 99297094854](https://github.com/antgroup/vsag/actions/runs/33326365240/job/99297094854) failed in that step before nested-log retention was available. They establish the shared failure surface, although their hidden inner diagnostics cannot independently prove `CORE=UNKNOWN`.

This restores the x86 `TARGET=GENERIC` baseline precedent from #527 while retaining the dynamic dispatch introduced by #769.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (controlled OpenBLAS A/B, wheel build/tests, workflow validation, and independent review)

Test details:

```text
OpenBLAS 0.3.24 forced-UNKNOWN A/B:
- DYNAMIC_ARCH=1 without TARGET: exit 2, reproducing CORE=UNKNOWN and the same getarch_2nd GEMM configuration errors.
- TARGET=GENERIC DYNAMIC_ARCH=1: full BLAS/CBLAS/LAPACK/LAPACKE build and install passed.

Installed OpenBLAS runtime probes:
- Automatic dispatch selected SkylakeX; CBLAS SGEMM returned the expected matrix.
- OPENBLAS_CORETYPE=PRESCOTT selected Prescott; the same SGEMM result passed.

Python wheel path with VSAG_OPENBLAS_TARGET=GENERIC and bundled dependencies:
- Built and installed pyvsag-1.1.0.dev128 for Python 3.10.
- Python suite: 110 passed, 3 warnings.
- auditwheel-repaired wheel installed in a fresh venv with no LD_LIBRARY_PATH override.
- IVF/KMeans build + full-bucket KNN smoke passed with automatic dispatch and forced Prescott, returning the exact self ID at distance 0.0. The smoke used dim=16 to exercise OpenBLAS SGEMM instead of the AMX fast path.

Workflow checks:
- actionlint 1.7.12: pass for all three changed workflows.
- YAML parse: pass.
- All three release-wheel jobs contain the x86-only CIBW_ENVIRONMENT expression: pass.
- Daily TSAN step-level VSAG_OPENBLAS_TARGET environment assertion: pass.
- CMake mapping probe: unset emits no TARGET; trimmed GENERIC and RISCV64_GENERIC map into build/install; semicolon and whitespace argument injection fail during configuration.
- DYNAMIC_ARCH=1 build/install configuration remains present: pass.
- git diff --check: pass.
- Independent scope/design review: no findings.
```

The local host has no Docker daemon, so the full GitHub Actions/cibuildwheel matrix was not executed locally. The earlier native build, auditwheel repair, fresh installation, and runtime probes validate the resulting bundled library; CI will validate the workflow container handoff.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: only the selected x86 CI source builds use a generic OpenBLAS common-code baseline; runtime kernel dispatch remains enabled
- Local builds and AArch64 behavior: unchanged

## Performance and Concurrency Impact

- Performance impact: optimized runtime-selected OpenBLAS kernels remain present; no material regression is expected
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Scope Boundary

The release tarball workflow builds inside an additional nested Docker boundary and is not changed here; forwarding CI-only configuration into that script can be handled separately. Historical-tag generation is also outside this main-branch workflow fix.

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this PR to restore build-host CPU auto-detection in these CI jobs

## Checklist

- [x] I have linked the relevant issues
- [x] No repository test was added; this CI-only behavior was verified with controlled A/B, end-to-end runtime probes, static workflow validation, and independent review
- [x] I have considered API compatibility impact
- [x] No documentation update is required
- [x] My commit messages follow project conventions


