### PR TITLE
chore: organize repository labels

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,120 @@
+[
+  {
+    "name": "area/bindings-node",
+    "color": "D4C5F9",
+    "description": "Node.js and TypeScript bindings Node.js 与 TypeScript 绑定"
+  },
+  {
+    "name": "area/bindings-python",
+    "color": "D4C5F9",
+    "description": "Python package and bindings Python 包与绑定"
+  },
+  {
+    "name": "area/ci",
+    "color": "D4C5F9",
+    "description": "CI/CD, build configuration, and automation CI/CD、构建配置与自动化"
+  },
+  {
+    "name": "area/dependencies",
+    "color": "D4C5F9",
+    "description": "Vendored and external dependencies 内置及外部依赖"
+  },
+  {
+    "name": "area/docker",
+    "color": "D4C5F9",
+    "description": "Container images and Docker environments 容器镜像与 Docker 环境"
+  },
+  {
+    "name": "area/docs",
+    "color": "D4C5F9",
+    "description": "Website and repository documentation 网站与仓库文档"
+  },
+  {
+    "name": "area/examples",
+    "color": "D4C5F9",
+    "description": "C++, Python, and TypeScript examples C++、Python 与 TypeScript 示例"
+  },
+  {
+    "name": "area/testing",
+    "color": "D4C5F9",
+    "description": "Tests, fixtures, and test infrastructure 测试、夹具与测试基础设施"
+  },
+  {
+    "name": "area/tools",
+    "color": "D4C5F9",
+    "description": "Command-line, evaluation, and developer tools 命令行、评测与开发工具"
+  },
+  {
+    "name": "module/api",
+    "color": "402BFA",
+    "description": "Public C++ API and headers 公共 C++ API 与头文件"
+  },
+  {
+    "name": "module/attr",
+    "color": "1CC88E",
+    "description": "Attribute filtering and expressions 属性过滤与表达式"
+  },
+  {
+    "name": "module/cicd",
+    "color": "0E8A16",
+    "description": "Legacy; use area/ci 已弃用；请使用 area/ci",
+    "legacy": true
+  },
+  {
+    "name": "module/datacell",
+    "color": "3C966A",
+    "description": "Data cells, vector I/O, and quantization 数据单元、向量 I/O 与量化"
+  },
+  {
+    "name": "module/docker",
+    "color": "5F5997",
+    "description": "Legacy; use area/docker 已弃用；请使用 area/docker",
+    "legacy": true
+  },
+  {
+    "name": "module/docs",
+    "color": "43C818",
+    "description": "Legacy; use area/docs 已弃用；请使用 area/docs",
+    "legacy": true
+  },
+  {
+    "name": "module/example",
+    "color": "47E1CB",
+    "description": "Legacy; use area/examples 已弃用；请使用 area/examples",
+    "legacy": true
+  },
+  {
+    "name": "module/index",
+    "color": "335514",
+    "description": "Index algorithms and implementations 索引算法与实现"
+  },
+  {
+    "name": "module/python",
+    "color": "45194C",
+    "description": "Legacy; use area/bindings-python 已弃用；请使用 area/bindings-python",
+    "legacy": true
+  },
+  {
+    "name": "module/simd",
+    "color": "C5DEF5",
+    "description": "SIMD dispatch and optimized kernels SIMD 分派与优化内核"
+  },
+  {
+    "name": "module/testing",
+    "color": "4C9330",
+    "description": "Legacy; use area/testing 已弃用；请使用 area/testing",
+    "legacy": true
+  },
+  {
+    "name": "module/thirdparty",
+    "color": "B2CAEA",
+    "description": "Legacy; use area/dependencies 已弃用；请使用 area/dependencies",
+    "legacy": true
+  },
+  {
+    "name": "module/tools",
+    "color": "A49C89",
+    "description": "Legacy; use area/tools 已弃用；请使用 area/tools",
+    "legacy": true
+  }
+]

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,45 +1,48 @@
 pull_request_rules:
-  - name: add module/cicd label
+  - name: add area/ci label
     conditions:
