### PR TITLE
build: add independently runnable module tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,7 @@ help:                    ## Show the help.
 debug:                   ## Build vsag with debug options.
 dev:                     ## Build full developer configuration.
 test:                    ## Build and run unit tests.
+test-module:             ## Build and run one unit-test module. Usage: make test-module MODULE=datacell
 asan:                    ## Build with AddressSanitizer option.
 test_asan: asan          ## Run unit tests with AddressSanitizer option.
 tsan:                    ## Build with ThreadSanitizer option.
@@ -93,6 +94,7 @@ Build target behavior:
 - `make debug` builds the default minimal configuration. It does not enable tests, examples, tools, or Python bindings unless they are explicitly turned on.
 - `make dev` builds the full developer configuration with tests, examples, tools, and Python bindings enabled.
 - `make test`, `make asan`, `make tsan`, and the related parallel test targets automatically enable tests.
+- `make test-module MODULE=<name>` builds and runs one unit-test subsystem without building the other unit-test modules. `CASE=<filter>` applies the usual Catch2 runtime filter; run `make test` for full validation.
 - `make release` is the reproducible release/package path. It uses the minimal configuration, Release optimization semantics, and disables ccache by default. Enable optional components explicitly when needed, for example `make release VSAG_ENABLE_TOOLS=ON`.
 - `make release-perf` uses the same Release optimization semantics and minimal configuration in `build-release-perf/`, but enables ccache by default for iterative development and benchmarking.
 - Override either cache default explicitly with `VSAG_ENABLE_CCACHE=ON` or `VSAG_ENABLE_CCACHE=OFF`.

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ UT_SHARD = ""
 ifdef SHARD
   UT_SHARD = $(SHARD)
 endif
+UNITTEST_MODULES := simd common algorithm factory attr datacell layout quantization storage io utils impl
 
 
 .PHONY: help
@@ -108,6 +109,18 @@ test:                    ## Build and run unit tests.
 	./build/tests/functests -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
 	./build/tests/eval_monitor_test -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
 
