### PR TITLE
docs: add C++ coding guide

### DIFF
--- a/docs/docs/en/src/SUMMARY.md
+++ b/docs/docs/en/src/SUMMARY.md
@@ -39,6 +39,7 @@
 # Developer Guide
 
 - [Code Structure](development/code_structure.md)
+- [C++ Coding Guide](development/coding_style.md)
 - [New Index Integration Checklist](development/new_index_checklist.md)
 - [Building](development/building.md)
 - [Offline / Air-gapped Builds](development/offline_build.md)

--- a/docs/docs/en/src/development/coding_style.md
+++ b/docs/docs/en/src/development/coding_style.md
@@ -1,0 +1,216 @@
+# C++ Coding Guide
+
+VSAG follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) with
+project-specific formatting, naming, and static-analysis rules. The configuration files at the
+repository root are authoritative:
+
+- [`.clang-format`](https://github.com/antgroup/vsag/blob/main/.clang-format) defines mechanical
+  formatting.
+- [`.clang-tidy`](https://github.com/antgroup/vsag/blob/main/.clang-tidy) defines naming and
+  static-analysis checks.
+
+VSAG requires **clang-format 15** and **clang-tidy 15** exactly. Other versions may produce
+different formatting or diagnostics and are not accepted by CI.
+
+## Code layout
+
+- Put public APIs in `include/vsag/` and implementation code in `src/`.
+- Use `.cpp` for C++ source files, not `.cc`.
+- Keep code in the `vsag` namespace unless the file clearly requires otherwise.
+- Preserve API compatibility unless a breaking change is explicitly planned.
+- Add or update Doxygen comments when changing a public API.
+- Prefer `uint64_t` over `size_t` in new code to avoid macOS compatibility problems.
+- Do not modify `extern/` unless the change explicitly concerns a third-party dependency.
+- End every committed text file with a trailing newline.
+
+## Formatting rules
+
+The formatter starts from the Google style and applies the following VSAG rules:
+
+| Rule | VSAG style |
+| --- | --- |
+| Indentation | 4 spaces |
+| C++ line length | At most 100 columns |
+| Access specifiers | Outdented by one indentation level |
+| Return types | Placed on a separate line from the function name |
+| Short blocks, functions, and `if` statements | Never collapsed onto one line |
+| Pointer and reference alignment | `*` and `&` bind to the type |
+| Includes | Sorted automatically |
+| Wrapped parameters and arguments | One per line instead of bin-packed |
+| Trailing comments | Aligned when they form a consecutive group |
+| Existing comment text | Not automatically reflowed |
+
+For example, clang-format 15 formats a class declaration like this:
+
+```cpp
+class Example {
+public:
+    Result<DatasetPtr>
+    Build(const DatasetPtr& base, const std::string& parameters);
+
+private:
+    void
+    reset_state();
+
+    DatasetPtr dataset_;
+};
+```
+
+The 100-column limit applies to C++ source and header files. It does not impose a line-width limit
+on Markdown or other non-C++ text.
+
+## Naming rules
+
+The `readability-identifier-naming` check enforces these names:
+
+| Entity | Style | Example |
+| --- | --- | --- |
+| Namespace | `lower_case` | `vsag::storage` |
+| Class | `CamelCase` | `HGraphIndex` |
+| Struct | `CamelCase` | `SearchResult` |
+| Type template parameter | `CamelCase` | `DataType` |
+| Value template parameter | `lower_case` | `max_degree` |
+| Free or C-style function | `lower_case` | `normalize_vector` |
+| Public method | `CamelCase` | `Build` |
+| Private method | `lower_case` | `reset_state` |
+| Variable | `lower_case` | `search_result` |
+| Private or protected data member | `lower_case_` | `search_result_` |
+| Macro definition | `UPPER_CASE` | `CHECK_ARGUMENT` |
+| Enum constant | `UPPER_CASE` | `ROUTING` |
+| Global constant | `UPPER_CASE` | `DEFAULT_RESIZE_INCREASE_COUNT_BIT` |
+
+`make lint` also runs `scripts/linters/check-struct-names.py`. It checks named struct definitions
+across tracked project C/C++ files, including files outside the normal clang-tidy source scope.
+Therefore, all new named structs must use `CamelCase`.
+
+For entities without an explicit project rule, follow the Google C++ style and the convention in
+the surrounding code.
+
+## Choosing between `class` and `struct`
+
+Use a `struct` for a passive, value-like data carrier:
+
+- Its primary purpose is to group related values.
+- Its data members are intentionally public and callers may modify them independently.
+- It does not need to protect an invariant or hide a representation.
+- It does not own a resource that requires controlled access or lifetime management.
+
+Examples include `Binary`, `SparseVector`, and `MultiVector`. A `struct` may still have default
+member initializers, constructors, or small helper functions. Having a method does not by itself
+require using a `class`; the deciding factor is whether the type remains a transparent data value.
+
+Use a `class` when the type represents behavior or must control its state:
+
+- It maintains invariants through its public methods.
+- It hides implementation details behind private or protected members.
+- It owns or manages resources whose lifetime must be controlled.
+- It provides a behavioral or polymorphic interface, especially one with virtual methods.
+
+Examples include `BinarySet`, `Dataset`, `Filter`, and `Index`. Prefer `class` for new interfaces
+and polymorphic base types.
+
+When unsure, ask whether callers should be allowed to change every data member directly and in any
+order. If yes, use `struct`; if the type must validate, coordinate, or restrict those changes, use
+`class`. Do not use `struct` merely to avoid writing `public:`, and do not expose mutable
+implementation details just to make a type aggregate-initializable.
+
+Both classes and structs use `CamelCase`. Preserve the existing choice for a public type unless an
+intentional API change requires otherwise; do not switch between `class` and `struct` as a cosmetic
+cleanup.
+
+## Static analysis
+
+All enabled clang-tidy diagnostics are treated as errors. The configuration enables the following
+check families:
+
+- `bugprone-*` for likely logic defects and suspicious constructs.
+- `clang-analyzer-*` for path-sensitive correctness and lifetime analysis.
+- `clang-diagnostic-*` for compiler diagnostics exposed through clang-tidy.
+- `modernize-*` for supported modern C++ practices.
+- `openmp-*` for OpenMP correctness.
+- `performance-*` for avoidable copies and inefficient operations.
+- `readability-*` for maintainability and naming consistency.
+
+Some checks are deliberately disabled because they conflict with VSAG's low-level and
+performance-sensitive code or are too noisy for the current codebase:
+
+| Disabled check | Reason |
+| --- | --- |
+| `clang-analyzer-deadcode.DeadStores` | Stored-but-unread values produce too much noise |
+| `clang-diagnostic-deprecated-builtins` | Some deprecated builtins are required for toolchain or platform compatibility |
+| `bugprone-easily-swappable-parameters` | Produces too many false positives |
+| `modernize-use-trailing-return-type` | Conflicts with the project return-type style |
+| `modernize-avoid-c-arrays` | C arrays are intentional in SIMD and other low-level code |
+| `readability-identifier-length` | Short names are acceptable when clear in context |
+| `readability-magic-numbers` | Numeric-heavy vector-index code makes the check excessively noisy |
+| `readability-function-cognitive-complexity` | Deferred until existing violations can be addressed |
+| `readability-redundant-access-specifiers` | Repeated access specifiers may separate method groups visually |
+
+A disabled check is not a recommendation to ignore the underlying concern. Use meaningful
+parameter names and named constants whenever they make the code clearer.
+
+### Suppressing a diagnostic
+
+Fix the underlying issue whenever practical. If a diagnostic is a false positive or the construct
+is required for compatibility or performance, use the narrowest suppression and explain why it is
+safe:
+
+```cpp
+// NOLINTNEXTLINE(performance-no-int-to-ptr): the platform API stores this handle as an integer.
+auto* handle = reinterpret_cast<Handle*>(raw_handle);
+```
+
+Name the exact check in `NOLINT`, `NOLINTNEXTLINE`, or a tightly scoped
+`NOLINTBEGIN`/`NOLINTEND` pair. Avoid an unqualified `NOLINT` or a file-wide suppression unless
+there is no narrower practical option.
+
+## Running the checks
+
+Install the required tools:
+
+```bash
+# Ubuntu or Debian
+sudo apt-get install clang-format-15 clang-tidy-15 clang-tools-15
+
+# macOS
+brew install llvm@15
+```
+
+Format all project C++ files and inspect the resulting diff:
+
+```bash
+make fmt
+git diff --check
+```
+
+clang-tidy requires a compilation database in `build-release/`, so create a release build first:
+
+```bash
+make release
+make lint
+```
+
+The default lint target uses production `.cpp` files under `src/` as clang-tidy entry points and
+excludes `*_test.cpp`. It also runs the repository-wide struct-name checker. Tests and other
+directories are not separate clang-tidy entry points in this command.
+
+`make fix-lint` applies suggested replacements in place. It may make broad edits, so use it on a
+clean or safely backed-up working tree, review the complete diff, and rerun the checks and relevant
+tests:
+
+```bash
+make fix-lint
+make fmt
+make lint
+make test
+```
+
+## Before submitting a change
+
+- Format all changed C++ files with clang-format 15.
+- Run clang-tidy 15 for changed production sources.
+- Ensure names follow the rules above, including `CamelCase` struct names.
+- Keep every `NOLINT` check-specific and document its rationale.
+- Add tests for new features and regression tests for bug fixes.
+- Keep unit-test coverage for the C++ library at or above 90%.
+- Run `git diff --check` and review the complete diff.

--- a/docs/docs/en/src/development/contributing.md
+++ b/docs/docs/en/src/development/contributing.md
@@ -104,37 +104,9 @@ compliance, and taking full responsibility for the contribution.
 
 ## Coding Style
 
-VSAG follows the
-[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) with project-specific
-tweaks covering indentation, naming, and line width. The authoritative configuration lives in the
-repository:
-
-- clang-format: <https://github.com/antgroup/vsag/blob/main/.clang-format>
-- clang-tidy: <https://github.com/antgroup/vsag/blob/main/.clang-tidy>
-
-> `clang-tidy` enforces not only naming conventions but also style checks such as magic-number
-> usage.
-
-The Makefile exposes formatting targets; `clang-format` and `clang-tidy` (both version 15) must be
-installed.
-
-Format code:
-
-```bash
-make fmt
-```
-
-Run static analysis (fix the reported issues manually):
-
-```bash
-make lint
-```
-
-Some clang-tidy findings can be auto-fixed:
-
-```bash
-make fix-lint
-```
+Read the [C++ Coding Guide](coding_style.md) before changing C++ code. It documents the exact
+clang-format 15 and clang-tidy 15 rules, naming conventions, diagnostic suppressions, and local
+commands required by VSAG.
 
 ## Local Testing
 

--- a/docs/docs/zh/src/SUMMARY.md
+++ b/docs/docs/zh/src/SUMMARY.md
@@ -39,6 +39,7 @@
 # 开发者指南
 
 - [代码目录结构](development/code_structure.md)
+- [C++ 编码指南](development/coding_style.md)
 - [新索引接入检查清单](development/new_index_checklist.md)
 - [编译构建](development/building.md)
 - [离线 / 内网环境构建](development/offline_build.md)

--- a/docs/docs/zh/src/development/coding_style.md
+++ b/docs/docs/zh/src/development/coding_style.md
@@ -1,0 +1,201 @@
+# C++ 编码指南
+
+VSAG 以 [Google C++ 风格指南](https://google.github.io/styleguide/cppguide.html) 为基础，并针对
+代码格式、命名和静态检查制定了项目规则。仓库根目录下的配置文件是这些规则的准确定义：
+
+- [`.clang-format`](https://github.com/antgroup/vsag/blob/main/.clang-format) 定义自动格式化规则；
+- [`.clang-tidy`](https://github.com/antgroup/vsag/blob/main/.clang-tidy) 定义命名与静态检查规则。
+
+VSAG 严格要求使用 **clang-format 15** 和 **clang-tidy 15**。其他版本可能产生不同的格式化
+结果或诊断信息，无法通过 CI。
+
+## 代码组织
+
+- 公开 API 放在 `include/vsag/`，实现代码放在 `src/`；
+- C++ 源文件使用 `.cpp` 后缀，不使用 `.cc`；
+- 除非文件有明确的特殊要求，代码应放在 `vsag` 命名空间中；
+- 除非明确计划进行破坏性变更，否则应保持 API 兼容；
+- 修改公开 API 时，应添加或更新 Doxygen 注释；
+- 新代码优先使用 `uint64_t` 而不是 `size_t`，避免 macOS 兼容性问题；
+- 除非修改目标明确涉及第三方依赖，否则不要修改 `extern/`；
+- 所有提交的文本文件都应以换行符结尾。
+
+## 格式化规则
+
+格式化配置以 Google 风格为基础，并应用以下 VSAG 规则：
+
+| 规则 | VSAG 风格 |
+| --- | --- |
+| 缩进 | 4 个空格 |
+| C++ 行宽 | 最多 100 列 |
+| 访问控制符 | 相对成员代码减少一级缩进 |
+| 返回类型 | 与函数名分行书写 |
+| 简短代码块、函数和 `if` 语句 | 不压缩到单行 |
+| 指针和引用 | `*`、`&` 与类型结合 |
+| 头文件引用 | 自动排序 |
+| 换行后的参数和实参 | 每行一个，不进行 bin-pack |
+| 行尾注释 | 连续成组时自动对齐 |
+| 已有注释文本 | 不自动重新换行 |
+
+例如，clang-format 15 会将类声明格式化为：
+
+```cpp
+class Example {
+public:
+    Result<DatasetPtr>
+    Build(const DatasetPtr& base, const std::string& parameters);
+
+private:
+    void
+    reset_state();
+
+    DatasetPtr dataset_;
+};
+```
+
+100 列限制只适用于 C++ 源文件和头文件，不要求 Markdown 或其他非 C++ 文本遵循这一行宽。
+
+## 命名规则
+
+`.clang-tidy` 中的 `readability-identifier-naming` 会检查以下命名：
+
+| 对象 | 风格 | 示例 |
+| --- | --- | --- |
+| 命名空间 | `lower_case` | `vsag::storage` |
+| 类 | `CamelCase` | `HGraphIndex` |
+| 结构体 | `CamelCase` | `SearchResult` |
+| 类型模板参数 | `CamelCase` | `DataType` |
+| 值模板参数 | `lower_case` | `max_degree` |
+| 自由函数或 C 风格函数 | `lower_case` | `normalize_vector` |
+| 公有方法 | `CamelCase` | `Build` |
+| 私有方法 | `lower_case` | `reset_state` |
+| 变量 | `lower_case` | `search_result` |
+| 私有或受保护的数据成员 | `lower_case_` | `search_result_` |
+| 宏定义 | `UPPER_CASE` | `CHECK_ARGUMENT` |
+| 枚举值 | `UPPER_CASE` | `ROUTING` |
+| 全局常量 | `UPPER_CASE` | `DEFAULT_RESIZE_INCREASE_COUNT_BIT` |
+
+`make lint` 还会运行 `scripts/linters/check-struct-names.py`，检查所有已被 Git 跟踪的项目 C/C++
+文件中的具名结构体，包括 clang-tidy 常规检查范围之外的文件。因此，新建的具名结构体都必须使用
+`CamelCase`。
+
+对于没有项目专用规则的对象，请遵循 Google C++ 风格以及所在模块的现有约定。
+
+## 选择 `class` 还是 `struct`
+
+当类型是被动、值语义的数据载体时，使用 `struct`：
+
+- 主要用途是将一组相关数据组织在一起；
+- 数据成员有意保持公开，调用方可以彼此独立地修改它们；
+- 不需要保护对象不变量，也不需要隐藏内部表示；
+- 不负责需要受控访问或生命周期管理的资源。
+
+例如 `Binary`、`SparseVector` 和 `MultiVector`。`struct` 仍然可以包含成员默认值、构造函数或简单的
+辅助函数。是否存在成员函数并不是选择 `class` 的决定因素，关键在于该类型是否仍是透明的数据值。
+
+当类型表示行为或必须控制自身状态时，使用 `class`：
+
+- 通过公开方法维护对象不变量；
+- 使用私有或受保护成员隐藏实现细节；
+- 持有或管理需要控制生命周期的资源；
+- 提供行为接口或多态接口，尤其是包含虚函数的接口。
+
+例如 `BinarySet`、`Dataset`、`Filter` 和 `Index`。新建接口和多态基类时，优先使用 `class`。
+
+无法确定时，可以判断调用方是否应当以任意顺序直接修改每一个数据成员。如果允许，使用 `struct`；如果
+类型必须校验、协调或限制这些修改，使用 `class`。不要仅仅为了省略 `public:` 而使用 `struct`，也不要
+为了支持聚合初始化而暴露可变的实现细节。
+
+类和结构体都使用 `CamelCase`。除非有意进行 API 变更，否则应保留公开类型当前使用的形式，不要把
+`class` 与 `struct` 之间的转换作为纯风格清理。
+
+## 静态检查
+
+所有已启用的 clang-tidy 诊断都按错误处理。当前配置启用了以下检查组：
+
+- `bugprone-*`：发现可能的逻辑缺陷和可疑写法；
+- `clang-analyzer-*`：进行路径敏感的正确性和生命周期分析；
+- `clang-diagnostic-*`：通过 clang-tidy 报告编译器诊断；
+- `modernize-*`：检查项目支持的现代 C++ 写法；
+- `openmp-*`：检查 OpenMP 使用的正确性；
+- `performance-*`：发现不必要的复制和低效操作；
+- `readability-*`：检查可维护性和命名一致性。
+
+部分检查会与 VSAG 的底层、高性能代码冲突，或者在当前代码库中产生过多噪声，因此被明确禁用：
+
+| 禁用的检查 | 原因 |
+| --- | --- |
+| `clang-analyzer-deadcode.DeadStores` | “写入但未读取”的诊断噪声过多 |
+| `clang-diagnostic-deprecated-builtins` | 工具链或平台兼容仍需要部分已弃用的 builtin |
+| `bugprone-easily-swappable-parameters` | 误报过多 |
+| `modernize-use-trailing-return-type` | 与项目的返回类型风格冲突 |
+| `modernize-avoid-c-arrays` | SIMD 和其他底层代码会有意使用 C 数组 |
+| `readability-identifier-length` | 上下文清晰时允许使用短名称 |
+| `readability-magic-numbers` | 数值密集的向量索引代码会产生过多噪声 |
+| `readability-function-cognitive-complexity` | 在解决现有问题前暂不启用 |
+| `readability-redundant-access-specifiers` | 允许重复访问控制符来划分方法组 |
+
+禁用检查并不意味着可以忽略它所关注的问题。在能够提升可读性的情况下，仍应使用含义明确的参数名和
+具名常量。
+
+### 抑制诊断
+
+应优先修复诊断指出的问题。如果诊断属于误报，或者相关写法是兼容性或性能所必需的，应使用范围最小的
+抑制，并说明这样做安全的原因：
+
+```cpp
+// NOLINTNEXTLINE(performance-no-int-to-ptr): platform API 将该句柄存储为整数。
+auto* handle = reinterpret_cast<Handle*>(raw_handle);
+```
+
+在 `NOLINT`、`NOLINTNEXTLINE` 或范围严格受控的 `NOLINTBEGIN`/`NOLINTEND` 中写出具体检查名。
+除非无法采用更小的范围，否则不要使用不带检查名的 `NOLINT` 或对整个文件禁用检查。
+
+## 运行检查
+
+首先安装指定版本的工具：
+
+```bash
+# Ubuntu 或 Debian
+sudo apt-get install clang-format-15 clang-tidy-15 clang-tools-15
+
+# macOS
+brew install llvm@15
+```
+
+格式化所有项目 C++ 文件并检查修改：
+
+```bash
+make fmt
+git diff --check
+```
+
+clang-tidy 需要 `build-release/` 中的编译数据库，因此应先完成发布模式构建：
+
+```bash
+make release
+make lint
+```
+
+默认 lint 目标以 `src/` 下的生产环境 `.cpp` 文件作为 clang-tidy 入口，并排除 `*_test.cpp`；同时还会
+运行覆盖整个仓库的结构体命名检查。测试和其他目录不会在该命令中作为独立的 clang-tidy 入口。
+
+`make fix-lint` 会直接应用 clang-tidy 建议的修改，可能产生较大范围的变更。请在干净或已安全备份的
+工作区中使用，检查完整 diff，然后重新运行格式化、静态检查和相关测试：
+
+```bash
+make fix-lint
+make fmt
+make lint
+make test
+```
+
+## 提交修改前
+
+- 使用 clang-format 15 格式化所有修改过的 C++ 文件；
+- 使用 clang-tidy 15 检查修改过的生产环境源码；
+- 确认命名符合上述规则，尤其是结构体使用 `CamelCase`；
+- 确保每个 `NOLINT` 都指定具体检查，并说明原因；
+- 新功能包含测试，bug 修复包含回归测试；
+- 保持 C++ 库的单元测试覆盖率不低于 90%；
+- 运行 `git diff --check` 并检查完整 diff。

--- a/docs/docs/zh/src/development/contributing.md
+++ b/docs/docs/zh/src/development/contributing.md
@@ -91,26 +91,8 @@ Assisted-by: OpenCode:claude-opus-4.7
 
 ### 编码风格
 
-VSAG 项目编码风格基于 [Google C++ 风格指南](https://google.github.io/styleguide/cppguide.html) 做了一些修改，包括缩进、命名规则、行宽等，具体可以参考以下两个配置文件：
-
-- clang-format：https://github.com/antgroup/vsag/blob/main/.clang-format
-- clang-tidy：https://github.com/antgroup/vsag/blob/main/.clang-tidy
-
-> clang-tidy 是一个静态代码分析的工具，配置文件中不仅定义了函数/变量的命名标准，定义了一些编码风格的检查，例如 Magic Number 使用的检查等。
-
-VSAG 项目通过 Makefile 提供了格式化代码的命令，需要安装 clang-format 和 clang-tidy。
-
-运行命令可以直接格式化代码：
-
-```bash
-make fmt
-```
-
-运行命令会静态代码检查，需要根据提示手动修复：
-
-```bash
-make lint
-```
+修改 C++ 代码前，请阅读 [C++ 编码指南](coding_style.md)。其中说明了 VSAG 要求的
+clang-format 15 和 clang-tidy 15 规则、命名约定、诊断抑制方式以及本地检查命令。
 
 ### 本地测试
 
@@ -119,4 +101,3 @@ VSAG 项目使用 Makefile 提供了方便运行所有测试的命令，请执�
 ```bash
 make test
 ```
-


### PR DESCRIPTION
## Change Type

- [x] Documentation

## Linked Issue

Not required for `kind/documentation`.

## What Changed

- Add English and Chinese C++ coding guides derived from the repository's current `.clang-format` and `.clang-tidy` configurations.
- Document formatting, naming, enabled and disabled static-analysis checks, diagnostic suppressions, and local verification commands.
- Explain when contributors should use `class` versus `struct`, with examples from VSAG.
- Add the guides to both documentation navigation trees and link them from the contribution guides.

## Test Evidence

- [x] Other (documentation validation)

Test details:

```text
mdbook build (English documentation)
mdbook build (Chinese documentation)
clang-tidy 15 --verify-config
git diff --check
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: none; documentation only

## Performance and Concurrency Impact

- Performance impact: none
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] Updated docs:
  - [x] Other: `docs/docs/{en,zh}/src/development/coding_style.md`, navigation, and contribution-guide links

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the documentation commit

## Checklist

- [x] No linked issue is required for this `kind/documentation` change
- [x] No tests are required for documentation-only behavior
- [x] I have considered API compatibility impact
- [x] I have updated the English and Chinese documentation together
- [x] My commit message follows project conventions
