### PR TITLE
fix(ci): retain Coverage failure diagnostics

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
           apt update
           apt install -y libcapture-tiny-perl libdatetime-perl curl jq
           git clone https://github.com/linux-test-project/lcov.git
-          cd lcov && git checkout v2.3 && make install
+          cd lcov && git checkout v2.3 && make SHELL=/bin/bash install
           lcov --version
       - name: Load Cache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -72,17 +72,20 @@ jobs:
         # `make cov` defaults to the OpenBLAS backend. Use the system-installed
         # OpenBLAS in the ci-x86-openblas image instead of building OpenBLAS
         # from source every run.
-        run: |
-          export CMAKE_GENERATOR="Ninja"
-          export EXTRA_DEFINED="-DVSAG_USE_SYSTEM_OPENBLAS=ON"
-          make cov
+        env:
+          CMAKE_GENERATOR: Ninja
+          EXTRA_DEFINED: -DVSAG_USE_SYSTEM_OPENBLAS=ON
+        run: ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/compile.log make cov
       - name: Run Test
-        run: |
+        run: >-
+          ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/tests.log
           ./scripts/testing/test_parallel_bg.sh
       - name: Collect Coverage Info
         run: |
-          bash scripts/coverage/collect_cpp_coverage.sh
-          head -n10 coverage/coverage.info
+          ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/collect.log \
+            bash scripts/coverage/collect_cpp_coverage.sh
+          ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/coverage-head.log \
+            head -n10 coverage/coverage.info
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -92,3 +95,11 @@ jobs:
           flags: cpp
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+      - name: Upload Coverage Diagnostics
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage-diagnostics/
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -86,10 +86,11 @@ jobs:
           persist-credentials: false
       - name: Trust exact workspace for Git tooling
         run: ./scripts/ci/configure-git-safe-directory.sh
-      - name: Test changed-source lint filter
+      - name: Test CI helper scripts
         run: |
           python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py'
           python3 -m unittest tests/scripts/configure_git_safe_directory_test.py
+          python3 -m unittest tests/scripts/coverage_diagnostics_test.py
       - name: Prepare Host
         run: |
           sudo env VSAG_INSTALL_INTEL_MKL=OFF bash ./scripts/deps/install_deps_ubuntu.sh

--- a/scripts/ci/run-with-diagnostics.sh
+++ b/scripts/ci/run-with-diagnostics.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+readonly FAILURE_TAIL_LINES=200
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: $0 <log-file> <command> [argument ...]" >&2
+    exit 2
+fi
+
+log_file="$1"
+shift
+
+if ! mkdir -p -- "$(dirname -- "$log_file")"; then
+    echo "Unable to create the diagnostic log directory for $log_file" >&2
+    exit 2
+fi
+
+printf -v command_display '%q ' "$@"
+command_display="${command_display% }"
+
+{
+    printf 'Command: %s\n' "$command_display"
+    echo "Output:"
+} | tee "$log_file"
+header_statuses=("${PIPESTATUS[@]}")
+capture_status="${header_statuses[1]}"
+
+"$@" 2>&1 | tee -a "$log_file"
+command_statuses=("${PIPESTATUS[@]}")
+command_status="${command_statuses[0]}"
+if [[ "${command_statuses[1]}" -ne 0 ]]; then
+    capture_status="${command_statuses[1]}"
+fi
+
+{
+    echo
+    printf 'Command: %s\n' "$command_display"
+    printf 'Command exit status: %s\n' "$command_status"
+    printf 'Diagnostic capture exit status: %s\n' "$capture_status"
+} | tee -a "$log_file"
+summary_statuses=("${PIPESTATUS[@]}")
+if [[ "${summary_statuses[1]}" -ne 0 ]]; then
+    capture_status="${summary_statuses[1]}"
+fi
+
+if [[ "$command_status" -ne 0 ]]; then
+    printf '::error title=Command failed::Exit status %s; full output is in %s\n' \
+        "$command_status" "$log_file"
+    echo "::group::Failure output (last ${FAILURE_TAIL_LINES} lines)"
+    tail -n "$FAILURE_TAIL_LINES" "$log_file" || true
+    echo "::endgroup::"
+    printf 'Command failed with exit status %s: %s\n' "$command_status" "$command_display"
+    exit "$command_status"
+fi
+
+if [[ "$capture_status" -ne 0 ]]; then
+    printf '::error title=Diagnostic capture failed::tee exited with status %s for %s\n' \
+        "$capture_status" "$log_file"
+    printf 'Diagnostic capture failed with exit status %s: %s\n' \
+        "$capture_status" "$command_display"
+    exit "$capture_status"
+fi

