### PR TITLE
refactor(parameters): remove legacy mapping utilities

### DIFF
--- a/src/type_helpers.h
+++ b/src/type_helpers.h
@@ -17,7 +17,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -33,8 +32,6 @@ inline auto
 AllocateShared(Allocator* allocator, Args&&... args) {
     return std::allocate_shared<T>(AllocatorWrapper<T>(allocator), std::forward<Args>(args)...);
 }
-
-using ConstParamMap = const std::unordered_multimap<std::string, std::vector<std::string>>;
 
 using IdFilterFuncType = std::function<bool(LabelType)>;
 

--- a/src/utils/util_functions.cpp
+++ b/src/utils/util_functions.cpp
@@ -17,7 +17,6 @@
 
 #include <iomanip>
 #include <limits>
-#include <nlohmann/json.hpp>
 #include <random>
 
 #include "common.h"
@@ -26,44 +25,6 @@
 #include "impl/allocator/safe_allocator.h"
 #include "vsag_exception.h"
 namespace vsag {
-
-std::string
-format_map(const std::string& str, const std::unordered_map<std::string, std::string>& mappings) {
-    std::string result = str;
-
-    for (const auto& [key, value] : mappings) {
-        uint64_t pos = result.find("{" + key + "}");
-        while (pos != std::string::npos) {
-            result.replace(pos, key.length() + 2, value);
-            pos = result.find("{" + key + "}");
-        }
-    }
-    return result;
-}
-
-void
-mapping_external_param_to_inner(const JsonType& external_json,
-                                ConstParamMap& param_map,
-                                JsonType& inner_json) {
-    auto* external_raw_json = external_json.GetInnerJson();
-    auto* inner_raw_json = inner_json.GetInnerJson();
-    for (const auto& [key, value] : external_raw_json->items()) {
-        auto ranges = param_map.equal_range(key);
-        if (ranges.first == ranges.second) {
-            // key not found in param_map
-            throw VsagException(ErrorType::INVALID_ARGUMENT,
-                                fmt::format("invalid config param: {}", key));
-        }
-        for (auto iter = ranges.first; iter != ranges.second; ++iter) {
-            const auto& vec = iter->second;
-            auto* json = inner_raw_json;
-            for (const auto& str : vec) {
-                json = &(json->operator[](str));
-            }
-            *json = value;
-        }
-    }
-}
 
 std::tuple<DatasetPtr, float*, int64_t*>
 create_fast_dataset(int64_t dim, Allocator* allocator) {

--- a/src/utils/util_functions.h
+++ b/src/utils/util_functions.h
@@ -56,14 +56,6 @@ align_up(const int64_t& value, int64_t base) {
     return ((value + base - 1) / base) * base;
 }
 
-std::string
-format_map(const std::string& str, const std::unordered_map<std::string, std::string>& mappings);
-
-void
-mapping_external_param_to_inner(const JsonType& external_json,
-                                ConstParamMap& param_map,
-                                JsonType& inner_json);
-
 std::tuple<DatasetPtr, float*, int64_t*>
 create_fast_dataset(int64_t dim, Allocator* allocator);
 

--- a/src/utils/util_functions_test.cpp
+++ b/src/utils/util_functions_test.cpp
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <limits>
 #include <sstream>
-#include <unordered_map>
 #include <unordered_set>
 
 #include "impl/allocator/default_allocator.h"
@@ -27,12 +26,6 @@
 using namespace vsag;
 
 TEST_CASE("UtilFunctions Basic", "[ut][UtilFunctions]") {
-    SECTION("format map") {
-        std::unordered_map<std::string, std::string> mappings{{"name", "vsag"}, {"v", "1.0"}};
-        std::string formatted = format_map("{name}-{v}", mappings);
-        REQUIRE(formatted == "vsag-1.0");
-    }
-
     SECTION("split string") {
         auto parts = split_string("a,,b", ',');
         REQUIRE(parts.size() == 3);


### PR DESCRIPTION
## Summary

Remove the unused string-template and JSON-path parameter mapping utilities after all production parameter entry points migrated to explicit structured construction.

## Changes

- Remove `format_map` and `mapping_external_param_to_inner`.
- Remove the now-unused `ConstParamMap` alias.
- Remove the obsolete `format_map` unit-test section and related includes.

## Compatibility

This only removes internal, unused helpers. External parameter JSON, internal Parameter JSON, and serialized index formats are unchanged.

## Testing

- Release build completed successfully.
- `UtilFunctions Basic`: 45 assertions passed.
- `make fmt` completed with clang-format 15.
- clang-tidy 15 checked `src/utils/util_functions.cpp` with no user-code warnings.
- Confirmed the removed symbols no longer exist under `src/`.
- Confirmed the branch contains one commit relative to the latest `main`.

Fixes #2821
