### PR TITLE
build: prefer Ninja with Unix Makefiles fallback

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,6 +30,7 @@ docker pull vsaglib/vsag:ubuntu
   - or Clang version 13.0.0 or later
 - Build Tools: 
   - CMake version 3.18.0 or later
+  - Ninja (preferred when available; Unix Makefiles remain the compatibility fallback)
   - clang-tidy version 15 EXACTLY (not higher, not lower - required for consistent lint diagnostics)
   - clang-format version 15 EXACTLY (not higher, not lower - required for consistent formatting)
 - Additional Dependencies:
@@ -47,7 +48,7 @@ $ ./scripts/deps/install_deps_macos.sh
 ```
 
 ## VSAG Build Tool
-VSAG project use the Unix Makefiles to compile, package and install the library. Here is the commands below:
+VSAG uses CMake to compile, package, and install the library through the commands below. The Makefile prefers Ninja when a usable installation is available and otherwise falls back to Unix Makefiles. Set `CMAKE_GENERATOR` explicitly to use another supported generator; explicit values always take precedence.
 ```bash
 Usage: make <target>
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 
 # Personal Configurations, Disable Some Options via Env Vars to Accelerate Building
-CMAKE_GENERATOR ?= "Unix Makefiles"
+# Respect an explicit generator; otherwise prefer a usable Ninja installation.
+ifeq ($(origin CMAKE_GENERATOR), undefined)
+  ifneq ($(shell ninja --version >/dev/null 2>&1 && echo available),)
+    CMAKE_GENERATOR := Ninja
+  else
+    CMAKE_GENERATOR := Unix Makefiles
+  endif
+endif
 CMAKE_INSTALL_PREFIX ?= "/usr/local/"
 COMPILE_JOBS ?= 6
 CMAKE_BUILD_ARGS ?=
@@ -56,7 +63,7 @@ endif
 ifdef EXTRA_DEFINED
   VSAG_CMAKE_ARGS := ${VSAG_CMAKE_ARGS} ${EXTRA_DEFINED}
 endif
-VSAG_CMAKE_ARGS := ${VSAG_CMAKE_ARGS} -G ${CMAKE_GENERATOR} -S.
+VSAG_CMAKE_ARGS := ${VSAG_CMAKE_ARGS} -G "${CMAKE_GENERATOR}" -S.
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -103,6 +110,7 @@ test:                    ## Build and run unit tests.
 
 .PHONY: test-cmake
 test-cmake:              ## Run focused CMake helper tests.
+	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/generator_selection_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/thirdparty_override_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/release_build_modes_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/object_library_test.cmake

--- a/docs/docs/en/src/development/building.md
+++ b/docs/docs/en/src/development/building.md
@@ -7,6 +7,7 @@ This page documents how to build VSAG from source.
 - **OS**: Ubuntu 20.04+, CentOS 7+, or macOS 14+ on Apple Silicon
 - **Compiler**: GCC 9.4.0+, Clang 13.0.0+, or Apple Clang from Xcode Command Line Tools
 - **CMake**: 3.18.0+
+- **Ninja**: preferred when available; Unix Makefiles are used as the fallback
 - **clang-format / clang-tidy**: exactly version 15 (enforced)
 - Optional: HDF5 (for `tools/eval/eval_performance`), libaio (for the `async_io` data-cell backend),
   liburing (for `uring_io` on Linux), Intel MKL.