--- a/scripts/coverage/collect_cpp_coverage.sh
+++ b/scripts/coverage/collect_cpp_coverage.sh
@@ -13,11 +13,14 @@ else
     mkdir -p "${COVERAGE_DIR}"
 fi
 
+# Exclude system headers before lcov runs consistency checks. The remove step below keeps the
+# same filter for compatibility with existing trace files.
 lcov --rc branch_coverage=1 \
      --rc geninfo_unexecuted_blocks=1 \
      --parallel 8 \
      --directory . \
      --capture \
+     --exclude '/usr/*' \
      --substitute "s#${ROOT_DIR}/##g" \
      --ignore-errors mismatch,mismatch \
      --ignore-errors count,count \

--- a/tests/scripts/coverage_diagnostics_test.py
+++ b/tests/scripts/coverage_diagnostics_test.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DIAGNOSTIC_RUNNER = ROOT / "scripts/ci/run-with-diagnostics.sh"
+COVERAGE_COLLECTOR = ROOT / "scripts/coverage/collect_cpp_coverage.sh"
+
+
+class DiagnosticRunnerTest(unittest.TestCase):
+    def run_command(
+        self, log_file: Path, *command: str
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(DIAGNOSTIC_RUNNER), str(log_file), *command],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_records_successful_command_and_status(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log_file = Path(directory) / "diagnostics/success.log"
+            result = self.run_command(log_file, "bash", "-c", "printf 'success output\\n'")
+            log = log_file.read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("success output", log)
+        self.assertIn("Command exit status: 0", log)
+        self.assertIn("Diagnostic capture exit status: 0", log)
+
+    def test_propagates_failure_and_repeats_useful_tail(self):
+        command = (
+            "for value in {1..250}; do printf 'noise %s\\n' \"$value\"; done; "
+            "printf 'causal detail\\n'; "
+            "for value in {1..10}; do printf 'cleanup %s\\n' \"$value\"; done; "
+            "exit 23"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            log_file = Path(directory) / "diagnostics/failure.log"
+            result = self.run_command(log_file, "bash", "-c", command)
+            log = log_file.read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 23, result.stdout + result.stderr)
+        self.assertIn("causal detail", log)
+        self.assertIn("Command exit status: 23", log)
+        self.assertIn("::error title=Command failed::Exit status 23", result.stdout)
+        failure_tail = result.stdout.split("::group::Failure output", maxsplit=1)[1]
+        self.assertIn("causal detail", failure_tail)
+        self.assertIn("Command failed with exit status 23", result.stdout)
+
+    def test_distinguishes_a_capture_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log_file = Path(directory) / "existing-directory"
+            log_file.mkdir()
+            result = self.run_command(log_file, "bash", "-c", "printf 'command ran\\n'")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("command ran", result.stdout)
+        self.assertIn("Diagnostic capture failed", result.stdout)
+
+
+class CoverageCollectorTest(unittest.TestCase):
+    def test_excludes_system_headers_during_capture(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary_root = Path(directory)
+            collector_dir = temporary_root / "scripts/coverage"
+            collector_dir.mkdir(parents=True)
+            collector = collector_dir / COVERAGE_COLLECTOR.name
+            shutil.copy2(COVERAGE_COLLECTOR, collector)
+
+            fake_bin = temporary_root / "fake-bin"
+            fake_bin.mkdir()
+            fake_lcov = fake_bin / "lcov"
+            fake_lcov.write_text(
+                """#!/usr/bin/env bash
+for argument in "$@"; do
+    printf '%s\\t' "$argument" >> "$LCOV_CALLS"
+done
+printf '\\n' >> "$LCOV_CALLS"
+
+output_file=""
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--output-file" ]]; then
+        shift
+        output_file="$1"
+    fi
+    shift
+done
+if [[ -n "$output_file" ]]; then
+    printf 'TN:\\n' > "$output_file"
+fi
+""",
+                encoding="utf-8",
+            )
+            fake_lcov.chmod(0o755)
+
+            calls_file = temporary_root / "lcov-calls"
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+            environment["LCOV_CALLS"] = str(calls_file)
+            result = subprocess.run(
+                ["bash", str(collector)],
+                cwd=temporary_root,
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            calls = [
+                [argument for argument in line.split("\t") if argument]
+                for line in calls_file.read_text(encoding="utf-8").splitlines()
+            ]
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(len(calls), 3)
+        capture = calls[0]
+        self.assertIn("--capture", capture)
+        exclude_index = capture.index("--exclude")
+        self.assertEqual(capture[exclude_index + 1], "/usr/*")
+        self.assertNotIn("inconsistent,inconsistent", capture)
+        self.assertIn("--remove", calls[1])
+        self.assertIn("/usr/*", calls[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2751

## What Changed

- Exclude `/usr/*` while `lcov` captures data, before consistency validation, while retaining the existing post-capture removal filter and all VSAG coverage requirements.
- Run the upstream lcov 2.3 Makefile with its required Bash shell so its non-POSIX here-string no longer emits a misleading, non-terminal `/bin/sh` error.
- Capture each repository Coverage command, its exit status, and complete output; repeat the useful failure tail in the Actions log and always upload the full diagnostic logs.
- Exercise successful commands, command failures, diagnostic-capture failures, and both the early and final system-header filters in focused regression tests.

The full logs for all 16 occurrences recorded on #2751 were inspected. Fifteen failed in the first `lcov --capture` command because lcov 2.3 rejected inconsistent GCC 11 branch data from the system `<chrono>` header. The remaining occurrence was a separate HGraph test assertion; this change does not alter HGraph, test outcomes, coverage thresholds, or error handling.

## Test Evidence

- [ ] `make fmt` (clang-format 15 is unavailable locally; CI will validate)
- [ ] `make lint` (clang-tidy 15 is unavailable locally; CI will validate)
- [ ] `make test` (no C++ source or build configuration changed)
- [ ] `make cov`, run tests, and collect coverage (full suite is not justified for script/workflow-only changes)
- [x] Other (described below)

Test details:

```text
python3 -m unittest tests/scripts/coverage_diagnostics_test.py
4 tests passed

python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py'
python3 -m unittest tests/scripts/configure_git_safe_directory_test.py tests/scripts/coverage_diagnostics_test.py
11 tests passed

bash -n scripts/ci/run-with-diagnostics.sh scripts/coverage/collect_cpp_coverage.sh
git diff --check
actionlint 1.7.12 .github/workflows/coverage.yml .github/workflows/pr-ci.yml
PyYAML 6.0.3 parsed both modified workflows
All passed

lcov 2.3 install fixture on Linux:
- default GNU Make shell: exited 0 but reproduced `redirection unexpected`
- `SHELL=/bin/bash`: exited 0 without the shell diagnostic
```

Local tool context: GCC 15.2.0, GNU Bash 5.3.9, CMake 4.2.3, Ninja 1.13.2.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: Coverage failures now retain explicit command diagnostics; discarded system headers are filtered before lcov validates them

## Performance and Concurrency Impact

- Performance impact: negligible; system-header data is discarded earlier and logs are compressed by the artifact action
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the commit to restore the previous Coverage workflow and capture order

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for the bug fix
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit message follows project conventions
