### PR TITLE
feat(ivf): add centroid scan routing switch

### DIFF
--- a/include/vsag/constants.h
+++ b/include/vsag/constants.h
@@ -247,6 +247,7 @@ extern const char* const BRUTE_FORCE_USE_RESIDUAL;
 extern const char* const IVF_USE_RESIDUAL;
 extern const char* const IVF_USE_REORDER;
 extern const char* const IVF_TRAIN_TYPE;
+extern const char* const IVF_USE_ROUTE_GRAPH;
 extern const char* const IVF_BUCKETS_COUNT;
 extern const char* const IVF_BASE_QUANTIZATION_TYPE;
 extern const char* const IVF_BASE_IO_TYPE;

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -89,6 +89,7 @@ build_default_ivf_param(const JsonType& external_param) {
     JsonType partition;
     partition[IVF_PARTITION_STRATEGY_TYPE_KEY].SetString(IVF_PARTITION_STRATEGY_TYPE_NEAREST);
     partition[IVF_TRAIN_TYPE_KEY].SetString(IVF_TRAIN_TYPE_KMEANS);
+    partition[IVF_USE_ROUTE_GRAPH_KEY].SetBool(true);
     partition[IVF_PARTITION_STRATEGY_TYPE_GNO_IMI][GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY].SetInt(
         10);
     partition[IVF_PARTITION_STRATEGY_TYPE_GNO_IMI][GNO_IMI_SECOND_ORDER_BUCKETS_COUNT_KEY].SetInt(
@@ -143,6 +144,8 @@ IVF::CheckAndMappingExternalParam(const JsonType& external_param,
         } else if (key == IVF_PARTITION_STRATEGY_TYPE_KEY) {
             inner_json[IVF_PARTITION_STRATEGY_PARAMS_KEY][IVF_PARTITION_STRATEGY_TYPE_KEY].SetJson(
                 value);
+        } else if (key == IVF_USE_ROUTE_GRAPH) {
+            inner_json[IVF_PARTITION_STRATEGY_PARAMS_KEY][IVF_USE_ROUTE_GRAPH_KEY].SetJson(value);
         } else if (key == GNO_IMI_FIRST_ORDER_BUCKETS_COUNT) {
             inner_json[IVF_PARTITION_STRATEGY_PARAMS_KEY][IVF_PARTITION_STRATEGY_TYPE_GNO_IMI]
                       [GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY]

--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -19,17 +19,54 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <limits>
 
 #include "algorithm/hgraph/hgraph.h"
 #include "algorithm/inner_index_interface.h"
+#include "container_types.h"
 #include "impl/allocator/safe_allocator.h"
+#include "impl/blas/blas_function.h"
 #include "impl/cluster/kmeans_cluster.h"
 #include "inner_string_params.h"
 #include "query_context.h"
+#include "simd/fp32_simd.h"
 #include "utils/util_functions.h"
 #include "vsag_exception.h"
 
 namespace vsag {
+
+namespace {
+
+constexpr uint64_t K_CENTROID_SCAN_LAYOUT_MARKER = 0x565341475343414EULL;  // "VSAGSCAN"
+
+constexpr BucketIdType INVALID_BUCKET_ID = static_cast<BucketIdType>(-1);
+
+// Max-heap used to keep the k smallest routing keys: the largest retained key is at top() and
+// is discarded when a better candidate arrives. bucket_id provides a deterministic tie-break.
+using ScanRouteHeap = std::priority_queue<std::pair<float, InnerIdType>,
+                                          Vector<std::pair<float, InnerIdType>>,
+                                          std::less<>>;
+
+// C = A * B^T (same shape as GNOIMIPartition's batched centroid routing).
+void
+compute_centroid_dots(const float* A, const float* B, float* C, int64_t M, int64_t N, int64_t K) {
+    BlasFunction::Sgemm(BlasFunction::ColMajor,
+                        BlasFunction::Trans,
+                        BlasFunction::NoTrans,
+                        static_cast<int32_t>(N),
+                        static_cast<int32_t>(M),
+                        static_cast<int32_t>(K),
+                        1.0F,
+                        B,
+                        static_cast<int32_t>(K),
+                        A,
+                        static_cast<int32_t>(K),
+                        0.0F,
+                        C,
+                        static_cast<int32_t>(N));
+}
+
+}  // namespace
 
 static constexpr const char* SEARCH_PARAM_TEMPLATE_STR = R"(
 {{
@@ -43,8 +80,12 @@ IVFNearestPartition::IVFNearestPartition(BucketIdType bucket_count,
                                          const IndexCommonParam& common_param,
                                          IVFPartitionStrategyParametersPtr param)
     : IVFPartitionStrategy(common_param, bucket_count),
-      ivf_partition_strategy_param_(std::move(param)) {
-    this->factory_router_index(common_param);
+      ivf_partition_strategy_param_(std::move(param)),
+      use_route_graph_(this->ivf_partition_strategy_param_->use_route_graph),
+      common_param_(common_param) {
+    if (this->use_route_graph_) {
+        this->factory_router_index(common_param);
+    }
 }
 
 void
@@ -84,7 +125,32 @@ IVFNearestPartition::Train(const DatasetPtr dataset) {
         }
     }
 
-    auto build_result = this->route_index_ptr_->Build(centroids);
+    if (this->use_route_graph_) {
+        const auto failed_ids = this->route_index_ptr_->Build(centroids);
+        if (not failed_ids.empty()) {
+            throw VsagException(ErrorType::INTERNAL_ERROR,
+                                "failed to build all IVF routing centroids");
+        }
+    } else {
+        // Persist the trained centroids (normalized for cosine) so the scan routing path can
+        // assign buckets without creating a routing HGraph.
+        this->centroids_.resize(this->bucket_count_ * this->dim_);
+        memcpy(
+            this->centroids_.data(), data.data(), this->bucket_count_ * this->dim_ * sizeof(float));
+        this->norms_.resize(this->bucket_count_);
+        if (metric_type_ == MetricType::METRIC_TYPE_L2SQR) {
+            for (int i = 0; i < bucket_count_; ++i) {
+                this->norms_[i] = FP32ComputeIP(this->centroids_.data() + i * dim_,
+                                                this->centroids_.data() + i * dim_,
+                                                dim_) /
+                                  2.0F;
+            }
+        } else {
+            // IP/COSINE distances are defined as `1 - dot`; with normalized cosine centroids
+            // the constant term is 1.0 for every centroid.
+            std::fill(this->norms_.begin(), this->norms_.end(), 1.0F);
+        }
+    }
     this->is_trained_ = true;
 }
 
@@ -93,9 +159,12 @@ IVFNearestPartition::ClassifyDatas(const void* datas,
                                    int64_t count,
                                    BucketIdType buckets_per_data,
                                    QueryContext* ctx) const {
+    if (not this->use_route_graph_) {
+        return this->classify_datas_by_scan(datas, count, buckets_per_data, ctx);
+    }
     std::mutex dist_cmp_reduce_mutex;
     uint32_t dist_cmp = 0;
-    Vector<BucketIdType> result(buckets_per_data * count, -1, this->allocator_);
+    Vector<BucketIdType> result(buckets_per_data * count, INVALID_BUCKET_ID, this->allocator_);
     auto task = [&](int64_t i) {
         auto query = Dataset::Make();
         query->Dim(this->dim_)
@@ -158,12 +227,50 @@ IVFNearestPartition::ClassifyDatas(const void* datas,
 void
 IVFNearestPartition::Serialize(StreamWriter& writer) {
     IVFPartitionStrategy::Serialize(writer);
-    this->route_index_ptr_->Serialize(writer);
+    if (this->use_route_graph_) {
+        // Keep the route-graph layout byte-for-byte compatible with the legacy format.
+        this->route_index_ptr_->Serialize(writer);
+    } else {
+        StreamWriter::WriteObj(writer, K_CENTROID_SCAN_LAYOUT_MARKER);
+        StreamWriter::WriteVector(writer, this->centroids_);
+        StreamWriter::WriteVector(writer, this->norms_);
+    }
 }
 void
 IVFNearestPartition::Deserialize(LvalueOrRvalue<StreamReader> reader) {
     IVFPartitionStrategy::Deserialize(reader);
-    this->route_index_ptr_->Deserialize(reader);
+    // Peek the layout marker without consuming bytes so legacy (marker-less) route-graph
+    // indices remain loadable with any reader configuration.
+    const auto cursor = reader->GetCursor();
+    uint64_t layout = 0;
+    StreamReader::ReadObj(reader, layout);
+    reader->Seek(cursor);
+    if (layout == K_CENTROID_SCAN_LAYOUT_MARKER) {
+        StreamReader::ReadObj(reader, layout);
+        StreamReader::ReadVector(reader, this->centroids_);
+        StreamReader::ReadVector(reader, this->norms_);
+        const bool invalid_trained_layout =
+            this->is_trained_ and (this->centroids_.size() != this->bucket_count_ * this->dim_ or
+                                   this->norms_.size() != this->bucket_count_);
+        const bool invalid_untrained_layout =
+            not this->is_trained_ and (not this->centroids_.empty() or not this->norms_.empty());
+        if (invalid_trained_layout or invalid_untrained_layout) {
+            throw VsagException(ErrorType::INVALID_BINARY,
+                                "invalid IVF centroid scan routing layout");
+        }
+        this->route_index_ptr_.reset();
+        this->use_route_graph_ = false;
+    } else {
+        // Route-graph layout (the legacy marker-less format). Lazily create the routing HGraph
+        // when the reader was configured with use_route_graph=false.
+        if (this->route_index_ptr_ == nullptr) {
+            this->factory_router_index(this->common_param_);
+        }
+        this->route_index_ptr_->Deserialize(reader);
+        this->centroids_.clear();
+        this->norms_.clear();
+        this->use_route_graph_ = true;
+    }
 }
 void
 IVFNearestPartition::factory_router_index(const IndexCommonParam& common_param) {
@@ -184,12 +291,102 @@ IVFNearestPartition::GetCentroid(BucketIdType bucket_id, Vector<float>& centroid
     if (bucket_id >= bucket_count_) {
         throw VsagException(ErrorType::INVALID_ARGUMENT, "Invalid bucket_id");
     }
-    this->route_index_ptr_->GetCodeByInnerId(bucket_id, (uint8_t*)centroid.data());
+    if (this->use_route_graph_) {
+        this->route_index_ptr_->GetCodeByInnerId(bucket_id, (uint8_t*)centroid.data());
+    } else {
+        memcpy(centroid.data(),
+               this->centroids_.data() + bucket_id * this->dim_,
+               this->dim_ * sizeof(float));
+    }
 }
 
 [[nodiscard]] uint64_t
 IVFNearestPartition::GetMemoryUsage() const {
-    return static_cast<uint64_t>(sizeof(IVFNearestPartition) +
-                                 this->route_index_ptr_->GetMemoryUsage());
+    auto memory = static_cast<uint64_t>(sizeof(IVFNearestPartition));
+    if (this->use_route_graph_) {
+        memory += this->route_index_ptr_->GetMemoryUsage();
+    }
+    memory += this->centroids_.size() * sizeof(float);
+    memory += this->norms_.size() * sizeof(float);
+    return memory;
 }
+Vector<BucketIdType>
+IVFNearestPartition::classify_datas_by_scan(const void* datas,
+                                            int64_t count,
+                                            BucketIdType buckets_per_data,
+                                            QueryContext* ctx) const {
+    Vector<BucketIdType> result(buckets_per_data * count, INVALID_BUCKET_ID, this->allocator_);
+    // Centroids only exist after Train(). An untrained index must not route: leave every slot
+    // at INVALID_BUCKET_ID (mirrors the untrained route-graph behavior).
+    if (not this->is_trained_ or this->bucket_count_ == 0 or count == 0) {
+        return result;
+    }
+
+    const auto k = std::min<BucketIdType>(buckets_per_data, bucket_count_);
+    if (k == 0) {
+        return result;
+    }
+
+    Vector<float> norm_vectors(allocator_);
+    const auto* query_data = static_cast<const float*>(datas);
+    if (metric_type_ == MetricType::METRIC_TYPE_COSINE) {
+        norm_vectors.resize(count * dim_);
+        for (int64_t i = 0; i < count; ++i) {
+            Normalize(query_data + i * dim_, norm_vectors.data() + i * dim_, dim_);
+        }
+        query_data = norm_vectors.data();
+    }
+
+    // Batch dot products query x centroids^T via Sgemm (same shape as GNOIMIPartition).
+    Vector<float> dots(count * bucket_count_, allocator_);
+    compute_centroid_dots(
+        query_data, this->centroids_.data(), dots.data(), count, bucket_count_, dim_);
+
+    auto task = [&](int64_t i) {
+        Vector<std::pair<float, InnerIdType>> heap_storage(this->allocator_);
+        heap_storage.reserve(k);
+        ScanRouteHeap heap(std::less<>{}, std::move(heap_storage));
+        const auto* dots_i = dots.data() + i * bucket_count_;
+        for (BucketIdType b = 0; b < bucket_count_; ++b) {
+            const std::pair<float, InnerIdType> candidate{this->norms_[b] - dots_i[b],
+                                                          static_cast<InnerIdType>(b)};
+            if (heap.size() < k || candidate < heap.top()) {
+                heap.push(candidate);
+            }
+            if (heap.size() > k) {
+                heap.pop();
+            }
+        }
+        for (BucketIdType j = k; j > 0; --j) {
+            result[i * buckets_per_data + j - 1] = static_cast<BucketIdType>(heap.top().second);
+            heap.pop();
+        }
+    };
+    if (thread_pool_ == nullptr or count == 1) {
+        for (int64_t i = 0; i < count; ++i) {
+            task(i);
+        }
+    } else {
+        Vector<std::future<void>> futures(allocator_);
+        for (int64_t i = 0; i < count; ++i) {
+            futures.push_back(thread_pool_->GeneralEnqueue(task, i));
+        }
+        for (auto& item : futures) {
+            item.get();
+        }
+    }
+
+    if (ctx != nullptr and ctx->stats != nullptr) {
+        const auto distance_evaluations =
+            static_cast<uint64_t>(count) * static_cast<uint64_t>(bucket_count_);
+        const auto dist_cmp_increment = static_cast<uint32_t>(
+            std::min<uint64_t>(distance_evaluations, std::numeric_limits<uint32_t>::max()));
+        ctx->stats->dist_cmp.fetch_add(dist_cmp_increment, std::memory_order_relaxed);
+        ctx->stats->AddDistance(SearchStatistics::DistancePhase::ROUTING,
+                                DistanceEvaluationBackend::FP32,
+                                distance_evaluations);
+    }
+    return result;
+}
+
 }  // namespace vsag

--- a/src/algorithm/ivf/ivf_nearest_partition.h
+++ b/src/algorithm/ivf/ivf_nearest_partition.h
@@ -58,6 +58,27 @@ public:
 private:
     void
     factory_router_index(const IndexCommonParam& common_param);
+
+    Vector<BucketIdType>
+    classify_datas_by_scan(const void* datas,
+                           int64_t count,
+                           BucketIdType buckets_per_data,
+                           QueryContext* ctx) const;
+
+private:
+    bool use_route_graph_{true};
+
+    // centroids_ stores the trained centroids (normalized for cosine), and norms_ stores the
+    // per-centroid constant term used by the scan routing key :
+    //   - L2SQR: norms_[b] = |c_b|^2 / 2
+    //   - IP/COSINE: norms_[b] = 1.0 (distance is defined as 1 - dot, and cosine centroids are
+    //     normalized during training)
+    Vector<float> centroids_{allocator_};
+    Vector<float> norms_{allocator_};
+
+    // Copied common param, used to lazily create the routing HGraph when a route-graph-layout
+    // index is deserialized by a reader configured with use_route_graph=false.
+    IndexCommonParam common_param_;
 };
 
 }  // namespace vsag

--- a/src/algorithm/ivf/ivf_nearest_partition_test.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition_test.cpp
@@ -15,10 +15,15 @@
 
 #include "ivf_nearest_partition.h"
 
+#include <algorithm>
+#include <vector>
+
 #include "algorithm/inner_index_interface.h"
 #include "impl/allocator/safe_allocator.h"
 #include "impl/inner_search_param.h"
 #include "impl/thread_pool/safe_thread_pool.h"
+#include "simd/fp32_simd.h"
+#include "simd/normalize.h"
 #include "storage/serialization_template_test.h"
 #include "unittest.h"
 using namespace vsag;
@@ -134,4 +139,115 @@ TEST_CASE("IVF Nearest Partition Routing Statistics Test", "[ut][IVFNearestParti
         auto dumped = JsonType::Parse(stats.Dump());
         REQUIRE(dumped["distance_evaluations_by_phase"]["routing"].GetUint64() > 0);
     }
+}
+
+TEST_CASE("IVF Nearest Partition Centroid Scan Test", "[ut][IVFNearestPartition]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 32;
+    constexpr BucketIdType bucket_count = 16;
+    constexpr int64_t data_count = 256;
+    constexpr BucketIdType buckets_per_data = 4;
+    const std::vector<MetricType> metrics{
+        MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_IP, MetricType::METRIC_TYPE_COSINE};
+
+    for (const auto metric : metrics) {
+        IndexCommonParam common_param;
+        common_param.dim_ = dim;
+        common_param.metric_ = metric;
+        common_param.allocator_ = allocator;
+
+        auto strategy_param = std::make_shared<IVFPartitionStrategyParameters>();
+        strategy_param->use_route_graph = false;
+        auto partition =
+            std::make_unique<IVFNearestPartition>(bucket_count, common_param, strategy_param);
+        REQUIRE(partition->route_index_ptr_ == nullptr);
+
+        const auto untrained_result =
+            partition->ClassifyDatas(nullptr, 1, buckets_per_data, nullptr);
+        REQUIRE(untrained_result == Vector<BucketIdType>(buckets_per_data,
+                                                         static_cast<BucketIdType>(-1),
+                                                         allocator.get()));
+        auto untrained_restored =
+            std::make_unique<IVFNearestPartition>(bucket_count, common_param, strategy_param);
+        test_serializion(*partition, *untrained_restored);
+        REQUIRE(untrained_restored->ClassifyDatas(nullptr, 1, buckets_per_data, nullptr) ==
+                untrained_result);
+
+        auto vectors = fixtures::generate_vectors(data_count, dim, true, 95);
+        auto dataset = Dataset::Make();
+        dataset->Float32Vectors(vectors.data())->Dim(dim)->NumElements(data_count)->Owner(false);
+        partition->Train(dataset);
+        REQUIRE(partition->route_index_ptr_ == nullptr);
+
+        auto actual =
+            partition->ClassifyDatas(vectors.data(), data_count, buckets_per_data, nullptr);
+        REQUIRE(actual.size() == static_cast<uint64_t>(data_count * buckets_per_data));
+
+        Vector<float> centroid(dim, allocator.get());
+        Vector<float> normalized_query(dim, allocator.get());
+        Vector<std::pair<float, BucketIdType>> expected(bucket_count, allocator.get());
+        for (int64_t i = 0; i < data_count; ++i) {
+            const auto* query = vectors.data() + i * dim;
+            if (metric == MetricType::METRIC_TYPE_COSINE) {
+                Normalize(query, normalized_query.data(), dim);
+                query = normalized_query.data();
+            }
+            for (BucketIdType b = 0; b < bucket_count; ++b) {
+                partition->GetCentroid(b, centroid);
+                float distance = 0.0F;
+                if (metric == MetricType::METRIC_TYPE_L2SQR) {
+                    distance = FP32ComputeL2Sqr(query, centroid.data(), dim);
+                } else {
+                    distance = 1.0F - FP32ComputeIP(query, centroid.data(), dim);
+                }
+                expected[b] = {distance, b};
+            }
+            std::sort(expected.begin(), expected.end());
+            for (BucketIdType j = 0; j < buckets_per_data; ++j) {
+                REQUIRE(actual[i * buckets_per_data + j] == expected[j].second);
+            }
+        }
+
+        auto graph_config_param = std::make_shared<IVFPartitionStrategyParameters>();
+        graph_config_param->use_route_graph = true;
+        auto restored =
+            std::make_unique<IVFNearestPartition>(bucket_count, common_param, graph_config_param);
+        test_serializion(*partition, *restored);
+        REQUIRE(restored->route_index_ptr_ == nullptr);
+        REQUIRE(restored->ClassifyDatas(vectors.data(), data_count, buckets_per_data, nullptr) ==
+                actual);
+    }
+}
+
+TEST_CASE("IVF Nearest Partition Route Graph Layout Cross Config Test",
+          "[ut][IVFNearestPartition]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    constexpr int64_t dim = 32;
+    constexpr BucketIdType bucket_count = 16;
+    constexpr int64_t data_count = 256;
+
+    IndexCommonParam common_param;
+    common_param.dim_ = dim;
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    common_param.allocator_ = allocator;
+
+    auto graph_param = std::make_shared<IVFPartitionStrategyParameters>();
+    graph_param->use_route_graph = true;
+    auto graph_partition =
+        std::make_unique<IVFNearestPartition>(bucket_count, common_param, graph_param);
+
+    auto vectors = fixtures::generate_vectors(data_count, dim, true, 95);
+    auto dataset = Dataset::Make();
+    dataset->Float32Vectors(vectors.data())->Dim(dim)->NumElements(data_count)->Owner(false);
+    graph_partition->Train(dataset);
+    auto expected = graph_partition->ClassifyDatas(vectors.data(), data_count, 1, nullptr);
+
+    auto scan_config_param = std::make_shared<IVFPartitionStrategyParameters>();
+    scan_config_param->use_route_graph = false;
+    auto restored =
+        std::make_unique<IVFNearestPartition>(bucket_count, common_param, scan_config_param);
+    REQUIRE(restored->route_index_ptr_ == nullptr);
+    test_serializion(*graph_partition, *restored);
+    REQUIRE(restored->route_index_ptr_ != nullptr);
+    REQUIRE(restored->ClassifyDatas(vectors.data(), data_count, 1, nullptr) == expected);
 }

--- a/src/algorithm/ivf/ivf_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_parameter_test.cpp
@@ -285,6 +285,23 @@ TEST_CASE("IVF rejects reader IO for base codes", "[ut][IVFParameter]") {
     }
 }
 
+TEST_CASE("IVF maps use_route_graph external parameter", "[ut][IVFParameter]") {
+    REQUIRE(std::string(vsag::IVF_USE_ROUTE_GRAPH) == "use_route_graph");
+    auto external_param = vsag::JsonType::Parse(R"({
+        "partition_strategy_type": "ivf",
+        "use_route_graph": false
+    })");
+
+    vsag::IndexCommonParam common_param;
+    common_param.dim_ = 64;
+    common_param.data_type_ = vsag::DataTypes::DATA_TYPE_FLOAT;
+
+    auto param = vsag::IVF::CheckAndMappingExternalParam(external_param, common_param);
+    auto ivf_param = std::dynamic_pointer_cast<vsag::IVFParameter>(param);
+    REQUIRE(ivf_param != nullptr);
+    REQUIRE_FALSE(ivf_param->ivf_partition_strategy_parameter->use_route_graph);
+}
+
 TEST_CASE("IVF maps RabitQ external parameters", "[ut][IVFParameter]") {
     auto external_param = vsag::JsonType::Parse(R"({
         "base_quantization_type": "rabitq",

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter.cpp
@@ -54,6 +54,10 @@ IVFPartitionStrategyParameters::FromJson(const JsonType& json) {
     CHECK_ARGUMENT(this->route_ef_construction >= this->route_max_degree,
                    "route_ef_construction must be no less than route_max_degree");
 
+    if (json.Contains(IVF_USE_ROUTE_GRAPH_KEY)) {
+        this->use_route_graph = json[IVF_USE_ROUTE_GRAPH_KEY].GetBool();
+    }
+
     this->gnoimi_param = std::make_shared<GNOIMIParameter>();
     if (this->partition_strategy_type == IVFPartitionStrategyType::GNO_IMI) {
         CHECK_ARGUMENT(
@@ -81,6 +85,7 @@ IVFPartitionStrategyParameters::ToJson() const {
     }
     json[IVF_ROUTE_MAX_DEGREE_KEY].SetInt(this->route_max_degree);
     json[IVF_ROUTE_EF_CONSTRUCTION_KEY].SetInt(this->route_ef_construction);
+    json[IVF_USE_ROUTE_GRAPH_KEY].SetBool(this->use_route_graph);
     if (this->partition_strategy_type == IVFPartitionStrategyType::GNO_IMI) {
         json[IVF_PARTITION_STRATEGY_TYPE_GNO_IMI].SetJson(this->gnoimi_param->ToJson());
     }
@@ -93,6 +98,8 @@ IVFPartitionStrategyParameters::CheckCompatibility(const ParamPtr& other) const 
     CHECK_FIELD_EQ(*this, *p, partition_strategy_type);
     CHECK_FIELD_EQ(*this, *p, route_max_degree);
     CHECK_FIELD_EQ(*this, *p, route_ef_construction);
+    // use_route_graph selects the layout only when a new index is trained. Serialized partitions
+    // are self-describing and must remain loadable by readers created with either setting.
     CHECK_SUB_PARAM(*this, *p, gnoimi_param);
     return true;
 }

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter.h
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter.h
@@ -53,6 +53,7 @@ public:
     IVFPartitionStrategyType partition_strategy_type{IVFPartitionStrategyType::IVF};
     int32_t route_max_degree{64};
     int32_t route_ef_construction{300};
+    bool use_route_graph{true};
     GNOIMIParameterPtr gnoimi_param{nullptr};
 };
 

--- a/src/algorithm/ivf/ivf_partition_strategy_parameter_test.cpp
+++ b/src/algorithm/ivf/ivf_partition_strategy_parameter_test.cpp
@@ -64,12 +64,19 @@ TEST_CASE("IVF Partition Strategy Routing Parameters", "[ut][IVFPartitionStrateg
         "partition_strategy_type": "ivf",
         "ivf_train_type": "kmeans",
         "route_max_degree": 128,
-        "route_ef_construction": 512
+        "route_ef_construction": 512,
+        "use_route_graph": false
     })");
 
     REQUIRE(param->route_max_degree == 128);
     REQUIRE(param->route_ef_construction == 512);
+    REQUIRE_FALSE(param->use_route_graph);
     vsag::ParameterTest::TestToJson(param);
+
+    auto compatible_layout_preference =
+        std::make_shared<vsag::IVFPartitionStrategyParameters>(*param);
+    compatible_layout_preference->use_route_graph = true;
+    REQUIRE(param->CheckCompatibility(compatible_layout_preference));
 
     auto incompatible = std::make_shared<vsag::IVFPartitionStrategyParameters>(*param);
     incompatible->route_max_degree = 64;

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -207,6 +207,7 @@ const char* const BRUTE_FORCE_USE_RESIDUAL = "use_residual";
 const char* const IVF_USE_RESIDUAL = "use_residual";
 const char* const IVF_USE_REORDER = "use_reorder";
 const char* const IVF_TRAIN_TYPE = "ivf_train_type";
+const char* const IVF_USE_ROUTE_GRAPH = "use_route_graph";
 const char* const IVF_BUCKETS_COUNT = "buckets_count";
 const char* const IVF_BASE_QUANTIZATION_TYPE = "base_quantization_type";
 const char* const IVF_BASE_IO_TYPE = "base_io_type";

--- a/src/inner_string_params.h
+++ b/src/inner_string_params.h
@@ -172,6 +172,7 @@ const char* const IVF_PARTITION_STRATEGY_TYPE_NEAREST = "ivf";
 const char* const IVF_PARTITION_STRATEGY_TYPE_GNO_IMI = "gno_imi";
 const char* const IVF_ROUTE_MAX_DEGREE_KEY = "route_max_degree";
 const char* const IVF_ROUTE_EF_CONSTRUCTION_KEY = "route_ef_construction";
+const char* const IVF_USE_ROUTE_GRAPH_KEY = "use_route_graph";
 
 const char* const GNO_IMI_FIRST_ORDER_BUCKETS_COUNT_KEY = "first_order_buckets_count";
 const char* const GNO_IMI_SECOND_ORDER_BUCKETS_COUNT_KEY = "second_order_buckets_count";


### PR DESCRIPTION
## Summary

Add an additive `use_route_graph` IVF partition parameter. It defaults to `true` to preserve the existing routing behavior. When set to `false`, IVF keeps the trained centroids and routes vectors by an exact batched centroid scan instead of constructing and querying a routing HGraph.

## Changes

- add `use_route_graph` parameter parsing, serialization, external parameter mapping, and a backward-compatible default
- skip routing HGraph/datacell construction when centroid scan routing is selected
- compute query-to-centroid inner products with `BlasFunction::Sgemm` and select deterministic exact top-k buckets
- preserve L2, IP, and cosine distance ordering semantics
- add a self-describing centroid-scan serialization layout while keeping the legacy route-graph layout loadable with either reader configuration
- cover exact routing, untrained behavior, parameter mapping, serialization round trips, and cross-configuration loading

## Testing

- `make release`
- `make fmt`
- `make lint`
- `./build/tests/unittests '[ut][IVFNearestPartition]' --reporter compact`
- `./build/tests/unittests '[ut][IVFPartitionStrategyParameters]' --reporter compact`
- `./build/tests/unittests '[ut][IVFParameter]' --reporter compact`

Fixes #2826