### PR TITLE
perf(ivf): keep routing statistics parsing out of ClassifyDatas reduce lock

### DIFF
--- a/src/algorithm/ivf/ivf_nearest_partition.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition.cpp
@@ -114,15 +114,24 @@ IVFNearestPartition::ClassifyDatas(const void* datas,
             result[i * buckets_per_data + j] = static_cast<BucketIdType>(result_ids[j]);
         }
 
-        std::scoped_lock lock(dist_cmp_reduce_mutex);
-        // the return value of GetStatistics always has the same length as the input keys, and
-        // atoi("") returns a `0`.
-        auto route_stats = search_result->GetStatistics({"dist_cmp", "distance_evaluations"});
-        dist_cmp += std::atoi(route_stats[0].c_str());
-        if (ctx != nullptr and ctx->stats != nullptr and route_stats.size() > 1) {
+        if (ctx != nullptr and ctx->stats != nullptr) {
+            // GetStatistics re-parses the routing statistics JSON and re-dumps it to strings,
+            // which is allocation-heavy; it must not run inside the reduce lock. Only the two
+            // integer accumulations below are serialized. The return value always has the same
+            // length as the input keys, and atoi("") returns a `0`.
+            auto route_stats = search_result->GetStatistics({"dist_cmp", "distance_evaluations"});
+            const uint32_t local_dist_cmp = std::atoi(route_stats[0].c_str());
+            uint64_t eval_count = 0;
+            if (route_stats.size() > 1) {
+                eval_count = std::strtoull(route_stats[1].c_str(), nullptr, 10);
+            }
+            {
+                std::scoped_lock lock(dist_cmp_reduce_mutex);
+                dist_cmp += local_dist_cmp;
+            }
             ctx->stats->AddDistance(SearchStatistics::DistancePhase::ROUTING,
                                     DistanceEvaluationBackend::FP32,
-                                    std::strtoull(route_stats[1].c_str(), nullptr, 10));
+                                    eval_count);
         }
     };
     if (thread_pool_ == nullptr or count == 1) {

--- a/src/algorithm/ivf/ivf_nearest_partition_test.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition_test.cpp
@@ -96,3 +96,42 @@ TEST_CASE("IVF Nearest Partition Serialize Test", "[ut][IVFNearestPartition]") {
     auto restored_class_result = partition2->ClassifyDatas(vec.data(), data_count, 1, nullptr);
     REQUIRE(restored_class_result == class_result);
 }
+
+TEST_CASE("IVF Nearest Partition Routing Statistics Test", "[ut][IVFNearestPartition]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto thread_pool = SafeThreadPool::FactoryDefaultThreadPool();
+    std::vector<SafeThreadPoolPtr> pools{thread_pool, nullptr};
+    int64_t dim = 128;
+    int64_t bucket_count = 20;
+    for (auto& tp : pools) {
+        IndexCommonParam param;
+        param.dim_ = dim;
+        param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+        param.allocator_ = allocator;
+        param.thread_pool_ = tp;
+
+        IVFPartitionStrategyParametersPtr strategy_param =
+            std::make_shared<IVFPartitionStrategyParameters>();
+        auto partition = std::make_unique<IVFNearestPartition>(bucket_count, param, strategy_param);
+
+        auto dataset = Dataset::Make();
+        int64_t data_count = 1000L;
+        auto vec = fixtures::generate_vectors(data_count, dim, true, 95);
+        dataset->Float32Vectors(vec.data())->Dim(dim)->NumElements(data_count)->Owner(false);
+
+        partition->Train(dataset);
+        auto class_result = partition->ClassifyDatas(vec.data(), data_count, 1, nullptr);
+
+        // The search path accumulates routing statistics through a non-null QueryContext. The
+        // statistics parsing must produce the same bucket assignment and non-zero routing stats
+        // (the parse now runs outside the reduce lock).
+        SearchStatistics stats;
+        QueryContext ctx;
+        ctx.stats = &stats;
+        auto stats_result = partition->ClassifyDatas(vec.data(), data_count, 1, &ctx);
+        REQUIRE(stats_result == class_result);
+        REQUIRE(stats.dist_cmp.load() > 0);
+        auto dumped = JsonType::Parse(stats.Dump());
+        REQUIRE(dumped["distance_evaluations_by_phase"]["routing"].GetUint64() > 0);
+    }
+}


### PR DESCRIPTION
## Summary

`IVFNearestPartition::ClassifyDatas` held `dist_cmp_reduce_mutex` across a full `DatasetImpl::GetStatistics` call once per routed vector. `GetStatistics` re-parses the routing HGraph statistics JSON and re-dumps two values back to strings for `atoi`/`strtoull`, an allocation-heavy round trip that ran inside the critical section and throttled multi-threaded IVF builds.

This PR narrows the critical section:

- Skip the whole accounting block when `ctx`/`ctx->stats` are null — the build path (`ivf.cpp` `ClassifyDatas(..., nullptr)`, `bucket_datacell.h` `Train`) never consumes these values, so this is dead-code removal.
- On the search path, parse `GetStatistics` outside the lock; only the two integer accumulations (`dist_cmp += ...` and `AddDistance(...)`) are serialized. `SearchStatistics::AddDistance` is already lock-free (atomics + CAS), so the lock now only guards the local `dist_cmp` counter.

Behavior is unchanged: identical `dist_cmp` and `SearchStatistics::DistancePhase::ROUTING` values on the search path, and the build path never produced them.

## Changes

- `src/algorithm/ivf/ivf_nearest_partition.cpp`: move the statistics parse out of `dist_cmp_reduce_mutex`; skip it entirely when `ctx`/`stats` are null.
- `src/algorithm/ivf/ivf_nearest_partition_test.cpp`: add "IVF Nearest Partition Routing Statistics Test" covering the search path (non-null `QueryContext` with stats) for both pooled and non-pooled thread configurations, asserting identical bucket assignment and non-zero routing stats.

## Testing

- `unittests [IVFNearestPartition]` — 2010 assertions in 3 test cases, all pass (incl. the new statistics test).
- `unittests *IVF*` — 2096 assertions in 12 test cases, all pass.
- `make fmt` (clang-format 15) clean.

## Related Issues

- Closes: #2825
