### PR TITLE
chore: align issue templates with label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_GUIDE.md
@@ -16,11 +16,11 @@ file an issue against [`antgroup/vsag`](https://github.com/antgroup/vsag).
 ## Title format
 
 ```
-[<prefix>](<area>): <short imperative summary>
+[<prefix>](<scope>): <short imperative summary>
 ```
 
 * `prefix`: `bug` / `feat` / `improve` / `docs` / `q`
-* `area`:   `hgraph` | `ivf` | `sindi` | `pyvsag` | `eval_performance` | `build` | `docs` | `other`
+* `scope`: a short lowercase subsystem name such as `hgraph`, `ivf`, `pyramid`, `sindi`, `pyvsag`, `eval`, `build`, `docs`, or `api`
 * Summary: imperative mood, lowercase, no trailing period.
 
 Good:
@@ -66,8 +66,13 @@ do not need a `kind/*` value.
 
 Maintainers may additionally add during triage:
 
-* `area/<name>` — mirrors the `area` field.
+* `module/<name>` — mirrors the **Affected module** field.
+* `area/<name>` — mirrors the **Affected area** field.
 * `version/<x.y>` — target release line.
+
+The module and area dropdown values use complete label names. Do not add a label for
+`not applicable` or `other`; choose the closest valid label during triage when the
+reported scope becomes clear.
 
 ## Drafting with an AI agent
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report a defect or unexpected behavior in VSAG.
-title: "[bug](<area>): <short imperative summary>"
+title: "[bug](<scope>): <short imperative summary>"
 labels: ["kind/bug", "bug"]
 assignees: ["wxyucs"]
 body:
@@ -16,18 +16,37 @@ body:
         `/create-issue` inside Claude Code, OpenCode or Codex.
 
   - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      description: Select the primary product module, or not applicable for a cross-cutting issue.
+      options:
+        - module/api
+        - module/attr
+        - module/datacell
+        - module/index
+        - module/simd
+        - not applicable
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
     id: area
     attributes:
       label: Affected area
-      description: Which subsystem does this bug touch?
+      description: Select the primary cross-cutting area, or not applicable if none applies.
       options:
-        - hgraph
-        - ivf
-        - sindi
-        - pyvsag
-        - eval_performance
-        - build
-        - docs
+        - area/bindings-node
+        - area/bindings-python
+        - area/ci
+        - area/dependencies
+        - area/docker
+        - area/docs
+        - area/examples
+        - area/testing
+        - area/tools
+        - not applicable
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: Documentation issue
 description: Report incorrect, missing, or unclear documentation.
-title: "[docs](<area>): <short imperative summary>"
-labels: ["kind/documentation"]
+title: "[docs](<scope>): <short imperative summary>"
+labels: ["kind/documentation", "area/docs"]
 assignees: ["wxyucs"]
 body:
   - type: dropdown
@@ -26,17 +26,36 @@ body:
       required: true
 
   - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      description: Select the primary documented product module, or not applicable.
+      options:
+        - module/api
+        - module/attr
+        - module/datacell
+        - module/index
+        - module/simd
+        - not applicable
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
     id: area
     attributes:
       label: Affected area
+      description: Select an additional cross-cutting area, or not applicable if none applies.
       options:
-        - hgraph
-        - ivf
-        - sindi
-        - pyvsag
-        - eval_performance
-        - build
-        - docs
+        - area/bindings-node
+        - area/bindings-python
+        - area/ci
+        - area/dependencies
+        - area/docker
+        - area/examples
+        - area/testing
+        - area/tools
+        - not applicable
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new capability or public API for VSAG.
-title: "[feat](<area>): <short imperative summary>"
+title: "[feat](<scope>): <short imperative summary>"
 labels: ["kind/feature", "enhancement"]
 assignees: ["wxyucs"]
 body:
@@ -11,17 +11,37 @@ body:
         [docs](https://vsag.io/docs) and the existing issues to avoid duplicates.
 
   - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      description: Select the primary product module, or not applicable for a cross-cutting issue.
+      options:
+        - module/api
+        - module/attr
+        - module/datacell
+        - module/index
+        - module/simd
+        - not applicable
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
     id: area
     attributes:
       label: Affected area
+      description: Select the primary cross-cutting area, or not applicable if none applies.
       options:
-        - hgraph
-        - ivf
-        - sindi
-        - pyvsag
-        - eval_performance
-        - build
-        - docs
+        - area/bindings-node
+        - area/bindings-python
+        - area/ci
+        - area/dependencies
+        - area/docker
+        - area/docs
+        - area/examples
+        - area/testing
+        - area/tools
+        - not applicable
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,6 +1,6 @@
 name: Improvement
 description: Refactor, performance tweak, chore, or test-only change.
-title: "[improve](<area>): <short imperative summary>"
+title: "[improve](<scope>): <short imperative summary>"
 labels: ["kind/improvement"]
 assignees: ["wxyucs"]
 body:
@@ -17,17 +17,37 @@ body:
       required: true
 
   - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      description: Select the primary product module, or not applicable for a cross-cutting issue.
+      options:
+        - module/api
+        - module/attr
+        - module/datacell
+        - module/index
+        - module/simd
+        - not applicable
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
     id: area
     attributes:
       label: Affected area
+      description: Select the primary cross-cutting area, or not applicable if none applies.
       options:
-        - hgraph
-        - ivf
-        - sindi
-        - pyvsag
-        - eval_performance
-        - build
-        - docs
+        - area/bindings-node
+        - area/bindings-python
+        - area/ci
+        - area/dependencies
+        - area/docker
+        - area/docs
+        - area/examples
+        - area/testing
+        - area/tools
+        - not applicable
         - other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,6 +1,6 @@
 name: Question / usage help
 description: Ask how to use VSAG. For long discussions, prefer GitHub Discussions.
-title: "[q](<area>): <short summary>"
+title: "[q](<scope>): <short summary>"
 labels: ["question"]
 assignees: ["wxyucs"]
 body:
@@ -13,17 +13,37 @@ body:
         >   if the topic is open-ended.
 
   - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      description: Select the primary product module, or not applicable for a cross-cutting question.
+      options:
+        - module/api
+        - module/attr
+        - module/datacell
+        - module/index
+        - module/simd
+        - not applicable
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
     id: area
     attributes:
       label: Affected area
+      description: Select the primary cross-cutting area, or not applicable if none applies.
       options:
-        - hgraph
-        - ivf
-        - sindi
-        - pyvsag
-        - eval_performance
-        - build
-        - docs
+        - area/bindings-node
+        - area/bindings-python
+        - area/ci
+        - area/dependencies
+        - area/docker
+        - area/docs
+        - area/examples
+        - area/testing
+        - area/tools
+        - not applicable
         - other
     validations:
       required: true

--- a/.github/agent-prompts/create-issue.md
+++ b/.github/agent-prompts/create-issue.md
@@ -38,10 +38,10 @@ project's templates and labelling policy, then submit it via `gh`.
    required form field to a value. If a value is genuinely unknown, write
    `// TODO` rather than inventing one.
 4. Compose the **title** as
-   `[<prefix>](<area>): <short imperative summary>` where `prefix` is one of
-   `bug` / `feat` / `improve` / `docs` / `q` and `area` is one of
-   `hgraph` / `ivf` / `sindi` / `pyvsag` / `eval_performance` / `build` /
-   `docs` / `other`.
+   `[<prefix>](<scope>): <short imperative summary>` where `prefix` is one of
+   `bug` / `feat` / `improve` / `docs` / `q` and `scope` is a short lowercase
+   subsystem name such as `hgraph`, `ivf`, `pyramid`, `sindi`, `pyvsag`,
+   `eval`, `build`, `docs`, or `api`.
 5. Run a duplicate scan:
 
    ```bash
@@ -80,7 +80,8 @@ project's templates and labelling policy, then submit it via `gh`.
     ```
 
     Labels come from the chosen template's front matter (e.g. `kind/bug,bug`).
-    Add `area/<area>` if such a label exists in the repo; otherwise omit.
+    Add the selected `module/*` and `area/*` values when those labels exist.
+    Do not add labels for `not applicable` or `other`.
     On `gh` failure, fall back to `gh issue create --web --title ... --body-file ...`
     so the user can finish in a browser.
 
@@ -111,8 +112,11 @@ Title: `[bug](hgraph): build throughput regressed 3x on gist-960 in v0.18.0`
 Body skeleton:
 
 ```
+### Affected module
+module/index
+
 ### Affected area
-hgraph
+not applicable
 
 ### Interface
 cpp


### PR DESCRIPTION
## What changed

- split Issue Form classification into label-aligned `module/*` and `area/*` dropdowns
- distinguish the free-form title scope from the repository label taxonomy
- pre-apply `area/docs` to documentation issues
- keep the Issue Guide and canonical `/create-issue` prompt in sync

This aligns issue input with the current label taxonomy. GitHub Issue Forms do not dynamically apply labels selected in dropdowns, so maintainers still apply those labels during triage; the AI-assisted flow applies matching labels when creating an issue.

## Validation

- parsed every Issue Form as YAML
- verified module and area options against `.github/labels.json`
- ran `git diff --check`