@@ -39,6 +40,12 @@ dist-cxx11-abi      Build redistributable tarball (C++11 ABI)
 dist-libcxx         Build redistributable tarball (libc++)
 clean       Remove build trees
 ```
+
+These targets prefer Ninja when a usable `ninja` executable is available. Otherwise they fall back
+to Unix Makefiles. An explicit generator always wins; for example, use
+`make debug CMAKE_GENERATOR='Unix Makefiles'` to request the fallback directly. Because CMake build
+trees are generator-specific, run the matching clean target before changing the generator for an
+existing build directory.
 
 ## Step-by-Step
 

--- a/docs/docs/zh/src/development/building.md
+++ b/docs/docs/zh/src/development/building.md
@@ -16,7 +16,7 @@ arm64 核心 C++ 构建，预编译 C++ 包与 Python wheel 仍以 Linux 为主�
 `-DENABLE_LIBURING=ON`。默认值为 `OFF`；在非 Linux 平台或未找到 liburing 时，
 请求 `uring_io` 的配置会打印一次性告警并回退到 `buffer_io`。
 
-在 CMake 配置中，有许多参数和编译目标。为了方便使用，我们将常用的编译目标（或命令）写到了 Makefile 中，使用 Unix Makefiles 进行管理，已避免记忆各种配置或者从命令行输入大段参数。这些编译目标（或命令）可以通过在项目根目录运行 `make help` 查看：
+在 CMake 配置中，有许多参数和编译目标。为了方便使用，我们将常用的编译目标（或命令）写到了 Makefile 中，以避免记忆各种配置或者从命令行输入大段参数。当存在可用的 `ninja` 且 CMake 支持 Ninja 生成器时，这些目标会优先使用 Ninja；否则会回退到 Unix Makefiles。显式设置的 `CMAKE_GENERATOR` 始终优先，例如可以使用 `make debug CMAKE_GENERATOR='Unix Makefiles'` 直接指定回退生成器。由于 CMake 构建目录与生成器绑定，更换现有构建目录的生成器前应先运行对应的清理目标。这些编译目标（或命令）可以通过在项目根目录运行 `make help` 查看：
 
 ```bash
 Usage: make <target>
@@ -144,7 +144,7 @@ make pyvsag-all
 
 环境变量说明如下：
 
-- `CMAKE_GENERATOR`：CMake 内部使用什么来编译项目，默认是 `"Unix Makefiles"`，其他可选值请参考 [CMake Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)；
+- `CMAKE_GENERATOR`：显式指定 CMake 使用的生成器；未设置时优先选择可用的 Ninja，否则回退到 Unix Makefiles。其他可选值请参考 [CMake Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html)；
 - `CMAKE_INSTALL_PREFIX`：安装路径，即运行 `make install` 后头文件和库文件会被安装到哪里，一般不需要修改；
 - `COMPILE_JOBS`：编译并行度，默认是 6 并行编译，建议设置成你的 CPU 核数以提高编译速度；
 - `DEBUG_BUILD_DIR`：开发模式产物目录，非必要不修改；

--- a/tests/cmake/generator_selection_test.cmake
+++ b/tests/cmake/generator_selection_test.cmake
@@ -1,0 +1,94 @@
+# Copyright 2026-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (NOT DEFINED VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+
+find_program (MAKE_EXECUTABLE NAMES gmake make REQUIRED)
+find_program (UNAME_EXECUTABLE NAMES uname REQUIRED)
+
+string (RANDOM LENGTH 12 ALPHABET 0123456789abcdef fixture_suffix)
+set (fixture_root "/tmp/vsag-generator-selection-${fixture_suffix}")
+set (ninja_path "${fixture_root}/with-ninja")
+set (fallback_path "${fixture_root}/without-ninja")
+
+function (create_tool_path path include_ninja)
+    file (MAKE_DIRECTORY "${path}")
+    file (CREATE_LINK "${CMAKE_COMMAND}" "${path}/cmake" SYMBOLIC)
+    file (CREATE_LINK "${MAKE_EXECUTABLE}" "${path}/make" SYMBOLIC)
+    file (CREATE_LINK "${UNAME_EXECUTABLE}" "${path}/uname" SYMBOLIC)
+    if (include_ninja)
+        # CMake accepts --version, so its executable is a deterministic stand-in for Ninja here.
+        file (CREATE_LINK "${CMAKE_COMMAND}" "${path}/ninja" SYMBOLIC)
+    endif ()
+endfunction ()
+
+function (run_make output_variable tool_path)
+    execute_process (
+        COMMAND ${CMAKE_COMMAND} -E env --unset=CMAKE_GENERATOR "PATH=${tool_path}"
+                ${MAKE_EXECUTABLE} --no-print-directory --dry-run debug ${ARGN}
+        WORKING_DIRECTORY "${VSAG_SOURCE_DIR}"
+        RESULT_VARIABLE make_result
+        OUTPUT_VARIABLE make_output
+        ERROR_VARIABLE make_error)
+    if (NOT make_result EQUAL 0)
+        file (REMOVE_RECURSE "${fixture_root}")
+        message (FATAL_ERROR "make ${ARGN} failed:\n${make_output}\n${make_error}")
+    endif ()
+    set (${output_variable} "${make_output}" PARENT_SCOPE)
+endfunction ()
+
+function (run_make_with_environment output_variable tool_path generator)
+    execute_process (
+        COMMAND ${CMAKE_COMMAND} -E env "PATH=${tool_path}" "CMAKE_GENERATOR=${generator}"
+                ${MAKE_EXECUTABLE} --no-print-directory --dry-run debug
+        WORKING_DIRECTORY "${VSAG_SOURCE_DIR}"
+        RESULT_VARIABLE make_result
+        OUTPUT_VARIABLE make_output
+        ERROR_VARIABLE make_error)
+    if (NOT make_result EQUAL 0)
+        file (REMOVE_RECURSE "${fixture_root}")
+        message (FATAL_ERROR "make with CMAKE_GENERATOR=${generator} failed:\n"
+                            "${make_output}\n${make_error}")
+    endif ()
+    set (${output_variable} "${make_output}" PARENT_SCOPE)
+endfunction ()
+
+function (assert_generator commands expected description)
+    string (FIND "${commands}" "-G \"${expected}\"" match_position)
+    if (match_position EQUAL -1)
+        file (REMOVE_RECURSE "${fixture_root}")
+        message (FATAL_ERROR "${description}: expected generator '${expected}' in:\n${commands}")
+    endif ()
+endfunction ()
+
+file (REMOVE_RECURSE "${fixture_root}")
+create_tool_path ("${ninja_path}" TRUE)
+create_tool_path ("${fallback_path}" FALSE)
+
+run_make (ninja_commands "${ninja_path}")
+assert_generator ("${ninja_commands}" "Ninja" "Ninja auto-selection")
+
+run_make (fallback_commands "${fallback_path}")
+assert_generator ("${fallback_commands}" "Unix Makefiles" "fallback selection")
+
+run_make (command_line_override "${ninja_path}" "CMAKE_GENERATOR=Unix Makefiles")
+assert_generator ("${command_line_override}" "Unix Makefiles" "command-line precedence")
+
+run_make_with_environment (environment_override "${ninja_path}" "Unix Makefiles")
+assert_generator ("${environment_override}" "Unix Makefiles" "environment precedence")
+
+file (REMOVE_RECURSE "${fixture_root}")
+message (STATUS "CMake generator selection checks passed")


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2773

