### PR TITLE
perf(build): reduce unit-test compile time with scoped PCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,21 @@ if (ENABLE_TESTS)
 endif ()
 
 add_subdirectory (src)
+if (ENABLE_TESTS AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+    # Keep the PCH target-local: compile options and definitions differ for OpenMP, SIMD, and
+    # platform-specific configurations. These high-fan-out targets amortize the extra PCH object.
+    foreach (_target IN ITEMS
+            algorithm_test
+            datacell_test
+            impl_test
+            io_test
+            quantizer_test
+            simd_test)
+        target_precompile_headers (${_target} PRIVATE
+            "$<$<COMPILE_LANGUAGE:CXX>:${PROJECT_SOURCE_DIR}/tests/fixtures/unittest.h>")
+    endforeach ()
+    unset (_target)
+endif ()
 if (ENABLE_TOOLS AND ENABLE_CXX11_ABI)
     add_subdirectory (tools)
 endif ()

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ test-cmake:              ## Run focused CMake helper tests.
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/release_build_modes_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/object_library_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/compile_flag_scope_test.cmake
+	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/precompiled_header_scope_test.cmake
 
 .PHONY: asan configure-asan build-asan
 asan:                    ## Build with AddressSanitizer option.

--- a/tests/cmake/precompiled_header_scope_test.cmake
+++ b/tests/cmake/precompiled_header_scope_test.cmake
@@ -1,0 +1,77 @@
+# Copyright 2026-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (NOT VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+
+file (READ "${VSAG_SOURCE_DIR}/CMakeLists.txt" root_cmake)
+set (pch_guard "if (ENABLE_TESTS AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)")
+string (FIND "${root_cmake}" "${pch_guard}" block_start)
+if (block_start EQUAL -1)
+    message (FATAL_ERROR "The unit-test PCH block must honor CMake's standard opt-out")
+endif ()
+
+string (SUBSTRING "${root_cmake}" ${block_start} -1 block_remainder)
+string (FIND "${block_remainder}" "\nendif ()" block_end)
+if (block_end EQUAL -1)
+    message (FATAL_ERROR "The unit-test PCH block is not terminated")
+endif ()
+string (SUBSTRING "${block_remainder}" 0 ${block_end} pch_block)
+
+function (assert_target target expect_pch)
+    string (REGEX MATCHALL "(^|[ \t\r\n])${target}([ \t\r\n)]|$)" matches "${pch_block}")
+    list (LENGTH matches match_count)
+    if (expect_pch AND NOT match_count EQUAL 1)
+        message (FATAL_ERROR "Expected exactly one PCH entry for ${target}")
+    elseif (NOT expect_pch AND NOT match_count EQUAL 0)
+        message (FATAL_ERROR "Unexpected PCH entry for ${target}")
+    endif ()
+endfunction ()
+
+set (pch_targets
+     algorithm_test
+     datacell_test
+     impl_test
+     io_test
+     quantizer_test
+     simd_test)
+foreach (target IN LISTS pch_targets)
+    assert_target (${target} TRUE)
+endforeach ()
+
+set (excluded_targets
+     attr_test
+     factory_test
+     layout_test
+     storage_test
+     utils_test
+     vsag_test)
+foreach (target IN LISTS excluded_targets)
+    assert_target (${target} FALSE)
+endforeach ()
+
+string (REGEX MATCHALL "target_precompile_headers" pch_commands "${pch_block}")
+list (LENGTH pch_commands pch_command_count)
+if (NOT pch_command_count EQUAL 1)
+    message (FATAL_ERROR "Unit-test PCH configuration must stay in one target-local command")
+endif ()
+if (NOT pch_block MATCHES "tests/fixtures/unittest\\.h")
+    message (FATAL_ERROR "Unit-test PCH must use the shared fixture header")
+endif ()
+if (pch_block MATCHES "CMAKE_UNITY_BUILD|UNITY_BUILD")
+    message (FATAL_ERROR "Unity Build must not be enabled by the PCH configuration")
+endif ()
+
+message (STATUS "Unit-test PCH scope checks passed")


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2775

## What Changed

- Add independent target-local PCHs using `tests/fixtures/unittest.h` to the six high-fan-out unit-test archives: algorithm, datacell, implementation, I/O, quantization, and SIMD.
- Honor the standard `CMAKE_DISABLE_PRECOMPILE_HEADERS=ON` opt-out; tests-off builds produce no PCH edges.
- Add a focused CMake regression check that locks the allowlist, opt-out, fixture header, and absence of Unity.
- Do not ship Unity Build. The measured clean-build gain beyond PCH was too small to justify its worse incremental time and generated-wrapper failure isolation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
Environment: Linux x86_64, GCC 15.2.0, CMake 4.2.3, Ninja 1.13.2
Common benchmark conditions: Debug, tests enabled, system OpenBLAS, ccache disabled,
same dependency sources and flags; three runs per accepted comparison.

cmake -S . -B <build> -G Ninja -DCMAKE_BUILD_TYPE=Debug \
  -DENABLE_TESTS=ON -DENABLE_CCACHE=OFF -DVSAG_USE_SYSTEM_OPENBLAS=ON
taskset -c 0-95 cmake --build <build> --target unittests --parallel 96

Stable full-clean medians:
  baseline                     70.622 s wall, 940.082 s CPU, 26,834,140 KiB sampled tree RSS
  PCH on all test archives     69.660 s wall, 864.716 s CPU, 25,349,808 KiB sampled tree RSS
  PCH-all + scoped Unity       69.123 s wall, 854.044 s CPU, 27,218,100 KiB sampled tree RSS
One-file incremental medians: baseline 6.395 s; PCH-all 5.938 s; scoped Unity 7.390 s.

Exact submitted six-target PCH, paired test-clean build at -j24:
  PCH disabled                 37.138 s wall, 278.807 s CPU, 7,184,576 KiB sampled tree RSS
  selected PCH                 30.518 s wall, 222.722 s CPU, 7,314,184 KiB sampled tree RSS
  change                       -17.8% wall, -20.1% CPU, +1.8% sampled tree RSS
Included I/O source edit: 8.116 -> 7.849 s wall; 6.710 -> 6.222 s CPU.
Generated PCH storage: 776.9 MiB. Test objects, archives, and final binary were each slightly smaller.

Focused Debug unit tests: 72 cases, 39,257,480 assertions passed across all six PCH areas.
Coverage Debug build: linked successfully; six representative cases, 506,434 assertions passed.
Functional Debug build: [bruteforce] excluding [daily], 33 cases, 103,218 assertions passed.
CMAKE_DISABLE_PRECOMPILE_HEADERS=ON: unittests built successfully without PCH edges.
ENABLE_TESTS=OFF: configured successfully without PCH edges.
make test-cmake: all five focused CMake checks passed.

Release: all six affected archives compiled with PCH. The final unit-test link hit an existing
undefined HGraph template specialization and failed identically with PCH disabled.
Sanitize + ASan/UBSan: all six PCHs and affected instrumented test sources compiled cleanly;
the complete local link/run was limited by the existing high-memory flatten factory compile hotspot.

clang-format 15 and clang-tidy 15 are unavailable locally; no substitute version was used.
Exact formatting/lint and the wider platform matrix are left to CI.
```

## Compatibility Impact

- API/ABI compatibility: none; no production or public API source changed.
- Behavior changes: build-time only for the six listed test archives; the standard CMake opt-out restores the baseline graph.

## Performance and Concurrency Impact

- Performance impact: selected test compilation improved; no runtime impact. The Debug build tree gains 776.9 MiB of compiler-specific PCH data.
- Concurrency/thread-safety impact: none. PCHs remain independent so targets do not gain cross-target serialization dependencies.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: low; the change is test-build-only, target-scoped, and has a standard opt-out.
- Rollback plan: revert this commit or configure with `CMAKE_DISABLE_PRECOMPILE_HEADERS=ON`.

## Checklist

- [x] I have linked the relevant issue.
- [x] I have added/updated tests for the new build behavior.
- [x] I have considered API compatibility impact.
- [x] I have updated docs if behavior/workflow changed (no update needed).
- [x] My commit messages follow project conventions.