+.PHONY: test-module
+test-module: VSAG_ENABLE_ASAN ?= OFF
+test-module: VSAG_ENABLE_CCACHE ?= ON
+test-module:             ## Build and run one unit-test module. Usage: make test-module MODULE=datacell
+	@if [ "$(words $(MODULE))" -ne 1 ] || [ "$(filter $(UNITTEST_MODULES),$(MODULE))" != "$(MODULE)" ]; then \
+		echo "MODULE must be exactly one of: $(UNITTEST_MODULES)"; \
+		exit 2; \
+	fi
+	cmake ${VSAG_CMAKE_ARGS} -B${DEBUG_BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=${VSAG_ENABLE_ASAN} -DENABLE_CCACHE=${VSAG_ENABLE_CCACHE} -DENABLE_TESTS=ON
+	cmake --build ${DEBUG_BUILD_DIR} --target unittests_${MODULE} --parallel ${COMPILE_JOBS}
+	${DEBUG_BUILD_DIR}/tests/unittests_${MODULE} -d yes ${UT_FILTER} --allow-running-no-tests ${UT_SHARD}
+
 .PHONY: test-cmake
 test-cmake:              ## Run focused CMake helper tests.
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/generator_selection_test.cmake
@@ -116,6 +129,7 @@ test-cmake:              ## Run focused CMake helper tests.
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/object_library_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/compile_flag_scope_test.cmake
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/precompiled_header_scope_test.cmake
+	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/module_test_targets_test.cmake
 
 .PHONY: asan configure-asan build-asan
 asan:                    ## Build with AddressSanitizer option.

--- a/docs/agents/build-and-test.md
+++ b/docs/agents/build-and-test.md
@@ -18,6 +18,7 @@ last-reviewed: 2026-05-12
 ```bash
 make debug
 make test
+make test-module MODULE=datacell
 make fmt
 make lint
 make fix-lint
@@ -27,6 +28,8 @@ make pyvsag
 ```
 
 Prefer these targets over invoking `cmake` directly so behavior matches CI.
+
+`make test-module MODULE=<name>` is the local acceleration path for one unit-test subsystem. The maintained module names are `simd`, `common`, `algorithm`, `factory`, `attr`, `datacell`, `layout`, `quantization`, `storage`, `io`, `utils`, and `impl`. It accepts the same `CASE` and `SHARD` runtime arguments as `make test`; use the aggregate `make test` path before submitting changes.
 
 ## Development environment
 

--- a/docs/docs/en/src/development/testing.md
+++ b/docs/docs/en/src/development/testing.md
@@ -16,6 +16,29 @@ suite:
 make test
 ```
 
+## Build and Run One Unit-Test Module
+
+For a shorter edit-build-test cycle, build and run one maintained unit-test subsystem:
+
+```bash
+make test-module MODULE=datacell
+make test-module MODULE=algorithm CASE='[ut][sample_train_data]'
+```
+
+The available module names are `simd`, `common`, `algorithm`, `factory`, `attr`, `datacell`,
+`layout`, `quantization`, `storage`, `io`, `utils`, and `impl`. Each command builds the shared
+production and fixture dependencies plus only the selected module's test sources. The corresponding
+CMake target and executable are named `unittests_<module>`:
+
+```bash
+cmake -S . -B build -DENABLE_TESTS=ON
+cmake --build build --target unittests_datacell
+./build/tests/unittests_datacell '[ut][AttributeInvertedInterfaceParameter]'
+```
+
+These module targets are a local acceleration path. Continue to run `make test`, whose aggregate
+`unittests` executable contains every module, for full validation.
+
 Note: `make test` does not enable coverage instrumentation. To produce a coverage report, use
 `make cov` — it configures the build with `ENABLE_COVERAGE=ON`; then run the same non-daily unit
 and functional suites as coverage CI with its fixed seed before collecting the trace:

--- a/docs/docs/zh/src/development/testing.md
+++ b/docs/docs/zh/src/development/testing.md
@@ -15,6 +15,27 @@ VSAG 采用 [Catch2](https://github.com/catchorg/Catch2) 作为测试框架，�
 make test
 ```
 
+## 构建并运行单个单元测试模块
+
+为了缩短编辑、构建和测试周期，可以只构建并运行一个仍在维护的单元测试子系统：
+
+```bash
+make test-module MODULE=datacell
+make test-module MODULE=algorithm CASE='[ut][sample_train_data]'
+```
+
+可用模块名为 `simd`、`common`、`algorithm`、`factory`、`attr`、`datacell`、`layout`、
+`quantization`、`storage`、`io`、`utils` 和 `impl`。每条命令都会构建共享的生产代码与测试夹具依赖，
+但只编译所选模块的测试源码。对应的 CMake 目标和可执行文件名为 `unittests_<module>`：
+
+```bash
+cmake -S . -B build -DENABLE_TESTS=ON
+cmake --build build --target unittests_datacell
+./build/tests/unittests_datacell '[ut][AttributeInvertedInterfaceParameter]'
+```
+
+模块目标仅用于加速本地开发。完整验证仍应运行 `make test`；其中聚合的 `unittests` 可执行文件包含所有模块。
+
 说明：
 
 1. 运行 `src/` 下的单元测试；

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,8 +16,9 @@
 # fixtures is already added by top-level CMakeLists.txt before src
 
 
-#  unittests
-add_executable (unittests
+# Unit tests are compiled into module-owned static libraries under src/. Keep the aggregate
+# executable for CI and full validation, and expose opt-in module executables for local iteration.
+set (VSAG_UNITTEST_FIXTURES
         test_main.cpp
         $<TARGET_OBJECTS:fixtures_allocator>
         $<TARGET_OBJECTS:fixtures_core>
@@ -25,42 +26,99 @@ add_executable (unittests
         $<TARGET_OBJECTS:fixtures_framework>
 )
 
-target_link_libraries (unittests
-        PRIVATE
-        Catch2::Catch2 
-        simd_test vsag_test algorithm_test factory_test attr_test
-        datacell_test layout_test quantizer_test storage_test io_test utils_test impl_test
-        vsag_static
-        coverage_config
+set (VSAG_UNITTEST_MODULES
+        simd
+        common
+        algorithm
+        factory
+        attr
+        datacell
+        layout
+        quantization
+        storage
+        io
+        utils
+        impl
 )
 
-if (APPLE)
-        # Ensure static test libraries are not dead-stripped on macOS.
-        target_link_options (unittests PRIVATE
-        "-Wl,-force_load,$<TARGET_FILE:simd_test>"
-        "-Wl,-force_load,$<TARGET_FILE:vsag_test>"
-        "-Wl,-force_load,$<TARGET_FILE:algorithm_test>"
-        "-Wl,-force_load,$<TARGET_FILE:factory_test>"
-        "-Wl,-force_load,$<TARGET_FILE:attr_test>"
-        "-Wl,-force_load,$<TARGET_FILE:datacell_test>"
-        "-Wl,-force_load,$<TARGET_FILE:layout_test>"
-        "-Wl,-force_load,$<TARGET_FILE:quantizer_test>"
-        "-Wl,-force_load,$<TARGET_FILE:storage_test>"
-        "-Wl,-force_load,$<TARGET_FILE:io_test>"
-        "-Wl,-force_load,$<TARGET_FILE:utils_test>"
-        "-Wl,-force_load,$<TARGET_FILE:impl_test>"
-        )
-else()
-        target_link_libraries (unittests
-                        PRIVATE
-                        "-Wl,--whole-archive"
-                        simd_test vsag_test algorithm_test factory_test attr_test
-                        datacell_test layout_test quantizer_test storage_test io_test utils_test impl_test
-                        "-Wl,--no-whole-archive"
-        )
-endif()
+set (VSAG_UNITTEST_LIBRARIES
+        simd_test
+        vsag_test
+        algorithm_test
+        factory_test
+        attr_test
+        datacell_test
+        layout_test
+        quantizer_test
+        storage_test
+        io_test
+        utils_test
+        impl_test
+)
 
-add_dependencies (unittests Catch2 vsag)
+function (vsag_add_unittest_executable target)
+    set (options EXCLUDE_FROM_ALL DEPEND_ON_SHARED_VSAG)
+    set (multi_value_args TEST_LIBRARIES)
+    cmake_parse_arguments (ARG "${options}" "" "${multi_value_args}" ${ARGN})
+
+    set (_exclude_from_all)
+    if (ARG_EXCLUDE_FROM_ALL)
+        set (_exclude_from_all EXCLUDE_FROM_ALL)
+    endif ()
+
+    add_executable (${target}
+            ${_exclude_from_all}
+            ${VSAG_UNITTEST_FIXTURES}
+    )
+
+    target_link_libraries (${target}
+            PRIVATE
+            Catch2::Catch2
+            coverage_config
+    )
+
+    if (APPLE)
+        target_link_libraries (${target} PRIVATE ${ARG_TEST_LIBRARIES} vsag_static)
+
+        # Ensure static test libraries are not dead-stripped on macOS.
+        foreach (_test_library IN LISTS ARG_TEST_LIBRARIES)
+            target_link_options (${target} PRIVATE
+                    "-Wl,-force_load,$<TARGET_FILE:${_test_library}>"
+            )
+        endforeach ()
+    else ()
+        target_link_libraries (${target}
+                PRIVATE
+                "-Wl,--whole-archive"
+                ${ARG_TEST_LIBRARIES}
+                "-Wl,--no-whole-archive"
+                vsag_static
+        )
+    endif ()
+
+    add_dependencies (${target} Catch2)
+    if (ARG_DEPEND_ON_SHARED_VSAG)
+        add_dependencies (${target} vsag)
+    endif ()
+endfunction ()
+
+list (LENGTH VSAG_UNITTEST_MODULES _module_count)
+list (LENGTH VSAG_UNITTEST_LIBRARIES _library_count)
+if (NOT _module_count EQUAL _library_count)
+    message (FATAL_ERROR "Unit-test module and library lists must have the same length")
+endif ()
+
+foreach (_module _test_library IN ZIP_LISTS VSAG_UNITTEST_MODULES VSAG_UNITTEST_LIBRARIES)
+    vsag_add_unittest_executable (unittests_${_module}
+            EXCLUDE_FROM_ALL
+            TEST_LIBRARIES ${_test_library}
+    )
+endforeach ()
+
+vsag_add_unittest_executable (unittests
+        DEPEND_ON_SHARED_VSAG
+        TEST_LIBRARIES ${VSAG_UNITTEST_LIBRARIES}
+)
 
 add_executable (eval_monitor_test
         ${PROJECT_SOURCE_DIR}/tools/eval/monitor/latency_monitor_test.cpp

--- a/tests/cmake/module_test_targets_test.cmake
+++ b/tests/cmake/module_test_targets_test.cmake
@@ -1,0 +1,118 @@
+# Copyright 2026-present the vsag project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (NOT DEFINED VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+
+find_program (MAKE_EXECUTABLE NAMES gmake make REQUIRED)
+
+file (READ "${VSAG_SOURCE_DIR}/tests/CMakeLists.txt" test_cmake)
+
+function (require_text content text description)
+    string (FIND "${content}" "${text}" position)
+    if (position EQUAL -1)
+        message (FATAL_ERROR "Missing ${description}")
+    endif ()
+endfunction ()
+
+set (expected_modules simd common algorithm factory attr datacell layout quantization storage io
+                      utils impl)
+set (expected_libraries simd_test vsag_test algorithm_test factory_test attr_test datacell_test
+                        layout_test quantizer_test storage_test io_test utils_test impl_test)
+
+foreach (module IN LISTS expected_modules)
+    require_text ("${test_cmake}" "        ${module}\n" "${module} unit-test module")
+endforeach ()
+foreach (library IN LISTS expected_libraries)
+    require_text ("${test_cmake}" "        ${library}\n" "${library} aggregate input")
+endforeach ()
+
+require_text ("${test_cmake}"
+              [=[foreach (_module _test_library IN ZIP_LISTS VSAG_UNITTEST_MODULES VSAG_UNITTEST_LIBRARIES)]=]
+              "module-to-library mapping")
+require_text ("${test_cmake}" "list (LENGTH VSAG_UNITTEST_MODULES _module_count)"
+              "module mapping length check")
+require_text ("${test_cmake}" "if (NOT _module_count EQUAL _library_count)"
+              "module mapping mismatch failure")
+require_text ("${test_cmake}" [=[vsag_add_unittest_executable (unittests_${_module}]=]
+              "module executable creation")
+require_text ("${test_cmake}" "            EXCLUDE_FROM_ALL\n"
+              "opt-in module executables")
+require_text ("${test_cmake}"
+              "vsag_add_unittest_executable (unittests\n        DEPEND_ON_SHARED_VSAG\n"
+              "aggregate compatibility executable")
+require_text ("${test_cmake}" "    if (ARG_DEPEND_ON_SHARED_VSAG)\n"
+              "selective shared-library dependency")
+require_text ("${test_cmake}"
+              "target_link_libraries (\${target}\n            PRIVATE\n            Catch2::Catch2\n            coverage_config\n"
+              "coverage instrumentation and runtime for aggregate and module executables")
+require_text ("${test_cmake}" [=["-Wl,-force_load,$<TARGET_FILE:${_test_library}>"]=]
+              "Apple registration preservation")
+require_text ("${test_cmake}" [=["-Wl,--whole-archive"]=]
+              "GNU registration preservation")
+
+foreach (module IN LISTS expected_modules)
+    execute_process (
+        COMMAND ${MAKE_EXECUTABLE} --no-print-directory --dry-run test-module MODULE=${module}
+                DEBUG_BUILD_DIR=./module-test-build
+        WORKING_DIRECTORY "${VSAG_SOURCE_DIR}"
+        RESULT_VARIABLE make_result
+        OUTPUT_VARIABLE make_output
+        ERROR_VARIABLE make_error)
+    if (NOT make_result EQUAL 0)
+        message (FATAL_ERROR "make test-module MODULE=${module} failed:\n${make_error}")
+    endif ()
+    require_text ("${make_output}" "[ \"1\" -ne 1 ] || [ \"${module}\" != \"${module}\" ]"
+                  "${module} Make allow-list membership")
+    require_text ("${make_output}" "--target unittests_${module}"
+                  "${module} module build command")
+    require_text ("${make_output}" "./module-test-build/tests/unittests_${module}"
+                  "${module} module execution command")
+endforeach ()
+
+foreach (invalid_module "" " " "unknown" "common simd" "common unknown" "unknown common"
+                        "common common" "%" "common\tsimd")
+    execute_process (
+        COMMAND ${MAKE_EXECUTABLE} --no-print-directory test-module "MODULE=${invalid_module}"
+                VSAG_CMAKE_ARGS=--invalid-module-test-sentinel COMPILE_JOBS=16
+        WORKING_DIRECTORY "${VSAG_SOURCE_DIR}"
+        RESULT_VARIABLE invalid_result
+        OUTPUT_VARIABLE invalid_output
+        ERROR_VARIABLE invalid_error)
+    if (NOT invalid_result EQUAL 2)
+        message (FATAL_ERROR "Invalid MODULE '${invalid_module}' must fail with exit code 2")
+    endif ()
+    require_text ("${invalid_output}" "MODULE must be exactly one of:"
+                  "invalid MODULE rejection before configuration")
+    string (FIND "${invalid_output}${invalid_error}" "cmake" configure_position)
+    if (NOT configure_position EQUAL -1)
+        message (FATAL_ERROR "Invalid MODULE '${invalid_module}' reached CMake")
+    endif ()
+endforeach ()
+
+execute_process (
+    COMMAND ${MAKE_EXECUTABLE} --no-print-directory --dry-run test-module MODULE=common
+            DEBUG_BUILD_DIR=./module-test-build VSAG_ENABLE_ASAN=ON VSAG_ENABLE_CCACHE=OFF
+    WORKING_DIRECTORY "${VSAG_SOURCE_DIR}"
+    RESULT_VARIABLE override_result
+    OUTPUT_VARIABLE override_output
+    ERROR_VARIABLE override_error)
+if (NOT override_result EQUAL 0)
+    message (FATAL_ERROR "make test-module overrides failed:\n${override_error}")
+endif ()
+require_text ("${override_output}" "-DENABLE_ASAN=ON" "module ASAN override")
+require_text ("${override_output}" "-DENABLE_CCACHE=OFF" "module ccache override")
+
+message (STATUS "Module unit-test target topology checks passed")

--- a/tests/scripts/coverage_diagnostics_test.py
+++ b/tests/scripts/coverage_diagnostics_test.py
@@ -226,7 +226,7 @@ class CoverageCMakeTest(unittest.TestCase):
     @staticmethod
     def coverage_scopes(cmake: str, target: str) -> list[str]:
         scopes = []
-        pattern = rf"target_link_libraries\s*\(\s*{re.escape(target)}\b(?P<body>.*?)\)"
+        pattern = rf"target_link_libraries\s*\(\s*{re.escape(target)}(?=\s|\))(?P<body>.*?)\)"
         for match in re.finditer(pattern, cmake, flags=re.DOTALL):
             current_scope = ""
             for token in match.group("body").split():
@@ -272,7 +272,13 @@ class CoverageCMakeTest(unittest.TestCase):
     def test_coverage_test_executables_link_runtime_privately(self):
         cmake = (ROOT / "tests/CMakeLists.txt").read_text(encoding="utf-8")
 
-        self.assertEqual(self.coverage_scopes(cmake, "unittests"), ["PRIVATE"])
+        helper = re.search(
+            r"function\s*\(\s*vsag_add_unittest_executable\s+target\s*\)(.*?)endfunction\s*\(\s*\)",
+            cmake,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(helper)
+        self.assertEqual(self.coverage_scopes(helper.group(1), "${target}"), ["PRIVATE"])
         self.assertEqual(self.coverage_scopes(cmake, "functests"), ["PRIVATE"])
 
 


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2769

## What Changed

- Add 12 stable, module-owned unit-test executables (`unittests_common`, `unittests_algorithm`, `unittests_datacell`, `unittests_impl`, and peers) that reuse the existing Catch2 main and shared fixtures while linking only the selected registration archive.
- Preserve `unittests` as the unchanged aggregate compatibility path for CI, scripts, runtime CASE filtering, sanitizers, and coverage.
- Preserve GNU whole-archive and Apple force-load registration behavior, and keep module executables out of the default all target.
- Add `make test-module MODULE=<name>`, focused topology checks, and English/Chinese developer documentation.

## Test Evidence

- [ ] `make fmt` (exact clang-format 15 is unavailable locally; CI will run it)
- [ ] `make lint` (exact clang-tidy 15 is unavailable locally; CI will run it)
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
Environment: Linux x86_64, GCC 15.2.0, CMake 4.2.3, Ninja 1.13.2

make test-cmake COMPILE_JOBS=6
  PASS (including module target topology and representative Make commands)

Review follow-up validation:
make test-cmake COMPILE_JOBS=16
  PASS: all seven helper scripts; all 12 valid module dry runs; nine invalid
  MODULE cases rejected before configuration, including "common simd".
python3 tests/scripts/coverage_diagnostics_test.py
  PASS: 15 tests.
git diff --check
  PASS

cmake --build build --target unittests --parallel 6
cmake --build build --target unittests_common unittests_algorithm unittests_datacell unittests_impl --parallel 6
./build/tests/unittests_common '[ut][option]'
./build/tests/unittests_algorithm '[ut][sample_train_data]'
./build/tests/unittests_datacell '[ut][AttributeInvertedInterfaceParameter]'
./build/tests/unittests_impl '[ut][DefaultAllocator]'
./build/tests/unittests '[ut][AttributeInvertedInterfaceParameter]'
  PASS

All 12 module executables link and discover 846 tests in total.
Baseline aggregate: 846 tests; final aggregate: 846 tests.

Debug + ASan/UBSan unittests_common '[ut][option]': PASS
Debug + coverage unittests_common '[ut][option]': PASS; .gcda data produced

Controlled Debug timings, ccache disabled, -j6:
- Aggregate clean: 244.15 s before / 199.58 s after; both 619 steps.
  Aggregate CPU was effectively unchanged (848.60 s / 841.41 s); wall time varied with background load.
- Aggregate no-op: 0.12 s before / 0.05 s after.
- Datacell edit: 12.17 s baseline aggregate relink / 8.80 s selective module relink.
- Final aggregate relink after the same edit: 11.03 s.

The selective datacell graph contains its 23 test sources and no algorithm,
implementation, SIMD, or quantizer test compile/archive/link commands.
```

The local GCC 15.2 optimized Release and repository `Sanitize` build types reach the final executable link but reproduce an existing production HGraph template-specialization undefined symbol. Debug, Debug+ASan/UBSan, and coverage link and run. This change does not modify HGraph; CI remains the authority for supported Release/sanitizer toolchains.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: none for the aggregate suite; new opt-in developer targets only

## Performance and Concurrency Impact

- Performance impact: improves selective unit-test relinking; aggregate build work remains unchanged
- Concurrency/thread-safety impact: none

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [x] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: agent build guide and English/Chinese testing guides

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the single commit to restore the former aggregate-only target definition

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
