### PR TITLE
feat: unify index analysis capabilities

### DIFF
--- a/docs/docs/en/src/resources/analyze_index.md
+++ b/docs/docs/en/src/resources/analyze_index.md
@@ -17,13 +17,53 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **Input**: a `SearchRequest` (query dataset + `topk` + search parameter JSON).
 - **Output**: a JSON-formatted string containing dynamic, query-driven metrics.
-- **Supported indexes**: currently `HGraph`, `IVF`, `Pyramid`, and `SINDI`. Indexes that do not
-  implement this API will throw an exception when called.
+- **Supported indexes**: all factory-registered indexes: `HGraph`, `IVF`, `Pyramid`, `SINDI`,
+  `SINDI_V2`, `SIMQ`, `BruteForce`, `WARP`, and `LazyHGraph`.
 
 It is complementary to `Index::GetStats()`, which reports static structural properties of the
 index without needing query data. For graph-based indexes, additional graph-health details such
 as degree distribution, entry-point quality, sub-index recall and low-recall hot-spots are
 exposed through `GetStats()` rather than through `AnalyzeIndexBySearch`.
+
+### Common output contract
+
+Every successful static or dynamic analysis returns a JSON object with an `_analysis` member:
+
+```json
+{
+  "_analysis": {
+    "schema_version": 1,
+    "index_type": "brute_force",
+    "analysis_type": "search",
+    "status": "partial",
+    "sample_count": 10,
+    "topk": 10,
+    "consistency": "weak_snapshot",
+    "skipped": { "recall_query": "ground truth was not requested" }
+  }
+}
+```
+
+Existing index-specific fields remain at the JSON root for compatibility. `status` is `complete`
+when all applicable metrics were computed, `partial` when individual metrics are listed under
+`skipped`, and `not_applicable` when the request is valid but no metric can be computed (for
+example, search analysis on an empty index). Invalid arguments and execution failures still throw.
+Specialized analyzers may report an unavailable root-level metric as an object containing a
+string `skipped_reason`; the common metadata layer mirrors that reason into
+`_analysis.skipped.<metric>`. Baseline analyzers write the same public representation directly to
+`_analysis.skipped`. Consumers should rely on `_analysis.skipped`, while `skipped_reason` remains
+an index-specific compatibility detail.
+
+`BruteForce` and `WARP` provide exact-search baseline counts and latency. `SINDI_V2` and `SIMQ`
+provide baseline counts and query latency while index-specific quality metrics are reported as
+skipped. `LazyHGraph` delegates to its active BruteForce or HGraph backend and adds its current
+`phase` and `transition_threshold`; its reported `index_type` remains `lazy_hgraph`.
+
+Analysis is synchronous and intended for offline diagnostics. It can scan substantial parts of an
+index and specialized analyzers may compute exact ground truth. Analysis never changes search or
+serialization configuration and is safe with concurrent read-only search. Unless an index offers a
+stronger lock-protected view, `_analysis.consistency` is `weak_snapshot`; do not run analysis
+concurrently with Add, Remove, Update, or phase transition.
 
 Pyramid query analysis follows the same path-scoping rules as `KnnSearch`. For the default
 hierarchy, attach one path per query with `Dataset::Paths`. For a named hierarchy, attach paths

--- a/docs/docs/zh/src/resources/analyze_index.md
+++ b/docs/docs/zh/src/resources/analyze_index.md
@@ -16,12 +16,48 @@ AnalyzeIndexBySearch(const SearchRequest& request);
 
 - **输入**：`SearchRequest`（查询数据集 + `topk` + 搜索参数 JSON）。
 - **输出**：JSON 字符串，包含基于查询的动态指标。
-- **支持的索引类型**：当前支持 `HGraph`、`IVF`、`Pyramid` 与 `SINDI`。未实现该接口的
-  索引在调用时会抛出异常。
+- **支持的索引类型**：工厂注册的全部索引，即 `HGraph`、`IVF`、`Pyramid`、`SINDI`、
+  `SINDI_V2`、`SIMQ`、`BruteForce`、`WARP` 与 `LazyHGraph`。
 
 该接口与 `Index::GetStats()` 互为补充：后者无需查询数据，只输出索引的静态结构指标。
 对于基于图的索引，度分布、入口点质量、子索引召回率以及低召回热点节点等图健康度信息，
 通过 `GetStats()` 而非 `AnalyzeIndexBySearch` 输出。
+
+### 公共输出契约
+
+每次成功的静态或动态分析都会返回 JSON 对象，并包含 `_analysis` 成员：
+
+```json
+{
+  "_analysis": {
+    "schema_version": 1,
+    "index_type": "brute_force",
+    "analysis_type": "search",
+    "status": "partial",
+    "sample_count": 10,
+    "topk": 10,
+    "consistency": "weak_snapshot",
+    "skipped": { "recall_query": "ground truth was not requested" }
+  }
+}
+```
+
+为保持兼容，已有索引专属字段继续位于 JSON 根节点。全部适用指标均已计算时 `status` 为
+`complete`；部分指标因依赖不足而位于 `skipped` 时为 `partial`；请求合法但无法计算任何指标
+（例如对空索引执行搜索分析）时为 `not_applicable`。非法参数和执行失败仍然抛出异常。
+专用 Analyzer 可以把不可用的根级指标表示为包含字符串 `skipped_reason` 的对象；公共元数据层
+会将该原因同步到 `_analysis.skipped.<metric>`。基线 Analyzer 则直接写入相同的公共表示
+`_analysis.skipped`。使用方应以 `_analysis.skipped` 为准，而将 `skipped_reason` 视为索引专属的
+兼容性细节。
+
+`BruteForce` 与 `WARP` 提供精确搜索基线计数及耗时；`SINDI_V2` 与 `SIMQ` 提供基线计数和
+查询耗时，并将尚无真值的专属质量指标标记为 skipped。`LazyHGraph` 委托当前 BruteForce 或
+HGraph 后端，并追加 `phase` 与 `transition_threshold`；其 `index_type` 始终为 `lazy_hgraph`。
+
+Analysis 是同步、面向离线诊断的操作，可能扫描大量索引数据，专用 Analyzer 还可能计算精确
+真值。Analysis 不修改搜索或序列化配置，可与只读 Search 并发执行。除非索引提供更强的加锁
+快照，否则 `_analysis.consistency` 为 `weak_snapshot`；不要让 Analysis 与 Add、Remove、Update
+或 phase transition 并发执行。
 
 Pyramid 的查询分析遵循与 `KnnSearch` 相同的路径限定语义。对于默认 hierarchy，
 使用 `Dataset::Paths` 为每条 query 设置路径；对于命名 hierarchy，使用

--- a/include/vsag/index_features.h
+++ b/include/vsag/index_features.h
@@ -87,6 +87,9 @@ enum IndexFeature {
                                            distances[q * count + j] is query q vs ids[q * count + j],
                                            and -1 indicates an invalid id. */
 
+    SUPPORT_GET_STATS,               /**< Supports static index analysis via GetStats */
+    SUPPORT_ANALYZE_INDEX_BY_SEARCH, /**< Supports query-based index analysis */
+
     INDEX_FEATURE_COUNT /** must be last one */
 };
 }  // namespace vsag

--- a/src/algorithm/hgraph/hgraph.cpp
+++ b/src/algorithm/hgraph/hgraph.cpp
@@ -24,6 +24,7 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "analyzer/analyzer.h"
+#include "analyzer/hgraph_analyzer.h"
 #include "attr/argparse.h"
 #include "common.h"
 #include "datacell/flatten_interface.h"
