### PR TITLE
chore: remove stale issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a defect or unexpected behavior in VSAG.
 title: "[bug](<scope>): <short imperative summary>"
-labels: ["kind/bug", "bug"]
+labels: ["kind/bug"]
 assignees: ["wxyucs"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Propose a new capability or public API for VSAG.
 title: "[feat](<scope>): <short imperative summary>"
-labels: ["kind/feature", "enhancement"]
+labels: ["kind/feature"]
 assignees: ["wxyucs"]
 body:
   - type: markdown


### PR DESCRIPTION
## What changed

- remove the nonexistent `bug` label from the bug Issue Form
- remove the nonexistent `enhancement` label from the feature Issue Form
- retain the canonical `kind/bug` and `kind/feature` labels

The repository already uses `vsag-bot` to classify newly created issues, so no additional auto-labeling workflow is introduced.

## Validation

- parsed every Issue Form as YAML
- verified the retained labels exist on GitHub
- ran `git diff --check`