-      - files~=^\.circleci/.*$
-      - files~=^\.github/.*$
-      - files~=^\scripts/.*$
+      - or:
+          - files~=^\.circleci/.*$
+          - files~=^\.github/.*$
+          - files~=^scripts/.*$
+          - files~=^cmake/.*$
+          - files~=^CMakeLists\.txt$
     actions:
       label:
         add:
-          - module/cicd
+          - area/ci
 
-  - name: add module/docker label
+  - name: add area/docker label
     conditions:
       - files~=^docker/.*$
     actions:
       label:
         add:
-          - module/docker
+          - area/docker
 
-  - name: add module/docs label
+  - name: add area/docs label
     conditions:
       - files~=^docs/.*$
     actions:
       label:
         add:
-          - module/docs
+          - area/docs
 
-  - name: add module/example label
+  - name: add area/examples label
     conditions:
       - files~=^examples/.*$
     actions:
       label:
         add:
-          - module/example
+          - area/examples
 
-  - name: add module/thirdparty label
+  - name: add area/dependencies label
     conditions:
       - files~=^extern/.*$
     actions:
       label:
         add:
-          - module/thirdparty
+          - area/dependencies
 
   - name: add module/api label
     conditions:
@@ -59,9 +62,10 @@ pull_request_rules:
 
   - name: add module/datacell label
     conditions:
-      - files~=^src/datacell/.*$
-      - files~=^src/io/.*$
-      - files~=^src/quantization/.*$
+      - or:
+          - files~=^src/datacell/.*$
+          - files~=^src/io/.*$
+          - files~=^src/quantization/.*$
     actions:
       label:
         add:
@@ -69,7 +73,9 @@ pull_request_rules:
 
   - name: add module/index label
     conditions:
-      - files~=^src/index/.*$
+      - or:
+          - files~=^src/index/.*$
+          - files~=^src/algorithm/.*$
     actions:
       label:
         add:
@@ -83,30 +89,41 @@ pull_request_rules:
         add:
           - module/simd
 
-  - name: add module/pyvsag label
+  - name: add area/bindings-python label
     conditions:
-      - files~=^python/.*$
-      - files~=^python_bindings/.*$
+      - or:
+          - files~=^python/.*$
+          - files~=^python_bindings/.*$
     actions:
       label:
         add:
-          - module/pyvsag
+          - area/bindings-python
 
-  - name: add module/tools label
+  - name: add area/bindings-node label
+    conditions:
+      - or:
+          - files~=^node_bindings/.*$
+          - files~=^typescript/.*$
+    actions:
+      label:
+        add:
+          - area/bindings-node
+
+  - name: add area/tools label
     conditions:
       - files~=^tools/.*$
     actions:
       label:
         add:
-          - module/tools
+          - area/tools
 
-  - name: add module/testing label
+  - name: add area/testing label
     conditions:
       - files~=^tests/.*$
     actions:
       label:
         add:
-          - module/testing
+          - area/testing
 merge_protections:
   - name: Require kind label
     if:

--- a/.github/scripts/check-label-config.mjs
+++ b/.github/scripts/check-label-config.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const manifestUrl = new URL('../labels.json', import.meta.url);
+const mergifyUrl = new URL('../mergify.yml', import.meta.url);
+
+const labels = JSON.parse(await readFile(manifestUrl, 'utf8'));
+const mergify = await readFile(mergifyUrl, 'utf8');
+
+assert(Array.isArray(labels), 'labels.json must contain an array');
+
+const names = new Set();
+for (const [index, label] of labels.entries()) {
+    const context = `labels.json entry ${index}`;
+    assert(label !== null && typeof label === 'object' && !Array.isArray(label), `${context} must be an object`);
+    assert.equal(typeof label.name, 'string', `${context}.name must be a string`);
+    assert.equal(typeof label.color, 'string', `${context}.color must be a string`);
+    assert.equal(typeof label.description, 'string', `${context}.description must be a string`);
+    assert.match(label.name, /^(?:area|module)\/[a-z0-9-]+$/, `invalid managed label: ${label.name}`);
+    assert(!names.has(label.name), `duplicate managed label: ${label.name}`);
+    assert.match(label.color, /^[0-9A-F]{6}$/, `invalid color for ${label.name}`);
+    assert(label.description.trim().length > 0, `missing description for ${label.name}`);
+    assert(label.legacy === undefined || label.legacy === true, `invalid legacy flag for ${label.name}`);
+    names.add(label.name);
+}
+
+const referencedNames = new Set(
+    [...mergify.matchAll(/^\s+- ((?:area|module)\/[a-z0-9-]+)\s*$/gm)].map((match) => match[1])
+);
+
+const missingFromManifest = [...referencedNames].filter((name) => !names.has(name));
+const activeNames = labels.filter((label) => !label.legacy).map((label) => label.name);
+const missingFromMergify = activeNames.filter((name) => !referencedNames.has(name));
+const referencedLegacyNames = labels
+    .filter((label) => label.legacy && referencedNames.has(label.name))
+    .map((label) => label.name);
+
+assert.deepEqual(missingFromManifest, [], `Mergify labels missing from manifest: ${missingFromManifest}`);
+assert.deepEqual(missingFromMergify, [], `manifest labels unused by Mergify: ${missingFromMergify}`);
+assert.deepEqual(referencedLegacyNames, [], `Mergify still uses legacy labels: ${referencedLegacyNames}`);
+
+const remoteIndex = process.argv.indexOf('--remote');
+if (remoteIndex !== -1) {
+    const repository = process.argv[remoteIndex + 1] ?? process.env.GITHUB_REPOSITORY;
+    assert(repository, '--remote requires an owner/repository argument or GITHUB_REPOSITORY');
+
+    const headers = {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'vsag-label-config-check',
+        'X-GitHub-Api-Version': '2022-11-28'
+    };
+    if (process.env.GITHUB_TOKEN) {
+        headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+
+    const remoteLabels = [];
+    for (let page = 1; ; page += 1) {
+        const response = await fetch(
+            `https://api.github.com/repos/${repository}/labels?per_page=100&page=${page}`,
+            { headers, signal: AbortSignal.timeout(30_000) }
+        );
+        assert(response.ok, `GitHub labels request failed: ${response.status} ${response.statusText}`);
+
+        const pageLabels = await response.json();
+        remoteLabels.push(...pageLabels);
+        if (pageLabels.length < 100) {
+            break;
+        }
+    }
+
+    const expectedByName = new Map(labels.map((label) => [label.name, label]));
+    const normalizedRemoteLabels = remoteLabels
+        .filter((label) => /^(?:area|module)\//.test(label.name))
+        .map((label) => ({
+            name: label.name,
+            color: label.color.toUpperCase(),
+            description: label.description ?? '',
+            ...(expectedByName.get(label.name)?.legacy ? { legacy: true } : {})
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name));
+    const normalizedExpectedLabels = [...labels].sort((left, right) =>
+        left.name.localeCompare(right.name)
+    );
+
+    assert.deepEqual(
+        normalizedRemoteLabels,
+        normalizedExpectedLabels,
+        `GitHub managed labels differ from ${manifestUrl.pathname}`
+    );
+}
+
+console.log(
+    `Validated ${labels.length} managed labels against .github/mergify.yml` +
+        (remoteIndex === -1 ? '' : ' and GitHub')
+);

--- a/.github/workflows/label-config.yml
+++ b/.github/workflows/label-config.yml
@@ -1,0 +1,32 @@
+name: Label configuration
+
+on:
+  pull_request:
+    paths:
+      - ".github/labels.json"
+      - ".github/mergify.yml"
+      - ".github/scripts/check-label-config.mjs"
+      - ".github/workflows/label-config.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/labels.json"
+      - ".github/mergify.yml"
+      - ".github/scripts/check-label-config.mjs"
+      - ".github/workflows/label-config.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node .github/scripts/check-label-config.mjs --remote antgroup/vsag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

- separate product `module/*` labels from cross-cutting `area/*` labels
- keep historical module labels as legacy labels without deleting issue or PR history
- align Mergify path rules with current CI, algorithm, Python, and Node.js directories
- add a versioned label manifest and CI validation against Mergify and GitHub

## Validation

- `node .github/scripts/check-label-config.mjs`
- `GITHUB_TOKEN=... node .github/scripts/check-label-config.mjs --remote antgroup/vsag`
- YAML parse check for `.github/mergify.yml` and `.github/workflows/label-config.yml`
- `git diff --check`