@@ -669,14 +670,28 @@ HGraph::SetPreciseCodesIO(const std::shared_ptr<Reader>& reader) {
 const static uint64_t QUERY_SAMPLE_SIZE = 10;
 const static int64_t DEFAULT_TOPK = 100;
 
+AnalyzerBasePtr
+HGraph::CreateAnalyzer(const AnalyzerParam& param) const {
+    return std::make_shared<HGraphAnalyzer>(this, param);
+}
+
 std::string
 HGraph::GetStats() const {
+    if (GetNumElements() == 0) {
+        JsonType stats;
+        stats["total_count"].SetInt64(0);
+        stats["live_count"].SetInt64(0);
+        stats["deleted_count"].SetInt64(GetNumberRemoved());
+        stats["_analysis"]["skipped"]["structure"].SetString("index is empty");
+        AddAnalysisMetadata(stats, GetName(), "stats", "partial");
+        return stats.Dump(4);
+    }
     AnalyzerParam analyzer_param(allocator_);
     analyzer_param.topk = DEFAULT_TOPK;
     analyzer_param.base_sample_size = std::min(QUERY_SAMPLE_SIZE, this->total_count_.load());
     analyzer_param.search_params =
         fmt::format(R"({{"hgraph": {{"ef_search": {}}}}})", ef_construct_);
-    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    auto analyzer = CreateAnalyzer(analyzer_param);
     JsonType stats = analyzer->GetStats();
     // Build-time cache hit-rate is a transient property of the
     // build_with_cache() path (taken only after ImportCache()), so it lives on
@@ -716,6 +731,7 @@ HGraph::GetStats() const {
         stats["mci_memory_usage"].SetInt(
             static_cast<int64_t>(this->mci_cliques_->GetMemoryUsage()));
     }
+    AddAnalysisMetadata(stats, GetName(), "stats", "complete");
     return stats.Dump(4);
 }
 
@@ -879,10 +895,25 @@ HGraph::UpdateExtraInfo(const DatasetPtr& new_base) {
 
 std::string
 HGraph::AnalyzeIndexBySearch(const SearchRequest& request) {
+    CHECK_ARGUMENT(request.query_ != nullptr, "analysis query cannot be null");
+    CHECK_ARGUMENT(request.topk_ > 0, "analysis topk must be greater than 0");
+    if (GetNumElements() == 0) {
+        JsonType stats;
+        stats["_analysis"]["skipped"]["search"].SetString("index is empty");
+        AddAnalysisMetadata(stats,
+                            GetName(),
+                            "search",
+                            "not_applicable",
+                            request.query_->GetNumElements(),
+                            request.topk_);
+        return stats.Dump(4);
+    }
     AnalyzerParam analyzer_param(allocator_);
     analyzer_param.topk = request.topk_;
-    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    auto analyzer = CreateAnalyzer(analyzer_param);
     JsonType stats = analyzer->AnalyzeIndexBySearch(request);
+    AddAnalysisMetadata(
+        stats, GetName(), "search", "complete", request.query_->GetNumElements(), request.topk_);
     return stats.Dump(4);
 }
 

--- a/src/algorithm/hgraph/hgraph.h
+++ b/src/algorithm/hgraph/hgraph.h
@@ -169,6 +169,9 @@ public:
     std::string
     GetStats() const override;
 
+    [[nodiscard]] AnalyzerBasePtr
+    CreateAnalyzer(const AnalyzerParam& param) const override;
+
     void
     GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
 

--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -29,12 +29,14 @@
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
+#include "analyzer/analyzer.h"
 #include "impl/filter/filter_headers.h"
 #include "impl/label_table/label_table.h"
 #include "impl/thread_pool/safe_thread_pool.h"
 #include "index_common_param.h"
 #include "index_detail_data.h"
 #include "index_feature_list.h"
+#include "inner_string_params.h"
 #include "storage/empty_index_binary_set.h"
 #include "storage/serialization.h"
 #include "storage/tlv_section.h"
@@ -72,6 +74,8 @@ InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_par
         std::make_shared<LabelTable>(allocator_, true, false, index_param->label_remap_type);
     this->index_feature_list_ = std::make_unique<IndexFeatureList>();
     this->index_feature_list_->SetFeature(SUPPORT_EXPORT_IDS);
+    this->index_feature_list_->SetFeature(SUPPORT_GET_STATS);
+    this->index_feature_list_->SetFeature(SUPPORT_ANALYZE_INDEX_BY_SEARCH);
     this->extra_info_size_ = common_param.extra_info_size_;
     if (this->extra_info_size_ > 0) {
         this->extra_infos_ =
@@ -92,6 +96,25 @@ InnerIndexInterface::InnerIndexInterface(const InnerIndexParameterPtr& index_par
 }
 
 InnerIndexInterface::~InnerIndexInterface() = default;
+
+AnalyzerBasePtr
+InnerIndexInterface::CreateAnalyzer(const AnalyzerParam& param) const {
+    return std::make_shared<BasicIndexAnalyzer>(this, param);
+}
+
+std::string
+InnerIndexInterface::GetStats() const {
+    AnalyzerParam param(allocator_);
+    return CreateAnalyzer(param)->GetStats().Dump(4);
+}
+
+std::string
+InnerIndexInterface::AnalyzeIndexBySearch(const SearchRequest& request) {
+    AnalyzerParam param(allocator_);
+    param.topk = request.topk_;
+    param.search_params = request.params_str_;
+    return CreateAnalyzer(param)->AnalyzeIndexBySearch(request).Dump(4);
+}
 
 std::vector<int64_t>
 InnerIndexInterface::Build(const DatasetPtr& base) {
@@ -982,41 +1005,55 @@ InnerIndexInterface::analyze_quantizer(JsonType& stats,
         logger::info("analyze_quantizer: sample_data_size = {}, topk = {}", sample_data_size, topk);
         float bias_ratio = 0.0F;
         float inversion_count_rate = 0.0F;
+        JsonType coarse_param;
+        if (not search_param.empty() && search_param != "default") {
+            coarse_param = JsonType::Parse(search_param);
+            CHECK_ARGUMENT(coarse_param.IsObject(), "search parameters must be a JSON object");
+        }
+        const auto index_name = this->GetName();
+        const bool has_valid_search_param =
+            not coarse_param.Contains(index_name) || coarse_param[index_name].IsObject();
+        CHECK_ARGUMENT(has_valid_search_param,
+                       fmt::format("search parameters for {} must be a JSON object", index_name));
+        coarse_param[index_name][SEARCH_PARAM_ENABLE_REORDER].SetBool(false);
+        const auto coarse_param_str = coarse_param.Dump();
         for (uint64_t i = 0; i < sample_data_size; ++i) {
             float tmp_bias_ratio = 0.0F;
             float tmp_inversion_count_rate = 0.0F;
-            this->use_reorder_ = false;
             const auto* query_data = data + i * dim_;
             auto query = Dataset::Make();
             FilterPtr filter = nullptr;
             query->Owner(false)->NumElements(1)->Float32Vectors(query_data)->Dim(dim_);
-            auto search_result = this->KnnSearch(query, topk, search_param, filter);
-            this->use_reorder_ = true;
+            auto search_result = this->KnnSearch(query, topk, coarse_param_str, filter);
             auto distance_result = this->CalcDistancesById(
                 query_data, search_result->GetIds(), search_result->GetDim());
             const auto* ground_distances = distance_result->GetDistances();
             const auto* approximate_distances = search_result->GetDistances();
-            for (int64_t j = 0; j < topk; ++j) {
+            const auto result_count = search_result->GetDim();
+            CHECK_ARGUMENT(result_count > 0,
+                           "analysis search returned no candidates for a non-empty index");
+            for (int64_t j = 0; j < result_count; ++j) {
                 if (ground_distances[j] > 0) {
                     tmp_bias_ratio += std::abs(approximate_distances[j] - ground_distances[j]) /
                                       ground_distances[j];
                 }
             }
-            tmp_bias_ratio /= static_cast<float>(topk);
+            tmp_bias_ratio /= static_cast<float>(result_count);
             bias_ratio += tmp_bias_ratio;
             // calculate inversion count rate
             int64_t inversion_count = 0;
-            for (int64_t j = 0; j < search_result->GetDim() - 1; ++j) {
-                for (int64_t k = j + 1; k < search_result->GetDim(); ++k) {
+            for (int64_t j = 0; j < result_count - 1; ++j) {
+                for (int64_t k = j + 1; k < result_count; ++k) {
                     if (ground_distances[j] > ground_distances[k]) {
                         inversion_count++;
                     }
                 }
             }
-            int64_t search_count = search_result->GetDim();
-            tmp_inversion_count_rate =
-                static_cast<float>(inversion_count) /
-                (static_cast<float>(search_count * (search_count - 1)) / 2.0F);
+            if (result_count > 1) {
+                tmp_inversion_count_rate =
+                    static_cast<float>(inversion_count) /
+                    (static_cast<float>(result_count * (result_count - 1)) / 2.0F);
+            }
             inversion_count_rate += tmp_inversion_count_rate;
         }
         stats["quantization_bias_ratio"].SetFloat(bias_ratio /

--- a/src/algorithm/inner_index_interface.h
+++ b/src/algorithm/inner_index_interface.h
@@ -60,8 +60,10 @@ DEFINE_POINTER2(InnerIndex, InnerIndexInterface);
 DEFINE_POINTER(LabelTable);
 DEFINE_POINTER(IndexFeatureList);
 DEFINE_POINTER(SafeThreadPool);
+DEFINE_POINTER(AnalyzerBase);
 
 class IndexCommonParam;
+struct AnalyzerParam;
 
 class InnerIndexInterface {
 public:
@@ -81,10 +83,10 @@ public:
     Add(const DatasetPtr& base) = 0;
 
     virtual std::string
-    AnalyzeIndexBySearch(const SearchRequest& request) {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support analyze index by search");
-    }
+    AnalyzeIndexBySearch(const SearchRequest& request);
+
+    [[nodiscard]] virtual AnalyzerBasePtr
+    CreateAnalyzer(const AnalyzerParam& param) const;
 
     virtual std::vector<int64_t>
     Build(const DatasetPtr& base);
@@ -346,10 +348,7 @@ public:
     }
 
     [[nodiscard]] virtual std::string
-    GetStats() const {
-        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
-                            "Index doesn't support GetStats");
-    }
+    GetStats() const;
 
     virtual void
     GetVectorByInnerId(InnerIdType inner_id, float* data) const {

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -210,7 +210,11 @@ TEST_CASE("InnerIndexInterface NOT Implemented", "[ut][InnerIndexInterface]") {
     REQUIRE_THROWS(empty_index->EstimateMemory(1000));
     REQUIRE_THROWS(empty_index->EstimateBuildMemory(1000));
     REQUIRE_THROWS(empty_index->Feedback(nullptr, 10, ""));
-    REQUIRE_THROWS(empty_index->GetStats());
+    const auto stats = JsonType::Parse(empty_index->GetStats());
+    REQUIRE(stats["_analysis"]["schema_version"].GetInt() == 1);
+    REQUIRE(stats["_analysis"]["index_type"].GetString() == "EmptyInnerIndex");
+    REQUIRE(stats["_analysis"]["analysis_type"].GetString() == "stats");
+    REQUIRE(stats["_analysis"]["status"].GetString() == "partial");
     REQUIRE_THROWS(empty_index->UpdateId(0, 1));
     REQUIRE_THROWS(empty_index->UpdateVector(0, nullptr));
     REQUIRE_THROWS(empty_index->UpdateExtraInfo(nullptr));

--- a/src/algorithm/ivf/ivf.cpp
+++ b/src/algorithm/ivf/ivf.cpp
@@ -27,6 +27,7 @@
 #include <unordered_map>
 
 #include "algorithm/inner_index_interface.h"
+#include "analyzer/analyzer.h"
 #include "datacell/bucket_datacell_parameter.h"
 #include "datacell/flatten_datacell_parameter.h"
 #include "datacell/flatten_interface.h"
@@ -595,21 +596,56 @@ IVF::GetStats() const {
         bucket_radius.push_back(max_distance);
     }
     // bucket_count_std
-    stats["bucket_num"].SetJson(get_data_stats(bucket_counts));
+    if (not bucket_counts.empty()) {
+        stats["bucket_num"].SetJson(get_data_stats(bucket_counts));
+    } else {
+        stats["_analysis"]["skipped"]["bucket_num"].SetString("index has no buckets");
+    }
     // bucket_radius
-    stats["bucket_radius"].SetJson(get_data_stats(bucket_radius));
+    if (not bucket_radius.empty()) {
+        stats["bucket_radius"].SetJson(get_data_stats(bucket_radius));
+    } else {
+        stats["_analysis"]["skipped"]["bucket_radius"].SetString("index has no non-empty buckets");
+    }
+    AddAnalysisMetadata(stats, GetName(), "stats", bucket_radius.empty() ? "partial" : "complete");
     return stats.Dump(4);
 }
 
 std::string
 IVF::AnalyzeIndexBySearch(const SearchRequest& request) {
+    CHECK_ARGUMENT(request.query_ != nullptr, "analysis query cannot be null");
+    CHECK_ARGUMENT(request.topk_ > 0, "analysis topk must be greater than 0");
     JsonType stats;
     auto querys = request.query_;
+    CHECK_ARGUMENT(querys->GetNumElements() > 0, "analysis query must contain at least one vector");
+    CHECK_ARGUMENT(querys->GetFloat32Vectors() != nullptr,
+                   "IVF analysis requires float32 query vectors");
+    CHECK_ARGUMENT(querys->GetDim() == dim_, "analysis query dimension mismatch");
     auto topk = std::min(request.topk_, GetNumElements());
     auto num_elements = querys->GetNumElements();
     auto param_str = request.params_str_;
+    if (param_str.empty() || param_str == "default") {
+        JsonType default_param;
+        default_param[GetName()][IVF_SEARCH_PARAM_SCAN_BUCKETS_COUNT].SetInt(
+            IVFSearchParameters::DEFAULT_SCAN_BUCKETS_COUNT);
+        param_str = default_param.Dump();
+    }
     // quantization error
+    if (GetNumElements() == 0) {
+        stats["quantization_bias_ratio"]["skipped_reason"].SetString("index is empty");
+        stats["quantization_inversion_count_rate"]["skipped_reason"].SetString("index is empty");
+        AddAnalysisMetadata(
+            stats, GetName(), "search", "not_applicable", num_elements, request.topk_);
+        return stats.Dump(4);
+    }
     this->analyze_quantizer(stats, querys->GetFloat32Vectors(), num_elements, topk, param_str);
+    const auto* const status = use_reorder_ ? "complete" : "partial";
+    if (not use_reorder_) {
+        stats["quantization_bias_ratio"]["skipped_reason"].SetString("reorder is disabled");
+        stats["quantization_inversion_count_rate"]["skipped_reason"].SetString(
+            "reorder is disabled");
+    }
+    AddAnalysisMetadata(stats, GetName(), "search", status, num_elements, request.topk_);
     return stats.Dump(4);
 }
 

--- a/src/algorithm/ivf/ivf_parameter.h
+++ b/src/algorithm/ivf/ivf_parameter.h
@@ -58,7 +58,9 @@ public:
     FromJson(const std::string& json_string);
 
 public:
-    int64_t scan_buckets_count{30};
+    static constexpr int64_t DEFAULT_SCAN_BUCKETS_COUNT = 30;
+
+    int64_t scan_buckets_count{DEFAULT_SCAN_BUCKETS_COUNT};
     bool disable_bucket_scan{false};
     float first_order_scan_ratio{1.0F};
     int64_t ef_search{100};

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <vector>
 
+#include "analyzer/analyzer.h"
 #include "dataset_impl.h"
 #include "index_common_param.h"
 #include "index_feature_list.h"
@@ -29,6 +30,15 @@
 #include "vsag/constants.h"
 
 namespace vsag {
+
+namespace {
+
+const char*
+phase_to_string(LazyHGraph::Phase phase) {
+    return phase == LazyHGraph::Phase::FLAT ? "flat" : "graph";
+}
+
+}  // namespace
 
 namespace {
 
@@ -349,6 +359,29 @@ uint64_t
 LazyHGraph::GetMemoryUsage() const {
     std::shared_lock lock(this->phase_mutex_);
     return ActiveIndex()->GetMemoryUsage();
+}
+
+std::string
+LazyHGraph::GetStats() const {
+    std::shared_lock lock(phase_mutex_);
+    auto stats = JsonType::Parse(ActiveIndex()->GetStats());
+    const auto status = stats["_analysis"]["status"].GetString();
+    AddAnalysisMetadata(stats, GetName(), "stats", status);
+    stats["_analysis"]["phase"].SetString(phase_to_string(GetPhase()));
+    stats["_analysis"]["transition_threshold"].SetUint64(transition_threshold_);
+    return stats.Dump(4);
+}
+
+std::string
+LazyHGraph::AnalyzeIndexBySearch(const SearchRequest& request) {
+    std::shared_lock lock(phase_mutex_);
+    auto stats = JsonType::Parse(ActiveIndex()->AnalyzeIndexBySearch(request));
+    const auto status = stats["_analysis"]["status"].GetString();
+    AddAnalysisMetadata(
+        stats, GetName(), "search", status, request.query_->GetNumElements(), request.topk_);
+    stats["_analysis"]["phase"].SetString(phase_to_string(GetPhase()));
+    stats["_analysis"]["transition_threshold"].SetUint64(transition_threshold_);
+    return stats.Dump(4);
 }
 
 DatasetPtr

--- a/src/algorithm/lazy_hgraph/lazy_hgraph.h
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph.h
@@ -129,6 +129,12 @@ public:
     [[nodiscard]] uint64_t
     GetMemoryUsage() const override;
 
+    [[nodiscard]] std::string
+    GetStats() const override;
+
+    std::string
+    AnalyzeIndexBySearch(const SearchRequest& request) override;
+
     void
     GetVectorByInnerId(InnerIdType inner_id, float* data) const override;
 

--- a/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
+++ b/src/algorithm/lazy_hgraph/lazy_hgraph_test.cpp
@@ -420,6 +420,22 @@ TEST_CASE("LazyHGraph threshold one transitions immediately", "[ut][lazy_hgraph]
     REQUIRE(index->GetPhase() == vsag::LazyHGraph::Phase::GRAPH);
 }
 
+TEST_CASE("LazyHGraph analysis identifies the active phase", "[ut][lazy_hgraph][analysis]") {
+    auto index = MakeLazyIndex(1);
+    auto stats = vsag::JsonType::Parse(index->GetStats());
+    REQUIRE(stats["_analysis"]["index_type"].GetString() == "lazy_hgraph");
+    REQUIRE(stats["_analysis"]["phase"].GetString() == "flat");
+    REQUIRE(stats["_analysis"]["status"].GetString() == "complete");
+
+    std::vector<float> vectors;
+    std::vector<int64_t> ids;
+    REQUIRE(index->Add(MakeDataset(1, 650, vectors, ids)).empty());
+    stats = vsag::JsonType::Parse(index->GetStats());
+    REQUIRE(stats["_analysis"]["index_type"].GetString() == "lazy_hgraph");
+    REQUIRE(stats["_analysis"]["phase"].GetString() == "graph");
+    REQUIRE(stats["_analysis"]["status"].GetString() == "partial");
+}
+
 TEST_CASE("LazyHGraph factory and flat serialization round trip", "[ut][lazy_hgraph]") {
     auto index = vsag::Factory::CreateIndex("lazy_hgraph", MakeFactoryParam(10));
     REQUIRE(index.has_value());

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -24,6 +24,7 @@
 
 #include "algorithm/inner_index_interface.h"
 #include "analyzer/analyzer.h"
+#include "analyzer/pyramid_analyzer.h"
 #include "datacell/compressed_graph_datacell_parameter.h"
 #include "datacell/flatten_datacell_parameter.h"
 #include "datacell/flatten_interface.h"
@@ -2493,11 +2494,20 @@ Pyramid::GetVectorByInnerId(InnerIdType inner_id, float* data) const {
 
 std::string
 Pyramid::GetStats() const {
+    if (GetNumElements() == 0) {
+        JsonType stats;
+        stats["total_count"].SetInt64(0);
+        stats["live_count"].SetInt64(0);
+        stats["deleted_count"].SetInt64(GetNumberRemoved());
+        stats["_analysis"]["skipped"]["structure"].SetString("index is empty");
+        AddAnalysisMetadata(stats, GetName(), "stats", "partial");
+        return stats.Dump(4);
+    }
     AnalyzerParam analyzer_param(allocator_);
     analyzer_param.topk = 10;
     analyzer_param.base_sample_size = std::min<uint64_t>(10, this->GetNumElements());
     analyzer_param.search_params = R"({"pyramid": {"ef_search": 500}})";
-    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    auto analyzer = CreateAnalyzer(analyzer_param);
     JsonType stats = analyzer->GetStats();
     if (build_cache_hit_rate_ >= 0.0F) {
         stats["build_cache_hit_rate"].SetFloat(build_cache_hit_rate_);
@@ -2514,7 +2524,13 @@ Pyramid::GetStats() const {
         total_route_graph_size += root_stats["route_graph_size"].GetUint64();
     }
     stats["total_route_graph_size"].SetUint64(total_route_graph_size);
+    AddAnalysisMetadata(stats, GetName(), "stats", "complete");
     return stats.Dump(4);
+}
+
+AnalyzerBasePtr
+Pyramid::CreateAnalyzer(const AnalyzerParam& param) const {
+    return std::make_shared<PyramidAnalyzer>(this, param);
 }
 void
 Pyramid::collect_graph_nodes(IndexNode* node,
@@ -2863,12 +2879,25 @@ Pyramid::AnalyzeIndexBySearch(const SearchRequest& request) {
                    fmt::format("topk({}) must be greater than 0", request.topk_));
     CHECK_ARGUMENT(request.topk_ <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
                    fmt::format("topk({}) exceeds the supported maximum", request.topk_));
-    CHECK_ARGUMENT(base_codes_->TotalCount() > 0,
-                   "Pyramid AnalyzeIndexBySearch requires a built index");
+    CHECK_ARGUMENT(request.query_ != nullptr, "analysis query cannot be null");
+    if (base_codes_->TotalCount() == 0) {
+        JsonType stats;
+        stats["_analysis"]["skipped"]["search"].SetString("index is empty");
+        AddAnalysisMetadata(stats,
+                            GetName(),
+                            "search",
+                            "not_applicable",
+                            request.query_->GetNumElements(),
+                            request.topk_);
+        return stats.Dump(4);
+    }
     AnalyzerParam analyzer_param(allocator_);
     analyzer_param.topk = request.topk_;
-    auto analyzer = CreateAnalyzer(this, analyzer_param);
-    return analyzer->AnalyzeIndexBySearch(request).Dump(4);
+    auto analyzer = CreateAnalyzer(analyzer_param);
+    auto stats = analyzer->AnalyzeIndexBySearch(request);
+    AddAnalysisMetadata(
+        stats, GetName(), "search", "complete", request.query_->GetNumElements(), request.topk_);
+    return stats.Dump(4);
 }
 
 }  // namespace vsag

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -203,6 +203,9 @@ public:
     std::string
     GetStats() const override;
 
+    [[nodiscard]] AnalyzerBasePtr
+    CreateAnalyzer(const AnalyzerParam& param) const override;
+
     std::string
     AnalyzeIndexBySearch(const SearchRequest& request) override;
 

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "analyzer/analyzer.h"
+#include "analyzer/sindi_analyzer.h"
 #include "datacell/sparse_dmq_datacell.h"
 #include "datacell/sparse_vector_datacell_parameter.h"
 #include "impl/heap/standard_heap.h"
@@ -321,27 +322,64 @@ SINDI::GetMemoryUsageDetail() const {
 
 std::string
 SINDI::GetStats() const {
+    if (GetNumElements() == 0) {
+        JsonType stats;
+        stats["total_count"].SetInt64(0);
+        stats["live_count"].SetInt64(0);
+        stats["deleted_count"].SetInt64(GetNumberRemoved());
+        stats["_analysis"]["skipped"]["structure"].SetString("index is empty");
+        AddAnalysisMetadata(stats, GetName(), "stats", "partial");
+        return stats.Dump(4);
+    }
     AnalyzerParam analyzer_param(allocator_);
     analyzer_param.topk = K_ANALYZE_DEFAULT_TOPK;
     analyzer_param.base_sample_size =
         std::min<uint64_t>(K_ANALYZE_BASE_SAMPLE_SIZE, cur_element_count_);
     analyzer_param.search_params =
         R"({"sindi": {"query_prune_ratio": 0, "term_prune_ratio": 0, "n_candidate": 500}})";
-    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    auto analyzer = CreateAnalyzer(analyzer_param);
     JsonType stats = analyzer->GetStats();
+    AddAnalysisMetadata(stats, GetName(), "stats", "complete");
     return stats.Dump(4);
+}
+
+AnalyzerBasePtr
+SINDI::CreateAnalyzer(const AnalyzerParam& param) const {
+    return std::make_shared<SINDIAnalyzer>(this, param);
 }
 
 std::string
 SINDI::AnalyzeIndexBySearch(const SearchRequest& request) {
+    // Preserve the legacy null-query fallback to stats analysis for SINDI callers.
+    // Query-driven analysis still validates top-k and handles empty indexes explicitly.
+    if (request.query_ != nullptr) {
+        CHECK_ARGUMENT(request.topk_ > 0, "analysis topk must be greater than 0");
+        if (GetNumElements() == 0) {
+            JsonType stats;
+            stats["_analysis"]["skipped"]["search"].SetString("index is empty");
+            AddAnalysisMetadata(stats,
+                                GetName(),
+                                "search",
+                                "not_applicable",
+                                request.query_->GetNumElements(),
+                                request.topk_);
+            return stats.Dump(4);
+        }
+    }
     AnalyzerParam analyzer_param(allocator_);
-    analyzer_param.topk = request.topk_;
+    analyzer_param.topk = request.query_ == nullptr ? K_ANALYZE_DEFAULT_TOPK : request.topk_;
     analyzer_param.base_sample_size =
         std::min<uint64_t>(K_ANALYZE_BASE_SAMPLE_SIZE, cur_element_count_);
     analyzer_param.search_params = request.params_str_;
-    auto analyzer = CreateAnalyzer(this, analyzer_param);
+    auto analyzer = CreateAnalyzer(analyzer_param);
     JsonType stats =
         request.query_ == nullptr ? analyzer->GetStats() : analyzer->AnalyzeIndexBySearch(request);
+    AddAnalysisMetadata(stats,
+                        GetName(),
+                        request.query_ == nullptr ? "stats" : "search",
+                        "complete",
+                        request.query_ == nullptr ? 0 : request.query_->GetNumElements(),
+                        request.topk_);
     return stats.Dump(4);
 }
 

--- a/src/algorithm/sindi/sindi.h
+++ b/src/algorithm/sindi/sindi.h
@@ -77,6 +77,9 @@ public:
     std::string
     GetStats() const override;
 
+    [[nodiscard]] AnalyzerBasePtr
+    CreateAnalyzer(const AnalyzerParam& param) const override;
+
     std::string
     AnalyzeIndexBySearch(const SearchRequest& request) override;
 

--- a/src/algorithm/sindi_v2/sindi_v2.cpp
+++ b/src/algorithm/sindi_v2/sindi_v2.cpp
@@ -26,6 +26,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "analyzer/analyzer.h"
 #include "datacell/sparse_dmq_datacell.h"
 #include "datacell/sparse_vector_datacell_parameter.h"
 #include "impl/filter/inner_id_wrapper_filter.h"
@@ -379,7 +380,19 @@ SINDIV2::GetMemoryUsageDetail() const {
 
 std::string
 SINDIV2::GetStats() const {
-    return "";
+    JsonType stats;
+    stats["total_count"].SetInt64(GetNumElements());
+    stats["window_size"].SetUint64(window_size_);
+    stats["term_id_limit"].SetUint64(term_id_limit_);
+    stats["doc_prune_ratio"].SetFloat(doc_prune_ratio_);
+    stats["use_reorder"].SetBool(use_reorder_);
+    stats["immutable"].SetBool(immutable_enabled_);
+    const bool is_empty = GetNumElements() == 0;
+    if (is_empty) {
+        stats["_analysis"]["skipped"]["structure"].SetString("index is empty");
+    }
+    AddAnalysisMetadata(stats, GetName(), "stats", is_empty ? "partial" : "complete");
+    return stats.Dump(4);
 }
 
 SparseVector

--- a/src/analyzer/analyzer.cpp
+++ b/src/analyzer/analyzer.cpp
@@ -15,34 +15,97 @@
 
 #include "analyzer.h"
 
-#include "hgraph_analyzer.h"
-#include "pyramid_analyzer.h"
-#include "sindi_analyzer.h"
+#include <chrono>
+#include <nlohmann/json.hpp>
 
 namespace vsag {
 
-AnalyzerBasePtr
-CreateAnalyzer(const InnerIndexInterface* index, const AnalyzerParam& param) {
-    if (index == nullptr) {
-        throw VsagException(ErrorType::INVALID_ARGUMENT,
-                            "Index pointer is null when creating analyzer");
+void
+AddAnalysisMetadata(JsonType& stats,
+                    const std::string& index_type,
+                    const std::string& analysis_type,
+                    const std::string& status,
+                    uint64_t sample_count,
+                    int64_t topk) {
+    auto metadata = stats["_analysis"];
+    for (const auto& [name, value] : stats.GetInnerJson()->items()) {
+        if (name != "_analysis" && value.is_object() && value.contains("skipped_reason") &&
+            value["skipped_reason"].is_string()) {
+            metadata["skipped"][name].SetString(value["skipped_reason"].get<std::string>());
+        }
     }
-    auto* index_no_const = const_cast<InnerIndexInterface*>(index);
-    if (dynamic_cast<HGraph*>(index_no_const) != nullptr) {
-        auto* hgraph = dynamic_cast<HGraph*>(index_no_const);
-        return std::make_shared<HGraphAnalyzer>(hgraph, param);
+    const bool has_skipped = metadata.GetInnerJson()->is_object() && metadata.Contains("skipped") &&
+                             not metadata["skipped"].GetInnerJson()->empty();
+    const auto effective_status = status == "complete" && has_skipped ? "partial" : status;
+    metadata["schema_version"].SetInt(1);
+    metadata["index_type"].SetString(index_type);
+    metadata["analysis_type"].SetString(analysis_type);
+    metadata["status"].SetString(effective_status);
+    metadata["consistency"].SetString("weak_snapshot");
+    if (sample_count > 0) {
+        metadata["sample_count"].SetUint64(sample_count);
     }
-    if (dynamic_cast<Pyramid*>(index_no_const) != nullptr) {
-        auto* pyramid = dynamic_cast<Pyramid*>(index_no_const);
-        return std::make_shared<PyramidAnalyzer>(pyramid, param);
+    if (topk > 0) {
+        metadata["topk"].SetInt64(topk);
     }
-    if (dynamic_cast<SINDI*>(index_no_const) != nullptr) {
-        auto* sindi = dynamic_cast<SINDI*>(index_no_const);
-        return std::make_shared<SINDIAnalyzer>(sindi, param);
+}
+
+BasicIndexAnalyzer::BasicIndexAnalyzer(const InnerIndexInterface* index, const AnalyzerParam& param)
+    : AnalyzerBase(param.allocator, 0), index_(index) {
+}
+
+JsonType
+BasicIndexAnalyzer::GetStats() {
+    JsonType stats;
+    std::string status = "complete";
+    const auto live_count = index_->GetNumElements();
+    stats["total_count"].SetInt64(live_count);
+    stats["live_count"].SetInt64(live_count);
+    try {
+        const auto deleted_count = index_->GetNumberRemoved();
+        stats["deleted_count"].SetInt64(deleted_count);
+        stats["total_count"].SetInt64(live_count + deleted_count);
+    } catch (const VsagException&) {
+        status = "partial";
+        stats["_analysis"]["skipped"]["deleted_count"].SetString(
+            "index does not expose deleted count");
     }
-    throw VsagException(
-        ErrorType::UNSUPPORTED_INDEX_OPERATION,
-        fmt::format("Unsupported index type ({}) for analyzer creation", index->GetName()));
+    AddAnalysisMetadata(stats, index_->GetName(), "stats", status);
+    return stats;
+}
+
+JsonType
+BasicIndexAnalyzer::AnalyzeIndexBySearch(const SearchRequest& request) {
+    CHECK_ARGUMENT(request.query_ != nullptr, "analysis query cannot be null");
+    CHECK_ARGUMENT(request.topk_ > 0, "analysis topk must be greater than 0");
+    const auto query_count = request.query_->GetNumElements();
+    CHECK_ARGUMENT(query_count > 0, "analysis query must contain at least one vector");
+    JsonType stats;
+    if (index_->GetNumElements() == 0) {
+        stats["_analysis"]["skipped"]["search"].SetString("index is empty");
+        AddAnalysisMetadata(
+            stats, index_->GetName(), "search", "not_applicable", query_count, request.topk_);
+        return stats;
+    }
+    const auto begin = std::chrono::steady_clock::now();
+    DatasetPtr result;
+    try {
+        result = index_->SearchWithRequest(request);
+    } catch (const VsagException& exception) {
+        if (exception.error_.type != ErrorType::UNSUPPORTED_INDEX_OPERATION) {
+            throw;
+        }
+        result =
+            index_->KnnSearch(request.query_, request.topk_, request.params_str_, request.filter_);
+    }
+    const auto elapsed =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - begin).count();
+    stats["time_cost_query"].SetFloat(
+        static_cast<float>(elapsed / static_cast<double>(query_count)));
+    stats["result_count"].SetInt64(result == nullptr ? 0 : result->GetDim());
+    stats["_analysis"]["skipped"]["recall_query"].SetString("ground truth was not requested");
+    AddAnalysisMetadata(stats, index_->GetName(), "search", "partial", query_count, request.topk_);
+    return stats;
 }
 
 }  // namespace vsag

--- a/src/analyzer/analyzer.h
+++ b/src/analyzer/analyzer.h
@@ -17,7 +17,6 @@
 
 #include <memory>
 
-#include "algorithm/hgraph/hgraph.h"
 #include "algorithm/inner_index_interface.h"
 #include "utils/pointer_define.h"
 #include "vsag/allocator.h"
@@ -57,7 +56,26 @@ public:
     std::string search_params;
 };
 
-AnalyzerBasePtr
-CreateAnalyzer(const InnerIndexInterface* index, const AnalyzerParam& param);
+void
+AddAnalysisMetadata(JsonType& stats,
+                    const std::string& index_type,
+                    const std::string& analysis_type,
+                    const std::string& status,
+                    uint64_t sample_count = 0,
+                    int64_t topk = 0);
+
+class BasicIndexAnalyzer : public AnalyzerBase {
+public:
+    BasicIndexAnalyzer(const InnerIndexInterface* index, const AnalyzerParam& param);
+
+    JsonType
+    GetStats() override;
+
+    JsonType
+    AnalyzeIndexBySearch(const SearchRequest& request) override;
+
+private:
+    const InnerIndexInterface* index_;
+};
 
 }  // namespace vsag

--- a/src/analyzer/hgraph_analyzer.h
+++ b/src/analyzer/hgraph_analyzer.h
@@ -22,7 +22,7 @@ namespace vsag {
 
 class HGraphAnalyzer : public AnalyzerBase {
 public:
-    HGraphAnalyzer(HGraph* hgraph, const AnalyzerParam& param)
+    HGraphAnalyzer(const HGraph* hgraph, const AnalyzerParam& param)
         : hgraph_(hgraph),
           base_ground_truth_(hgraph->allocator_),
           base_sample_ids_(hgraph->allocator_),
@@ -151,7 +151,7 @@ private:
                       const UnorderedMap<InnerIdType, Vector<LabelType>>& search_result);
 
 private:
-    HGraph* hgraph_;
+    const HGraph* hgraph_;
 
     uint32_t base_sample_size_{10};
     Vector<InnerIdType> base_sample_ids_;

--- a/src/analyzer/pyramid_analyzer.h
+++ b/src/analyzer/pyramid_analyzer.h
@@ -21,7 +21,7 @@ namespace vsag {
 
 class PyramidAnalyzer : public AnalyzerBase {
 public:
-    PyramidAnalyzer(Pyramid* pyramid, const AnalyzerParam& param)
+    PyramidAnalyzer(const Pyramid* pyramid, const AnalyzerParam& param)
         : pyramid_(pyramid),
           sample_ids_(pyramid->allocator_),
           sample_datas_(pyramid->allocator_),
@@ -217,7 +217,7 @@ private:
                                 const Vector<InnerIdType>& node_ids,
                                 uint32_t& duplicate_group_size);
 
-    Pyramid* pyramid_;
+    const Pyramid* pyramid_;
 
     Vector<InnerIdType> sample_ids_;
     Vector<float> sample_datas_;

--- a/src/analyzer/sindi_analyzer.h
+++ b/src/analyzer/sindi_analyzer.h
@@ -23,7 +23,7 @@ namespace vsag {
 
 class SINDIAnalyzer : public AnalyzerBase {
 public:
-    SINDIAnalyzer(SINDI* sindi, const AnalyzerParam& param)
+    SINDIAnalyzer(const SINDI* sindi, const AnalyzerParam& param)
         : AnalyzerBase(sindi->allocator_, static_cast<uint32_t>(sindi->GetNumElements())),
           sindi_(sindi),
           topk_(param.topk),
@@ -110,7 +110,7 @@ private:
                           const DatasetPtr& base_dataset = nullptr) const;
 
 private:
-    SINDI* sindi_{nullptr};
+    const SINDI* sindi_{nullptr};
     int64_t topk_{10};
     uint64_t base_sample_size_{10};
     std::string search_params_;

--- a/src/factory/factory_test.cpp
+++ b/src/factory/factory_test.cpp
@@ -55,6 +55,41 @@ TEST_CASE("Factory creates SINDI V2", "[ut][factory]") {
     auto index = vsag::Factory::CreateIndex("sindi_v2", parameters.Dump());
     REQUIRE(index.has_value());
     REQUIRE(index.value()->GetIndexType() == vsag::IndexType::SINDI_V2);
+    REQUIRE(index.value()->CheckFeature(vsag::IndexFeature::SUPPORT_GET_STATS));
+    REQUIRE(index.value()->CheckFeature(vsag::IndexFeature::SUPPORT_ANALYZE_INDEX_BY_SEARCH));
+    const auto stats = vsag::JsonType::Parse(index.value()->GetStats());
+    REQUIRE(stats["_analysis"]["schema_version"].GetInt() == 1);
+    REQUIRE(stats["_analysis"]["index_type"].GetString() == "sindi_v2");
+    REQUIRE(stats["_analysis"]["analysis_type"].GetString() == "stats");
+    REQUIRE(stats["_analysis"]["status"].GetString() == "partial");
+    REQUIRE(stats["_analysis"]["skipped"]["structure"].GetString() == "index is empty");
+    REQUIRE_FALSE(index.value()->GetStats().empty());
+}
+
+TEST_CASE("Factory indexes expose baseline analysis metadata", "[ut][factory]") {
+    auto index = vsag::Factory::CreateIndex("brute_force",
+                                            R"({"dtype":"float32","metric_type":"l2","dim":4})");
+    REQUIRE(index.has_value());
+    REQUIRE(index.value()->CheckFeature(vsag::IndexFeature::SUPPORT_GET_STATS));
+    REQUIRE(index.value()->CheckFeature(vsag::IndexFeature::SUPPORT_ANALYZE_INDEX_BY_SEARCH));
+
+    const auto stats = vsag::JsonType::Parse(index.value()->GetStats());
+    REQUIRE(stats["_analysis"]["index_type"].GetString() == "brute_force");
+    REQUIRE(stats["_analysis"]["status"].GetString() == "complete");
+    REQUIRE(stats["live_count"].GetInt() == 0);
+
+    float query_data[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+    auto query =
+        vsag::Dataset::Make()->NumElements(1)->Dim(4)->Float32Vectors(query_data)->Owner(false);
+    vsag::SearchRequest request;
+    request.query_ = query;
+    request.topk_ = 1;
+    query->NumElements(0);
+    REQUIRE_THROWS(index.value()->AnalyzeIndexBySearch(request));
+    query->NumElements(1);
+    const auto analysis = vsag::JsonType::Parse(index.value()->AnalyzeIndexBySearch(request));
+    REQUIRE(analysis["_analysis"]["analysis_type"].GetString() == "search");
+    REQUIRE(analysis["_analysis"]["status"].GetString() == "not_applicable");
 }
 
 TEST_CASE("Create Local File Reader", "[ut][factory]") {

--- a/src/index/index_impl.h
+++ b/src/index/index_impl.h
@@ -88,6 +88,10 @@ public:
 
     std::string
     AnalyzeIndexBySearch(const SearchRequest& request) override {
+        if (not CheckFeature(IndexFeature::SUPPORT_ANALYZE_INDEX_BY_SEARCH)) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "index does not support search analysis");
+        }
         return this->inner_index_->AnalyzeIndexBySearch(request);
     }
 
@@ -302,6 +306,10 @@ public:
 
     [[nodiscard]] std::string
     GetStats() const override {
+        if (not CheckFeature(IndexFeature::SUPPORT_GET_STATS)) {
+            throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                                "index does not support static analysis");
+        }
         return this->inner_index_->GetStats();
     }
 

--- a/tests/test_ivf.cpp
+++ b/tests/test_ivf.cpp
@@ -408,6 +408,11 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::IVFTestIndex, "IVF GetStatus", "[ft][ivf]
                 auto raw_num = dataset->query_->GetNumElements();
                 dataset->query_->NumElements(10);
                 INFO(index->AnalyzeIndexBySearch(request));
+                request.params_str_ = "default";
+                const auto default_analysis =
+                    vsag::JsonType::Parse(index->AnalyzeIndexBySearch(request));
+                REQUIRE(default_analysis["_analysis"]["analysis_type"].GetString() == "search");
+                REQUIRE(default_analysis["_analysis"]["sample_count"].GetInt() == 10);
                 dataset->query_->NumElements(raw_num);
             }
         }

--- a/tests/test_warp.cpp
+++ b/tests/test_warp.cpp
@@ -98,6 +98,17 @@ WarpTestIndex::GenerateWarpSearchParametersString() {
 
 }  // namespace fixtures
 
+TEST_CASE("WARP analysis preserves its public index type", "[ft][warp][analysis]") {
+    WarpParam warp_param;
+    auto index = Factory::CreateIndex(
+        INDEX_WARP,
+        fixtures::WarpTestIndex::GenerateWarpBuildParametersString("ip", 8, warp_param));
+    REQUIRE(index.has_value());
+    const auto stats = JsonType::Parse(index.value()->GetStats());
+    REQUIRE(stats["_analysis"]["index_type"].GetString() == INDEX_WARP);
+    REQUIRE(stats["_analysis"]["analysis_type"].GetString() == "stats");
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::WarpTestIndex, "Warp Add Test", "[ft][warp]") {
     auto metric_type = GENERATE("ip");
     std::string base_quantization_str = GENERATE("fp32");

--- a/tools/analyze_index/analyze_index.cpp
+++ b/tools/analyze_index/analyze_index.cpp
@@ -21,14 +21,9 @@
 #include <iostream>
 #include <memory>
 
-#include "algorithm/hgraph/hgraph.h"
-#include "algorithm/ivf/ivf.h"
-#include "algorithm/pyramid/pyramid.h"
-#include "algorithm/pyramid/pyramid_zparameters.h"
-#include "algorithm/sindi/sindi.h"
-#include "algorithm/sindi/sindi_parameter.h"
-#include "index/index_impl.h"
+#include "data_type.h"
 #include "inner_string_params.h"
+#include "metric_type.h"
 #include "storage/serialization.h"
 #include "storage/stream_reader.h"
 
@@ -56,12 +51,20 @@ is_sindi_inner_param(const JsonType& params) {
            params.Contains(USE_QUANTIZATION) || params.Contains(SPARSE_REMAP_TERM_IDS);
 }
 
+bool
+is_sindi_v2_inner_param(const JsonType& params) {
+    return params.Contains("term_io") || params.Contains("rerank_layout");
+}
+
 std::string
 infer_index_name_from_build_param(const JsonType& params) {
     if (params.Contains(TYPE_KEY)) {
         return params[TYPE_KEY].GetString();
     }
     if (is_sparse_build_param(params)) {
+        if (params.Contains(INDEX_PARAM) && is_sindi_v2_inner_param(params[INDEX_PARAM])) {
+            return INDEX_SINDI_V2;
+        }
         return INDEX_SINDI;
     }
     if (params.Contains(INDEX_PARAM)) {
@@ -72,6 +75,9 @@ infer_index_name_from_build_param(const JsonType& params) {
         if (index_param.Contains("base_quantization_type") ||
             index_param.Contains("index_min_size")) {
             return INDEX_PYRAMID;
+        }
+        if (is_sindi_v2_inner_param(index_param)) {
+            return INDEX_SINDI_V2;
         }
         if (is_sindi_inner_param(index_param)) {
             return INDEX_SINDI;
@@ -98,11 +104,13 @@ std::string
 DataTypesToString(DataTypes type) {
     switch (type) {
         case DataTypes::DATA_TYPE_FLOAT:
-            return "float";
+            return "float32";
         case DataTypes::DATA_TYPE_INT8:
             return "int8";
         case DataTypes::DATA_TYPE_FP16:
-            return "fp16";
+            return "float16";
+        case DataTypes::DATA_TYPE_BF16:
+            return "bfloat16";
         case DataTypes::DATA_TYPE_SPARSE:
             return "sparse";
         default:
@@ -283,12 +291,21 @@ public:
         }
         if (build_param_ != DEFAULT_BUILD_PARAM) {
             std::fstream new_stream(index_path_, std::ios::binary | std::ios::in);
+            if (not new_stream.is_open()) {
+                logger::error("Failed to reopen index file: {}", index_path_);
+                return false;
+            }
             if (not create_index_with_param(index_name_, new_stream)) {
                 return false;
             }
             return true;
         }
-        return create_index_without_param(index_name_, reader);
+        std::fstream new_stream(index_path_, std::ios::binary | std::ios::in);
+        if (not new_stream.is_open()) {
+            logger::error("Failed to reopen index file: {}", index_path_);
+            return false;
+        }
+        return create_index_without_param(new_stream);
     }
 
     void
@@ -304,6 +321,10 @@ public:
         }
         if (not query_dataset) {
             logger::error("Query dataset is null");
+            return;
+        }
+        if (not index_->CheckFeature(IndexFeature::SUPPORT_ANALYZE_INDEX_BY_SEARCH)) {
+            logger::error("Index {} does not support search analysis", index_name_);
             return;
         }
         SearchRequest query_request;
@@ -332,6 +353,10 @@ public:
 
     void
     ShowIndexProperty(const std::string& search_param, const std::string& base_path) const {
+        if (not index_->CheckFeature(IndexFeature::SUPPORT_GET_STATS)) {
+            logger::error("Index {} does not support static analysis", index_name_);
+            return;
+        }
         if (base_path.empty() || index_name_ != INDEX_SINDI) {
             logger::info("index inner property: {}", index_->GetStats());
             return;
@@ -394,6 +419,9 @@ private:
         std::string inner_param = basic_info[INDEX_PARAM].GetString();
         index_param_ = JsonType::Parse(inner_param);
         index_name_ = infer_index_name_from_build_param(index_param_);
+        if (basic_info.Contains("is_multi_vector") && basic_info["is_multi_vector"].GetBool()) {
+            index_name_ = INDEX_WARP;
+        }
         if (index_name_.empty()) {
             index_name_ = infer_index_name_from_build_param(basic_info);
         }
@@ -408,14 +436,16 @@ private:
         if (basic_info.Contains("data_type")) {
             data_type_ = static_cast<DataTypes>(basic_info["data_type"].GetInt());
         } else {
-            data_type_ = index_name_ == INDEX_SINDI ? DataTypes::DATA_TYPE_SPARSE
-                                                    : DataTypes::DATA_TYPE_FLOAT;
+            data_type_ = index_name_ == INDEX_SINDI || index_name_ == INDEX_SINDI_V2
+                             ? DataTypes::DATA_TYPE_SPARSE
+                             : DataTypes::DATA_TYPE_FLOAT;
         }
         if (basic_info.Contains("metric")) {
             metric_type_ = static_cast<MetricType>(basic_info["metric"].GetInt());
         } else {
-            metric_type_ = index_name_ == INDEX_SINDI ? MetricType::METRIC_TYPE_IP
-                                                      : MetricType::METRIC_TYPE_L2SQR;
+            metric_type_ = index_name_ == INDEX_SINDI || index_name_ == INDEX_SINDI_V2
+                               ? MetricType::METRIC_TYPE_IP
+                               : MetricType::METRIC_TYPE_L2SQR;
         }
         if (not basic_info.Contains(DIM) || not basic_info.Contains("extra_info_size") ||
             not basic_info.Contains("data_type") || not basic_info.Contains("metric")) {
@@ -449,48 +479,33 @@ private:
     }
 
     bool
-    create_index_without_param(const std::string& index_name, StreamReader& reader) {
-        // create index common parameters
-        IndexCommonParam index_common_params;
-        index_common_params.dim_ = dim_;
-        index_common_params.metric_ = metric_type_;
-        index_common_params.allocator_ = Engine::CreateDefaultAllocator();
-        index_common_params.data_type_ = data_type_;
-        index_common_params.extra_info_size_ = extra_info_size_;
-        // create index and deserialize
-        if (index_name_ == INDEX_HGRAPH) {
-            auto hgraph_parameter = std::make_shared<HGraphParameter>();
-            hgraph_parameter->FromJson(index_param_);
-            hgraph_parameter->data_type = data_type_;
-            auto inner_index = std::make_shared<HGraph>(hgraph_parameter, index_common_params);
-            inner_index->Deserialize(reader);
-            index_ = std::make_shared<IndexImpl<HGraph>>(inner_index, index_common_params);
-            return true;
-        } else if (index_name_ == INDEX_IVF) {
-            auto ivf_parameter = std::make_shared<IVFParameter>();
-            ivf_parameter->FromJson(index_param_);
-            auto inner_index = std::make_shared<IVF>(ivf_parameter, index_common_params);
-            inner_index->Deserialize(reader);
-            index_ = std::make_shared<IndexImpl<IVF>>(inner_index, index_common_params);
-            return true;
-        } else if (index_name_ == INDEX_PYRAMID) {
-            auto pyramid_parameter = std::make_shared<PyramidParameters>();
-            pyramid_parameter->FromJson(index_param_);
-            auto inner_index = std::make_shared<Pyramid>(pyramid_parameter, index_common_params);
-            inner_index->Deserialize(reader);
-            index_ = std::make_shared<IndexImpl<Pyramid>>(inner_index, index_common_params);
-            return true;
-        } else if (index_name_ == INDEX_SINDI) {
-            auto sindi_parameter = std::make_shared<SINDIParameter>();
-            sindi_parameter->FromJson(index_param_);
-            auto inner_index = std::make_shared<SINDI>(sindi_parameter, index_common_params);
-            inner_index->Deserialize(reader);
-            index_ = std::make_shared<IndexImpl<SINDI>>(inner_index, index_common_params);
-            return true;
-        } else {
-            logger::error("Index type {} not supported", index_name_);
+    create_index_without_param(std::istream& in_stream) {
+        JsonType build_param;
+        build_param["dtype"].SetString(DataTypesToString(data_type_));
+        build_param["metric_type"].SetString(MetricTypeToString(metric_type_));
+        if (data_type_ != DataTypes::DATA_TYPE_SPARSE) {
+            build_param["dim"].SetInt64(dim_);
+        }
+        if (extra_info_size_ > 0) {
+            build_param["extra_info_size"].SetInt64(extra_info_size_);
+        }
+        build_param[INDEX_PARAM].SetJson(index_param_);
+
+        auto create_result = Factory::CreateIndex(index_name_, build_param.Dump());
+        if (not create_result.has_value()) {
+            logger::error("Failed to create index {} from serialized metadata: {}",
+                          index_name_,
+                          create_result.error().message);
             return false;
         }
+        index_ = create_result.value();
+        auto deserialize_result = index_->Deserialize(in_stream);
+        if (not deserialize_result.has_value()) {
+            logger::error("Failed to deserialize index from file: {}",
+                          deserialize_result.error().message);
+            return false;
+        }
+        return true;
     }
 
 private:


### PR DESCRIPTION
## Summary

- introduce a common analysis metadata contract and lightweight baseline analyzer for all registered indexes
- let HGraph, Pyramid, and SINDI own their analyzer providers; delegate LazyHGraph analysis under its phase lock
- harden IVF analysis validation and remove temporary mutation of shared reorder state
- return valid static diagnostics for SINDI_V2 and preserve WARP's public index identity
- migrate `analyze_index` to `Factory::CreateIndex` plus the unified deserialize API
- document capabilities, statuses, skipped metrics, consistency, and cost in English and Chinese

## Validation

- `make fmt`
- `git diff --check`
- `./build/tests/unittests "[analysis]"`
- `./build/tests/functests "[analysis]"`
- `./build/tests/unittests "Factory indexes expose baseline analysis metadata"`
- `./build/tests/unittests "Factory creates SINDI V2"`
- `./build/tests/unittests "InnerIndexInterface NOT Implemented"`
- `make release`

Fixes: #2843