## What Changed

- Prefer Ninja for Makefile-driven local builds when `ninja --version` succeeds, while retaining Unix Makefiles as the compatibility fallback.
- Preserve command-line and environment `CMAKE_GENERATOR` precedence, including multi-word generators, and keep builds on portable `cmake --build`.
- Add isolated regression coverage for Ninja selection, fallback, and explicit override precedence.
- Document the behavior and generator-specific build-directory caveat in the English and Chinese developer guides.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
cmake -DVSAG_SOURCE_DIR="$PWD" -P tests/cmake/generator_selection_test.cmake
make test-cmake COMPILE_JOBS=6

# Full configure/build, no-op, one-file incremental, generator clean/rebuild,
# and clean/reconfigure/rebuild exercised with both:
make debug DEBUG_BUILD_DIR=./build-ninja-validation/ COMPILE_JOBS=48 EXTRA_DEFINED=-DVSAG_USE_SYSTEM_OPENBLAS=ON
PATH=<controlled-unusable-ninja>:$PATH make debug DEBUG_BUILD_DIR=./build-make-validation/ COMPILE_JOBS=48 EXTRA_DEFINED=-DVSAG_USE_SYSTEM_OPENBLAS=ON

# Explicit override with Ninja installed:
make debug CMAKE_GENERATOR='Unix Makefiles' DEBUG_BUILD_DIR=./build-make-validation/ COMPILE_JOBS=48 EXTRA_DEFINED=-DVSAG_USE_SYSTEM_OPENBLAS=ON

git diff --check
```

All commands above passed with CMake 4.2.3, Ninja 1.13.2, GNU Make 4.4.1, and GCC 15.2.0. The controlled fallback prepended an isolated failing `ninja` entry to `PATH`; it did not modify the system installation. The full C++ unit suite was not rerun because no C++ source or runtime behavior changed. clang-format 15 and clang-tidy 15 are unavailable in the local environment, so their exact checks are deferred to CI.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: Makefile-driven builds now choose Ninja by default when usable. Explicit generator choices remain authoritative; systems without usable Ninja continue to use Unix Makefiles. Existing build directories must be cleaned before switching generators, as documented.

## Performance and Concurrency Impact

- Performance impact: expected improvement in local scheduling and incremental-build responsiveness; no runtime-library impact
- Concurrency/thread-safety impact: none

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [x] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: English and Chinese building guides

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the single commit to restore the Unix Makefiles default

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
