### PR TITLE
refactor(datacell): use FixedLayout for graph records

### DIFF
--- a/src/datacell/graph_datacell.h
+++ b/src/datacell/graph_datacell.h
@@ -27,6 +27,7 @@
 #include "impl/reverse_edge.h"
 #include "index_common_param.h"
 #include "io/common/basic_io.h"
+#include "layout/fixed_layout.h"
 #include "vsag/constants.h"
 
 namespace vsag {
@@ -73,12 +74,12 @@ public:
 
     inline void
     SetIO(std::shared_ptr<BasicIO<IOTmpl>> io) {
-        this->io_ = io;
+        this->layout_.SetIO(std::move(io));
     }
 
     virtual void
     InitIO(const IOParamPtr& io_param) override {
-        this->io_->InitIO(io_param);
+        this->layout_.InitIO(io_param);
     }
 
     /****
@@ -88,8 +89,9 @@ public:
      */
     void
     Prefetch(InnerIdType id, uint32_t neighbor_i) override {
-        io_->Prefetch(static_cast<uint64_t>(id) * static_cast<uint64_t>(this->code_line_size_) +
-                      sizeof(uint32_t) + neighbor_i * sizeof(InnerIdType));
+        const uint64_t offset_in_record =
+            NEIGHBORS_OFFSET + static_cast<uint64_t>(neighbor_i) * sizeof(InnerIdType);
+        layout_.PrefetchAt(id, offset_in_record, 64);
     }
 
     void
@@ -109,9 +111,7 @@ public:
     uint64_t
     GetMemoryUsage() const override {
         uint64_t memory = sizeof(GraphDataCell) + node_versions_.size() * sizeof(uint8_t);
-        if (IOTmpl::InMemory) {
-            memory += io_->GetMemoryUsage();
-        }
+        memory += layout_.GetMemoryUsage();
         if (reverse_edges_) {
             memory += reverse_edges_->GetMemoryUsage();
         }
@@ -137,8 +137,7 @@ public:
 
     void
     ShrinkToFit(InnerIdType capacity) override {
-        uint64_t io_size = static_cast<uint64_t>(capacity) * static_cast<uint64_t>(code_line_size_);
-        this->io_->Shrink(io_size);
+        this->layout_.Shrink(capacity);
         if (is_support_delete_) {
             node_versions_.resize(capacity);
         }
@@ -146,7 +145,10 @@ public:
     }
 
 protected:
-    std::shared_ptr<BasicIO<IOTmpl>> io_{nullptr};
+    static constexpr uint64_t COUNT_OFFSET = 0;
+    static constexpr uint64_t NEIGHBORS_OFFSET = sizeof(uint32_t);
+
+    FixedLayout<IOTmpl> layout_{};
 
     Vector<uint8_t> node_versions_;
 
@@ -191,7 +193,6 @@ template <typename IOTmpl>
 GraphDataCell<IOTmpl>::GraphDataCell(const GraphDataCellParamPtr& param,
                                      const IndexCommonParam& common_param)
     : node_versions_(common_param.allocator_.get()) {
-    this->io_ = std::make_shared<IOTmpl>(param->io_parameter_, common_param);
     this->maximum_degree_ = param->max_degree_;
     this->max_capacity_ = param->init_max_capacity_;
     this->is_support_delete_ = param->support_remove_;
@@ -199,6 +200,8 @@ GraphDataCell<IOTmpl>::GraphDataCell(const GraphDataCellParamPtr& param,
     this->id_bit_ = sizeof(InnerIdType) * 8 - this->remove_flag_bit_;
     this->remove_flag_mask_ = (1 << this->id_bit_) - 1;
     this->code_line_size_ = this->maximum_degree_ * sizeof(InnerIdType) + sizeof(uint32_t);
+    this->layout_.SetCodeSize(this->code_line_size_);
+    this->layout_.SetIO(std::make_shared<IOTmpl>(param->io_parameter_, common_param));
     this->allocator_ = common_param.allocator_.get();
     if (this->is_support_delete_) {
         node_versions_.resize(max_capacity_);
@@ -238,54 +241,60 @@ GraphDataCell<IOTmpl>::InsertNeighborsById(InnerIdType id,
     InnerIdType current = total_count_.load();
     while (current < id + 1 && !total_count_.compare_exchange_weak(current, id + 1)) {
     }
-    auto start = static_cast<uint64_t>(id) * static_cast<uint64_t>(this->code_line_size_);
     if (is_support_delete_) {
         uint32_t neighbor_count = std::min((uint32_t)(neighbor_ids.size()), this->maximum_degree_);
-        this->io_->Write((uint8_t*)(&neighbor_count), sizeof(neighbor_count), start);
-        start += sizeof(neighbor_count);
+        this->layout_.WriteAt(id,
+                              COUNT_OFFSET,
+                              reinterpret_cast<const uint8_t*>(&neighbor_count),
+                              sizeof(neighbor_count));
         Vector<InnerIdType> neighbor_ids_ptr(neighbor_ids.size(), 0, this->allocator_);
         for (int i = 0; i < neighbor_ids.size(); ++i) {
             auto neighbor_id = neighbor_ids[i];
             neighbor_ids_ptr[i] = neighbor_id | (node_versions_[neighbor_id] << id_bit_);
         }
-        this->io_->Write((uint8_t*)(neighbor_ids_ptr.data()),
-                         static_cast<uint64_t>(neighbor_count) * sizeof(InnerIdType),
-                         start);
+        this->layout_.WriteAt(id,
+                              NEIGHBORS_OFFSET,
+                              reinterpret_cast<const uint8_t*>(neighbor_ids_ptr.data()),
+                              static_cast<uint64_t>(neighbor_count) * sizeof(InnerIdType));
     } else {
         uint32_t neighbor_count = std::min((uint32_t)(neighbor_ids.size()), this->maximum_degree_);
-        this->io_->Write((uint8_t*)(&neighbor_count), sizeof(neighbor_count), start);
-        start += sizeof(neighbor_count);
-        this->io_->Write((uint8_t*)(neighbor_ids.data()),
-                         static_cast<uint64_t>(neighbor_count) * sizeof(InnerIdType),
-                         start);
+        this->layout_.WriteAt(id,
+                              COUNT_OFFSET,
+                              reinterpret_cast<const uint8_t*>(&neighbor_count),
+                              sizeof(neighbor_count));
+        this->layout_.WriteAt(id,
+                              NEIGHBORS_OFFSET,
+                              reinterpret_cast<const uint8_t*>(neighbor_ids.data()),
+                              static_cast<uint64_t>(neighbor_count) * sizeof(InnerIdType));
     }
 }
 
 template <typename IOTmpl>
 uint32_t
 GraphDataCell<IOTmpl>::GetNeighborSize(InnerIdType id) const {
-    auto start = static_cast<uint64_t>(id) * static_cast<uint64_t>(this->code_line_size_);
     uint32_t neighbor_count = 0;
-    this->io_->Read(sizeof(neighbor_count), start, (uint8_t*)(&neighbor_count));
+    this->layout_.ReadAt(
+        id, COUNT_OFFSET, sizeof(neighbor_count), reinterpret_cast<uint8_t*>(&neighbor_count));
     return neighbor_count;
 }
 
 template <typename IOTmpl>
 void
 GraphDataCell<IOTmpl>::GetNeighbors(InnerIdType id, Vector<InnerIdType>& neighbor_ids) const {
-    auto start = static_cast<uint64_t>(id) * static_cast<uint64_t>(this->code_line_size_);
     uint32_t neighbor_count = 0;
-    this->io_->Read(sizeof(neighbor_count), start, (uint8_t*)(&neighbor_count));
+    this->layout_.ReadAt(
+        id, COUNT_OFFSET, sizeof(neighbor_count), reinterpret_cast<uint8_t*>(&neighbor_count));
     if (neighbor_count > this->maximum_degree_) {
         neighbor_ids.clear();
         return;
     }
     if (is_support_delete_) {
         neighbor_count &= remove_flag_mask_;
-        start += sizeof(neighbor_count);
         Vector<InnerIdType> shared_neighbor_ids(neighbor_count, this->allocator_);
-        this->io_->Read(
-            neighbor_count * sizeof(InnerIdType), start, (uint8_t*)(shared_neighbor_ids.data()));
+        this->layout_.ReadAt(id,
+                             NEIGHBORS_OFFSET,
+                             static_cast<uint64_t>(neighbor_count) * sizeof(InnerIdType),
+                             reinterpret_cast<uint8_t*>(shared_neighbor_ids.data()));
         neighbor_ids.clear();
         neighbor_ids.reserve(neighbor_count);
         for (int i = 0; i < neighbor_count; ++i) {
@@ -296,10 +305,11 @@ GraphDataCell<IOTmpl>::GetNeighbors(InnerIdType id, Vector<InnerIdType>& neighbo
             }
         }
     } else {
-        start += sizeof(neighbor_count);
         neighbor_ids.resize(neighbor_count);
-        this->io_->Read(
-            neighbor_ids.size() * sizeof(InnerIdType), start, (uint8_t*)(neighbor_ids.data()));
+        this->layout_.ReadAt(id,
+                             NEIGHBORS_OFFSET,
+                             static_cast<uint64_t>(neighbor_ids.size()) * sizeof(InnerIdType),
+                             reinterpret_cast<uint8_t*>(neighbor_ids.data()));
     }
 }
 
@@ -317,8 +327,7 @@ GraphDataCell<IOTmpl>::Resize(InnerIdType new_size) {
         }
         node_versions_.resize(new_size);
     }
-    uint64_t io_size = static_cast<uint64_t>(new_size) * static_cast<uint64_t>(code_line_size_);
-    this->io_->Resize(io_size);
+    this->layout_.Resize(new_size);
     this->max_capacity_ = new_size;
     if (this->duplicate_tracker_ != nullptr) {
         this->duplicate_tracker_->Resize(new_size);
@@ -329,7 +338,7 @@ template <typename IOTmpl>
 void
 GraphDataCell<IOTmpl>::Serialize(StreamWriter& writer) {
     GraphInterface::Serialize(writer);
-    this->io_->Serialize(writer);
+    this->layout_.Serialize(writer);
     StreamWriter::WriteObj(writer, this->code_line_size_);
     if (is_support_delete_) {
         StreamWriter::WriteVector(writer, node_versions_);
@@ -340,8 +349,9 @@ template <typename IOTmpl>
 void
 GraphDataCell<IOTmpl>::Deserialize(StreamReader& reader) {
     GraphInterface::Deserialize(reader);
-    this->io_->Deserialize(reader);
+    this->layout_.Deserialize(reader);
     StreamReader::ReadObj(reader, this->code_line_size_);
+    this->layout_.SetCodeSize(this->code_line_size_);
     if (is_support_delete_) {
         StreamReader::ReadVector(reader, node_versions_);
     }

--- a/src/layout/fixed_layout.h
+++ b/src/layout/fixed_layout.h
@@ -76,6 +76,11 @@ public:
     }
 
     void
+    WriteAt(InnerIdType id, uint64_t offset_in_record, const uint8_t* data, uint64_t length) {
+        io_->Write(data, length, GetOffsetAt(id, offset_in_record, length));
+    }
+
+    void
     WriteRange(InnerIdType begin_id, const uint8_t* codes, uint64_t count) {
         io_->Write(codes, GetByteSize(count), GetOffset(begin_id));
     }
@@ -83,6 +88,11 @@ public:
     bool
     Read(InnerIdType id, uint8_t* code) const {
         return io_->Read(code_size_, GetOffset(id), code);
+    }
+
+    bool
+    ReadAt(InnerIdType id, uint64_t offset_in_record, uint64_t length, uint8_t* data) const {
+        return io_->Read(length, GetOffsetAt(id, offset_in_record, length), data);
     }
 
     [[nodiscard]] const uint8_t*
@@ -115,6 +125,12 @@ public:
     void
     Prefetch(InnerIdType id, uint64_t bytes) {
         io_->Prefetch(GetOffset(id), bytes);
+    }
+
+    /** Prefetches from a record-relative offset; hints may start or span beyond one record. */
+    void
+    PrefetchAt(InnerIdType id, uint64_t offset_in_record, uint64_t bytes) {
+        io_->Prefetch(AddOffset(GetOffset(id), offset_in_record), bytes);
     }
 
     void
@@ -182,6 +198,23 @@ private:
     [[nodiscard]] uint64_t
     GetOffset(InnerIdType id) const {
         return GetByteSize(static_cast<uint64_t>(id));
+    }
+
+    [[nodiscard]] uint64_t
+    GetOffsetAt(InnerIdType id, uint64_t offset_in_record, uint64_t length) const {
+        if (offset_in_record > code_size_ or length > code_size_ - offset_in_record) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "fixed layout range exceeds record boundary");
+        }
+        return AddOffset(GetOffset(id), offset_in_record);
+    }
+
+    [[nodiscard]] uint64_t
+    AddOffset(uint64_t offset, uint64_t delta) const {
+        if (delta > std::numeric_limits<uint64_t>::max() - offset) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT, "fixed layout offset overflow");
+        }
+        return offset + delta;
     }
 
     [[nodiscard]] uint64_t

--- a/src/layout/fixed_layout_test.cpp
+++ b/src/layout/fixed_layout_test.cpp
@@ -56,6 +56,25 @@ public:
     }
 };
 
+class PrefetchReviewIO : public BasicIO<PrefetchReviewIO> {
+public:
+    static constexpr bool InMemory = true;
+    static constexpr bool SkipDeserialize = false;
+
+    PrefetchReviewIO(const IOParamPtr&, const IndexCommonParam& common_param)
+        : BasicIO<PrefetchReviewIO>(common_param.allocator_.get()) {
+    }
+
+    void
+    PrefetchImpl(uint64_t offset, uint64_t bytes) {
+        prefetch_offset_ = offset;
+        prefetch_bytes_ = bytes;
+    }
+
+    uint64_t prefetch_offset_{0};
+    uint64_t prefetch_bytes_{0};
+};
+
 IndexCommonParam
 MakeCommonParam() {
     IndexCommonParam common_param;
@@ -85,6 +104,56 @@ TEST_CASE("FixedLayout maps ids to fixed records", "[ut][FixedLayout]") {
     layout.Write(1, replacement.data());
     REQUIRE(layout.Read(1, output.data()));
     REQUIRE(output == replacement);
+}
+
+TEST_CASE("FixedLayout supports record-local reads and writes", "[ut][FixedLayout]") {
+    auto common_param = MakeCommonParam();
+    FixedLayout<MemoryIO> layout(6, nullptr, common_param);
+    layout.Resize(3);
+
+    const std::array<uint8_t, 18> records{
+        1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16, 21, 22, 23, 24, 25, 26};
+    layout.WriteRange(0, records.data(), 3);
+
+    const std::array<uint8_t, 3> replacement{31, 32, 33};
+    layout.WriteAt(1, 2, replacement.data(), replacement.size());
+
+    std::array<uint8_t, 3> output{};
+    REQUIRE(layout.ReadAt(1, 2, output.size(), output.data()));
+    REQUIRE(output == replacement);
+
+    std::array<uint8_t, 6> first{};
+    std::array<uint8_t, 6> second{};
+    std::array<uint8_t, 6> third{};
+    REQUIRE(layout.Read(0, first.data()));
+    REQUIRE(layout.Read(1, second.data()));
+    REQUIRE(layout.Read(2, third.data()));
+    REQUIRE(first == std::array<uint8_t, 6>{1, 2, 3, 4, 5, 6});
+    REQUIRE(second == std::array<uint8_t, 6>{11, 12, 31, 32, 33, 16});
+    REQUIRE(third == std::array<uint8_t, 6>{21, 22, 23, 24, 25, 26});
+
+    REQUIRE_NOTHROW(layout.WriteAt(0, layout.GetCodeSize(), replacement.data(), 0));
+    REQUIRE(layout.ReadAt(0, layout.GetCodeSize(), 0, output.data()));
+    REQUIRE_THROWS_AS(layout.WriteAt(0, 7, replacement.data(), 0), VsagException);
+    REQUIRE_THROWS_AS(layout.WriteAt(0, 5, replacement.data(), 2), VsagException);
+    REQUIRE_THROWS_AS(layout.ReadAt(0, 7, 0, output.data()), VsagException);
+    REQUIRE_THROWS_AS(layout.ReadAt(0, 5, 2, output.data()), VsagException);
+}
+
+TEST_CASE("FixedLayout prefetches from a record-local offset", "[ut][FixedLayout]") {
+    auto common_param = MakeCommonParam();
+    auto io = std::make_shared<PrefetchReviewIO>(nullptr, common_param);
+    FixedLayout<PrefetchReviewIO> layout;
+    layout.SetCodeSize(16);
+    layout.SetIO(io);
+
+    layout.PrefetchAt(3, 5, 64);
+    REQUIRE(io->prefetch_offset_ == 53);
+    REQUIRE(io->prefetch_bytes_ == 64);
+
+    layout.PrefetchAt(3, 17, 64);
+    REQUIRE(io->prefetch_offset_ == 65);
+    REQUIRE(io->prefetch_bytes_ == 64);
 }
 
 TEST_CASE("FixedLayout supports ranges and id batch reads", "[ut][FixedLayout]") {


### PR DESCRIPTION
## Summary

Refactor fixed-record `GraphDataCell<IOTmpl>` storage to use the common `FixedLayout` abstraction while preserving the existing partial IO behavior and serialized byte format.

## Changes

- Add record-local `ReadAt`, `WriteAt`, and `PrefetchAt` operations to `FixedLayout`.
- Validate that record-local reads and writes do not cross a fixed-record boundary.
- Preserve prefetch hint behavior, including hints that may span record boundaries.
- Replace direct `BasicIO` addressing in `GraphDataCell` with a value-held `FixedLayout`.
- Keep neighbor-count and active-neighbor IO sizes unchanged.
- Restore the layout code size after deserialization without changing serialization order.
- Add unit coverage for local access boundaries, adjacent-record isolation, and prefetch offsets.

## Testing

- `make fmt` with clang-format 15
- `make lint` with clang-tidy 15
- Release `datacell` target build
- `./build-test/tests/unittests "[FixedLayout]"`
  - 38 assertions in 7 test cases passed
- `./build-test/tests/unittests "[GraphDataCell]"`
  - 1,003,321 assertions in 7 test cases passed

## Related Issues

Fixes #2817
