### PR TITLE
perf(build): reduce flatten factory compile and lint hotspots

### DIFF
--- a/src/datacell/flatten_datacell_factory.cpp
+++ b/src/datacell/flatten_datacell_factory.cpp
@@ -1,0 +1,46 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_interface_factory.h"
+#include "index_common_param.h"
+
+namespace vsag {
+
+FlattenInterfacePtr
+make_flatten_data_cell_l2(const FlattenInterfaceParamPtr& param,
+                          const IndexCommonParam& common_param);
+
+FlattenInterfacePtr
+make_flatten_data_cell_ip(const FlattenInterfaceParamPtr& param,
+                          const IndexCommonParam& common_param);
+
+FlattenInterfacePtr
+make_flatten_data_cell_cosine(const FlattenInterfaceParamPtr& param,
+                              const IndexCommonParam& common_param);
+
+FlattenInterfacePtr
+MakeFlattenDataCell(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
+    if (common_param.metric_ == MetricType::METRIC_TYPE_L2SQR) {
+        return make_flatten_data_cell_l2(param, common_param);
+    }
+    if (common_param.metric_ == MetricType::METRIC_TYPE_IP) {
+        return make_flatten_data_cell_ip(param, common_param);
+    }
+    if (common_param.metric_ == MetricType::METRIC_TYPE_COSINE) {
+        return make_flatten_data_cell_cosine(param, common_param);
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/datacell/flatten_datacell_factory_cosine.cpp
+++ b/src/datacell/flatten_datacell_factory_cosine.cpp
@@ -1,0 +1,25 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_datacell_factory_impl.h"
+
+namespace vsag {
+
+FlattenInterfacePtr
+make_flatten_data_cell_cosine(const FlattenInterfaceParamPtr& param,
+                              const IndexCommonParam& common_param) {
+    return MakeFlattenDataCellForMetric<MetricType::METRIC_TYPE_COSINE>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/datacell/flatten_datacell_factory_impl.h
+++ b/src/datacell/flatten_datacell_factory_impl.h
@@ -1,0 +1,179 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "flatten_datacell.h"
+#include "inner_string_params.h"
+#include "io/io_headers.h"
+#include "quantization/int8_quantizer.h"
+#include "quantization/quantizer_adapter.h"
+#include "quantization/quantizer_headers.h"
+#include "quantization/transform_quantization/transform_quantizer_parameter.h"
+#include "rabitq_split_datacell_factory.h"
+
+namespace vsag {
+
+template <typename QuantTmpl, typename IOTmpl>
+FlattenInterfacePtr
+MakeFlattenDataCellInstance(const FlattenInterfaceParamPtr& param,
+                            const IndexCommonParam& common_param) {
+    if (param->name == FLATTEN_DATA_CELL) {
+        return std::make_shared<FlattenDataCell<QuantTmpl, FixedLayout<IOTmpl>>>(
+            param->quantizer_parameter, param->io_parameter, common_param);
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("Unknown flatten interface name: {}", param->name));
+}
+
+template <typename QuantizerT, typename IOTmpl, MetricType metric>
+FlattenInterfacePtr
+MakeFlattenDataCellInstanceWithTQ(const FlattenInterfaceParamPtr& param,
+                                  const IndexCommonParam& common_param,
+                                  bool is_transform_quantizer) {
+    if (is_transform_quantizer) {
+        return MakeFlattenDataCellInstance<TransformQuantizer<QuantizerT, metric>, IOTmpl>(
+            param, common_param);
+    }
+    return MakeFlattenDataCellInstance<QuantizerT, IOTmpl>(param, common_param);
+}
+
+template <MetricType metric, typename IOTmpl>
+FlattenInterfacePtr
+MakeFlattenDataCellInstance(const FlattenInterfaceParamPtr& param,
+                            const IndexCommonParam& common_param) {
+    const std::string quantization_string = param->quantizer_parameter->GetTypeName();
+
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_INT8) {
+            return MakeFlattenDataCellInstance<INT8Quantizer<metric>, IOTmpl>(param, common_param);
+        }
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
+            return MakeFlattenDataCellInstance<QuantizerAdapter<ProductQuantizer<metric>, int8_t>,
+                                               IOTmpl>(param, common_param);
+        }
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("INT8 data type does not support {} quantization", quantization_string));
+    }
+
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_FP16 ||
+        common_param.data_type_ == DataTypes::DATA_TYPE_BF16) {
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_FP16) {
+            return MakeFlattenDataCellInstance<QuantizerAdapter<FP16Quantizer<metric>, uint16_t>,
+                                               IOTmpl>(param, common_param);
+        }
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_BF16) {
+            return MakeFlattenDataCellInstance<QuantizerAdapter<BF16Quantizer<metric>, uint16_t>,
+                                               IOTmpl>(param, common_param);
+        }
+        if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
+            return MakeFlattenDataCellInstance<QuantizerAdapter<ProductQuantizer<metric>, uint16_t>,
+                                               IOTmpl>(param, common_param);
+        }
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("FP16/BF16 data type does not support {} quantization",
+                                        quantization_string));
+    }
+
+    auto actual_quantization = quantization_string;
+    const bool is_transform_quantizer = quantization_string == QUANTIZATION_TYPE_VALUE_TQ;
+    if (is_transform_quantizer) {
+        const auto tq_param =
+            std::dynamic_pointer_cast<TransformQuantizerParameter>(param->quantizer_parameter);
+        if (not tq_param) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Expected TransformQuantizerParameter for TQ quantization");
+        }
+        actual_quantization = tq_param->GetBottomQuantizationName();
+    }
+
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_SQ8) {
+        return MakeFlattenDataCellInstanceWithTQ<SQ8Quantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_FP32) {
+        return MakeFlattenDataCellInstanceWithTQ<FP32Quantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_SQ4) {
+        return MakeFlattenDataCellInstanceWithTQ<SQ4Quantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM) {
+        return MakeFlattenDataCellInstanceWithTQ<SQ4UniformQuantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
+        return MakeFlattenDataCellInstanceWithTQ<SQ8UniformQuantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_BF16) {
+        return MakeFlattenDataCellInstanceWithTQ<BF16Quantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_FP16) {
+        return MakeFlattenDataCellInstanceWithTQ<FP16Quantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_PQ) {
+        return MakeFlattenDataCellInstanceWithTQ<ProductQuantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_PQFS) {
+        return MakeFlattenDataCellInstanceWithTQ<PQFastScanQuantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+    if (actual_quantization == QUANTIZATION_TYPE_VALUE_RABITQ) {
+        if (param->name == RABITQ_SPLIT_DATA_CELL) {
+            return MakeRaBitQSplitDataCell(param, common_param, is_transform_quantizer);
+        }
+        return MakeFlattenDataCellInstanceWithTQ<RaBitQuantizer<metric>, IOTmpl, metric>(
+            param, common_param, is_transform_quantizer);
+    }
+
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("Unsupported quantization type: {}", actual_quantization));
+}
+
+template <MetricType metric>
+FlattenInterfacePtr
+MakeFlattenDataCellForMetric(const FlattenInterfaceParamPtr& param,
+                             const IndexCommonParam& common_param) {
+    const auto& io_type = param->io_parameter->GetTypeName();
+    if (io_type == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        return MakeFlattenDataCellInstance<metric, MemoryBlockIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_MEMORY_IO) {
+        return MakeFlattenDataCellInstance<metric, MemoryIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_BUFFER_IO) {
+        return MakeFlattenDataCellInstance<metric, BufferIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_ASYNC_IO) {
+        return MakeFlattenDataCellInstance<metric, AsyncIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_URING_IO) {
+        return MakeFlattenDataCellInstance<metric, UringIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_MMAP_IO) {
+        return MakeFlattenDataCellInstance<metric, MMapIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_READER_IO) {
+        return MakeFlattenDataCellInstance<metric, ReaderIO>(param, common_param);
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/datacell/flatten_datacell_factory_ip.cpp
+++ b/src/datacell/flatten_datacell_factory_ip.cpp
@@ -1,0 +1,25 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_datacell_factory_impl.h"
+
+namespace vsag {
+
+FlattenInterfacePtr
+make_flatten_data_cell_ip(const FlattenInterfaceParamPtr& param,
+                          const IndexCommonParam& common_param) {
+    return MakeFlattenDataCellForMetric<MetricType::METRIC_TYPE_IP>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/datacell/flatten_datacell_factory_l2.cpp
+++ b/src/datacell/flatten_datacell_factory_l2.cpp
@@ -1,0 +1,25 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_datacell_factory_impl.h"
+
+namespace vsag {
+
+FlattenInterfacePtr
+make_flatten_data_cell_l2(const FlattenInterfaceParamPtr& param,
+                          const IndexCommonParam& common_param) {
+    return MakeFlattenDataCellForMetric<MetricType::METRIC_TYPE_L2SQR>(param, common_param);
+}
+
+}  // namespace vsag

--- a/src/datacell/flatten_interface.cpp
+++ b/src/datacell/flatten_interface.cpp
@@ -14,18 +14,9 @@
 
 #include "flatten_interface.h"
 
-#include "flatten_datacell.h"
+#include "flatten_interface_factory.h"
 #include "index_common_param.h"
 #include "inner_string_params.h"
-#include "io/io_headers.h"
-#include "multi_vector_datacell.h"
-#include "quantization/int8_quantizer.h"
-#include "quantization/quantizer_adapter.h"
-#include "quantization/quantizer_headers.h"
-#include "quantization/sparse_quantization/sparse_quantizer.h"
-#include "quantization/transform_quantization/transform_quantizer_parameter.h"
-#include "rabitq_split_datacell_factory.h"
-#include "sparse_vector_datacell.h"
 
 namespace vsag {
 
@@ -34,237 +25,16 @@ FlattenInterface::ExportCommonParam() {
     throw VsagException(ErrorType::INTERNAL_ERROR, "ExportCommonParam is not implemented");
 }
 
-template <typename QuantTemp, typename IOTemp>
-static FlattenInterfacePtr
-make_instance_flatten(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
-    auto& io_param = param->io_parameter;
-    auto& quantizer_param = param->quantizer_parameter;
-    if (param->name == FLATTEN_DATA_CELL) {
-        return std::make_shared<FlattenDataCell<QuantTemp, FixedLayout<IOTemp>>>(
-            quantizer_param, io_param, common_param);
-    }
-    throw VsagException(ErrorType::INVALID_ARGUMENT,
-                        fmt::format("Unknown flatten interface name: {}", param->name));
-}
-template <typename QuantTemp, typename IOTemp>
-static FlattenInterfacePtr
-make_instance_multi_vector(const FlattenInterfaceParamPtr& param,
-                           const IndexCommonParam& common_param) {
-    auto& io_param = param->io_parameter;
-    auto& quantizer_param = param->quantizer_parameter;
-
-    if (param->name == MULTI_VECTOR_DATA_CELL) {
-        return std::make_shared<MultiVectorDataCell<QuantTemp, IOTemp>>(
-            quantizer_param, io_param, common_param);
-    }
-    throw VsagException(ErrorType::INVALID_ARGUMENT,
-                        fmt::format("Unknown flatten interface name: {}", param->name));
-}
-
-template <typename QuantTemp, typename IOTemp>
-static FlattenInterfacePtr
-make_instance_sparse(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
-    auto& io_param = param->io_parameter;
-    auto& quantizer_param = param->quantizer_parameter;
-
-    if (param->name == SPARSE_VECTOR_DATA_CELL) {
-        return std::make_shared<SparseVectorDataCell<QuantTemp, IOTemp>>(
-            quantizer_param, io_param, common_param);
-    }
-    throw VsagException(ErrorType::INVALID_ARGUMENT,
-                        fmt::format("Unknown flatten interface name: {}", param->name));
-}
-
-template <typename QuantizerType, typename IOTemp, MetricType metric>
-static FlattenInterfacePtr
-make_instance_with_tq(const FlattenInterfaceParamPtr& param,
-                      const IndexCommonParam& common_param,
-                      bool is_transform_quantizer) {
-    if (is_transform_quantizer) {
-        return make_instance_flatten<TransformQuantizer<QuantizerType, metric>, IOTemp>(
-            param, common_param);
-    }
-    return make_instance_flatten<QuantizerType, IOTemp>(param, common_param);
-}
-
-template <MetricType metric, typename IOTemp>
-static FlattenInterfacePtr
-make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
-    if (param->name == MULTI_VECTOR_DATA_CELL) {
-        std::string quantization_string = param->quantizer_parameter->GetTypeName();
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_FP32) {
-            return make_instance_multi_vector<FP32Quantizer<metric>, IOTemp>(param, common_param);
-        }
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_FP16) {
-            return make_instance_multi_vector<FP16Quantizer<metric>, IOTemp>(param, common_param);
-        }
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_BF16) {
-            return make_instance_multi_vector<BF16Quantizer<metric>, IOTemp>(param, common_param);
-        }
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
-            return make_instance_multi_vector<SQ8UniformQuantizer<metric>, IOTemp>(param,
-                                                                                   common_param);
-        }
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_INT8) {
-            return make_instance_multi_vector<INT8Quantizer<metric>, IOTemp>(param, common_param);
-        }
-        throw VsagException(
-            ErrorType::INVALID_ARGUMENT,
-            fmt::format("multi-vector datacell does not support quantization type: {}",
-                        quantization_string));
-    }
-
-    std::string quantization_string = param->quantizer_parameter->GetTypeName();
-
-    // Handle INT8 data type specially
-    if (common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_INT8) {
-            return make_instance_flatten<INT8Quantizer<metric>, IOTemp>(param, common_param);
-        }
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
-            return make_instance_flatten<QuantizerAdapter<ProductQuantizer<metric>, int8_t>,
-                                         IOTemp>(param, common_param);
-        }
-        throw VsagException(
-            ErrorType::INVALID_ARGUMENT,
-            fmt::format("INT8 data type does not support {} quantization", quantization_string));
-    }
-
-    // Handle FP16/BF16 data type specially
-    if (common_param.data_type_ == DataTypes::DATA_TYPE_FP16 ||
-        common_param.data_type_ == DataTypes::DATA_TYPE_BF16) {
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_FP16) {
-            return make_instance_flatten<QuantizerAdapter<FP16Quantizer<metric>, uint16_t>, IOTemp>(
-                param, common_param);
-        }
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_BF16) {
-            return make_instance_flatten<QuantizerAdapter<BF16Quantizer<metric>, uint16_t>, IOTemp>(
-                param, common_param);
-        }
-        if (quantization_string == QUANTIZATION_TYPE_VALUE_PQ) {
-            return make_instance_flatten<QuantizerAdapter<ProductQuantizer<metric>, uint16_t>,
-                                         IOTemp>(param, common_param);
-        }
-        throw VsagException(ErrorType::INVALID_ARGUMENT,
-                            fmt::format("FP16/BF16 data type does not support {} quantization",
-                                        quantization_string));
-    }
-
-    // Determine the actual quantization type to use
-    auto actual_quant_type = quantization_string;
-    bool is_transform_quantizer = (quantization_string == QUANTIZATION_TYPE_VALUE_TQ);
-
-    if (is_transform_quantizer) {
-        auto tq_param =
-            std::dynamic_pointer_cast<TransformQuantizerParameter>(param->quantizer_parameter);
-        if (not tq_param) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT,
-                                "Expected TransformQuantizerParameter for TQ quantization");
-        }
-        actual_quant_type = tq_param->GetBottomQuantizationName();
-    }
-
-    // Dispatch based on the resolved quantization type
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ8) {
-        return make_instance_with_tq<SQ8Quantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_FP32) {
-        return make_instance_with_tq<FP32Quantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ4) {
-        return make_instance_with_tq<SQ4Quantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM) {
-        return make_instance_with_tq<SQ4UniformQuantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
-        return make_instance_with_tq<SQ8UniformQuantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_BF16) {
-        return make_instance_with_tq<BF16Quantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_FP16) {
-        return make_instance_with_tq<FP16Quantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_PQ) {
-        return make_instance_with_tq<ProductQuantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_PQFS) {
-        return make_instance_with_tq<PQFastScanQuantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_RABITQ) {
-        if (param->name == RABITQ_SPLIT_DATA_CELL) {
-            return MakeRaBitQSplitDataCell(param, common_param, is_transform_quantizer);
-        }
-        return make_instance_with_tq<RaBitQuantizer<metric>, IOTemp, metric>(
-            param, common_param, is_transform_quantizer);
-    }
-    if (actual_quant_type == QUANTIZATION_TYPE_VALUE_SPARSE and not is_transform_quantizer) {
-        if constexpr (metric == MetricType::METRIC_TYPE_IP) {
-            return make_instance_sparse<SparseQuantizer<metric>, IOTemp>(param, common_param);
-        } else {
-            throw VsagException(ErrorType::INVALID_ARGUMENT,
-                                fmt::format("Sparse quantization only supports IP metric, got {}",
-                                            static_cast<int>(metric)));
-        }
-    }
-
-    // Unsupported quantization type
-    throw VsagException(ErrorType::INVALID_ARGUMENT,
-                        fmt::format("Unsupported quantization type: {}", actual_quant_type));
-}
-
-template <typename IOTemp>
-static FlattenInterfacePtr
-make_instance(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param) {
-    auto metric = common_param.metric_;
-    if (metric == MetricType::METRIC_TYPE_L2SQR) {
-        return make_instance<MetricType::METRIC_TYPE_L2SQR, IOTemp>(param, common_param);
-    }
-    if (metric == MetricType::METRIC_TYPE_IP) {
-        return make_instance<MetricType::METRIC_TYPE_IP, IOTemp>(param, common_param);
-    }
-    if (metric == MetricType::METRIC_TYPE_COSINE) {
-        return make_instance<MetricType::METRIC_TYPE_COSINE, IOTemp>(param, common_param);
-    }
-    return nullptr;
-}
-
 FlattenInterfacePtr
 FlattenInterface::MakeInstance(const FlattenInterfaceParamPtr& param,
                                const IndexCommonParam& common_param) {
-    auto io_type_name = param->io_parameter->GetTypeName();
-    if (io_type_name == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
-        return make_instance<MemoryBlockIO>(param, common_param);
+    if (param->name == MULTI_VECTOR_DATA_CELL) {
+        return MakeMultiVectorDataCell(param, common_param);
     }
-    if (io_type_name == IO_TYPE_VALUE_MEMORY_IO) {
-        return make_instance<MemoryIO>(param, common_param);
+    if (param->name == SPARSE_VECTOR_DATA_CELL) {
+        return MakeSparseVectorDataCell(param, common_param);
     }
-    if (io_type_name == IO_TYPE_VALUE_BUFFER_IO) {
-        return make_instance<BufferIO>(param, common_param);
-    }
-    if (io_type_name == IO_TYPE_VALUE_ASYNC_IO) {
-        return make_instance<AsyncIO>(param, common_param);
-    }
-    if (io_type_name == IO_TYPE_VALUE_URING_IO) {
-        return make_instance<UringIO>(param, common_param);
-    }
-    if (io_type_name == IO_TYPE_VALUE_MMAP_IO) {
-        return make_instance<MMapIO>(param, common_param);
-    }
-    if (io_type_name == IO_TYPE_VALUE_READER_IO) {
-        return make_instance<ReaderIO>(param, common_param);
-    }
-    return nullptr;
+    return MakeFlattenDataCell(param, common_param);
 }
 
 }  // namespace vsag

--- a/src/datacell/flatten_interface_factory.h
+++ b/src/datacell/flatten_interface_factory.h
@@ -1,0 +1,32 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "flatten_interface.h"
+
+namespace vsag {
+
+FlattenInterfacePtr
+MakeFlattenDataCell(const FlattenInterfaceParamPtr& param, const IndexCommonParam& common_param);
+
+FlattenInterfacePtr
+MakeMultiVectorDataCell(const FlattenInterfaceParamPtr& param,
+                        const IndexCommonParam& common_param);
+
+FlattenInterfacePtr
+MakeSparseVectorDataCell(const FlattenInterfaceParamPtr& param,
+                         const IndexCommonParam& common_param);
+
+}  // namespace vsag

--- a/src/datacell/flatten_interface_factory_test.cpp
+++ b/src/datacell/flatten_interface_factory_test.cpp
@@ -1,0 +1,244 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+#include <tuple>
+
+#include "flatten_datacell.h"
+#include "flatten_datacell_parameter.h"
+#include "impl/allocator/safe_allocator.h"
+#include "index_common_param.h"
+#include "inner_string_params.h"
+#include "io/io_headers.h"
+#include "multi_vector_datacell.h"
+#include "multi_vector_datacell_parameter.h"
+#include "quantization/fp32_quantizer.h"
+#include "quantization/quantizer_parameter.h"
+#include "quantization/sparse_quantization/sparse_quantizer.h"
+#include "quantization/transform_quantization/transform_quantizer.h"
+#include "quantization/transform_quantization/transform_quantizer_parameter.h"
+#include "sparse_vector_datacell.h"
+#include "sparse_vector_datacell_parameter.h"
+#include "unittest.h"
+
+namespace vsag {
+namespace {
+
+IOParamPtr
+MakeFactoryIOParam(const std::string& io_type, const std::string& path) {
+    JsonType json;
+    json[TYPE_KEY].SetString(io_type);
+    json[IO_FILE_PATH_KEY].SetString(path);
+    return IOParameter::GetIOParameterByJson(json);
+}
+
+IndexCommonParam
+MakeFactoryCommonParam(MetricType metric = MetricType::METRIC_TYPE_IP) {
+    IndexCommonParam common_param;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    common_param.dim_ = 16;
+    common_param.metric_ = metric;
+    return common_param;
+}
+
+FlattenDataCellParamPtr
+MakeFlattenFactoryParam(const std::string& quantization,
+                        const std::string& io_type,
+                        const std::string& path,
+                        bool transform = false) {
+    auto param = std::make_shared<FlattenDataCellParameter>();
+    param->io_parameter = MakeFactoryIOParam(io_type, path);
+    if (transform) {
+        param->quantizer_parameter =
+            TransformQuantizerParameter::CreateDefault("rom," + quantization);
+    } else {
+        param->quantizer_parameter = QuantizerParameter::CreateDefault(quantization);
+    }
+    return param;
+}
+
+MultiVectorDataCellParamPtr
+MakeMultiVectorFactoryParam(const std::string& quantization,
+                            const std::string& io_type,
+                            const std::string& path) {
+    auto param = std::make_shared<MultiVectorDataCellParameter>();
+    param->io_parameter = MakeFactoryIOParam(io_type, path);
+    param->quantizer_parameter = QuantizerParameter::CreateDefault(quantization);
+    return param;
+}
+
+SparseVectorDataCellParamPtr
+MakeSparseFactoryParam(const std::string& io_type, const std::string& path) {
+    auto param = std::make_shared<SparseVectorDataCellParameter>();
+    param->io_parameter = MakeFactoryIOParam(io_type, path);
+    param->quantizer_parameter = QuantizerParameter::CreateDefault(QUANTIZATION_TYPE_VALUE_SPARSE);
+    return param;
+}
+
+template <typename IOTmpl>
+void
+CheckFactoryIO(const std::string& io_type, fixtures::TempDir& dir) {
+    auto common_param = MakeFactoryCommonParam();
+
+    auto flatten_param = MakeFlattenFactoryParam(
+        QUANTIZATION_TYPE_VALUE_FP32, io_type, dir.GenerateRandomFile(false));
+    auto flatten = FlattenInterface::MakeInstance(flatten_param, common_param);
+    using FlattenCell =
+        FlattenDataCell<FP32Quantizer<MetricType::METRIC_TYPE_IP>, FixedLayout<IOTmpl>>;
+    REQUIRE(std::dynamic_pointer_cast<FlattenCell>(flatten) != nullptr);
+
+    auto multi_param = MakeMultiVectorFactoryParam(
+        QUANTIZATION_TYPE_VALUE_FP32, io_type, dir.GenerateRandomFile(false));
+    auto multi = FlattenInterface::MakeInstance(multi_param, common_param);
+    using MultiVectorCell = MultiVectorDataCell<FP32Quantizer<MetricType::METRIC_TYPE_IP>, IOTmpl>;
+    REQUIRE(std::dynamic_pointer_cast<MultiVectorCell>(multi) != nullptr);
+
+    common_param.data_type_ = DataTypes::DATA_TYPE_SPARSE;
+    common_param.repr_ = RecordRepr::SPARSE;
+    auto sparse_param = MakeSparseFactoryParam(io_type, dir.GenerateRandomFile(false));
+    auto sparse = FlattenInterface::MakeInstance(sparse_param, common_param);
+    using SparseCell = SparseVectorDataCell<SparseQuantizer<MetricType::METRIC_TYPE_IP>, IOTmpl>;
+    REQUIRE(std::dynamic_pointer_cast<SparseCell>(sparse) != nullptr);
+}
+
+template <MetricType metric>
+void
+CheckFlattenMetricTypes() {
+    auto common_param = MakeFactoryCommonParam(metric);
+    auto param = MakeFlattenFactoryParam(
+        QUANTIZATION_TYPE_VALUE_FP32, IO_TYPE_VALUE_MEMORY_IO, std::string());
+    auto flatten = FlattenInterface::MakeInstance(param, common_param);
+    using FlattenCell = FlattenDataCell<FP32Quantizer<metric>, FixedLayout<MemoryIO>>;
+    REQUIRE(std::dynamic_pointer_cast<FlattenCell>(flatten) != nullptr);
+
+    auto transform_param = MakeFlattenFactoryParam(
+        QUANTIZATION_TYPE_VALUE_FP32, IO_TYPE_VALUE_MEMORY_IO, std::string(), true);
+    auto transformed = FlattenInterface::MakeInstance(transform_param, common_param);
+    using TransformCell =
+        FlattenDataCell<TransformQuantizer<FP32Quantizer<metric>, metric>, FixedLayout<MemoryIO>>;
+    REQUIRE(std::dynamic_pointer_cast<TransformCell>(transformed) != nullptr);
+}
+
+}  // namespace
+
+TEST_CASE("FlattenInterface factory dispatches every IO for each data-cell family",
+          "[ut][FlattenInterface][factory]") {
+    fixtures::TempDir dir("flatten_interface_factory");
+    CheckFactoryIO<MemoryBlockIO>(IO_TYPE_VALUE_BLOCK_MEMORY_IO, dir);
+    CheckFactoryIO<MemoryIO>(IO_TYPE_VALUE_MEMORY_IO, dir);
+    CheckFactoryIO<BufferIO>(IO_TYPE_VALUE_BUFFER_IO, dir);
+    CheckFactoryIO<AsyncIO>(IO_TYPE_VALUE_ASYNC_IO, dir);
+    CheckFactoryIO<UringIO>(IO_TYPE_VALUE_URING_IO, dir);
+    CheckFactoryIO<MMapIO>(IO_TYPE_VALUE_MMAP_IO, dir);
+    CheckFactoryIO<ReaderIO>(IO_TYPE_VALUE_READER_IO, dir);
+}
+
+TEST_CASE("FlattenInterface factory preserves dense quantizer and data-type dispatch",
+          "[ut][FlattenInterface][factory]") {
+    constexpr std::array<MetricType, 3> metrics = {
+        MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_IP, MetricType::METRIC_TYPE_COSINE};
+    const std::array<const char*, 10> quantizations = {QUANTIZATION_TYPE_VALUE_SQ8,
+                                                       QUANTIZATION_TYPE_VALUE_FP32,
+                                                       QUANTIZATION_TYPE_VALUE_SQ4,
+                                                       QUANTIZATION_TYPE_VALUE_SQ4_UNIFORM,
+                                                       QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM,
+                                                       QUANTIZATION_TYPE_VALUE_BF16,
+                                                       QUANTIZATION_TYPE_VALUE_FP16,
+                                                       QUANTIZATION_TYPE_VALUE_PQ,
+                                                       QUANTIZATION_TYPE_VALUE_PQFS,
+                                                       QUANTIZATION_TYPE_VALUE_RABITQ};
+
+    for (const auto metric : metrics) {
+        for (const auto* quantization : quantizations) {
+            CAPTURE(metric, quantization);
+            auto common_param = MakeFactoryCommonParam(metric);
+            auto param =
+                MakeFlattenFactoryParam(quantization, IO_TYPE_VALUE_MEMORY_IO, std::string());
+            auto flatten = FlattenInterface::MakeInstance(param, common_param);
+            REQUIRE(flatten != nullptr);
+            CHECK(flatten->GetQuantizerName() == quantization);
+
+            auto transform_param =
+                MakeFlattenFactoryParam(quantization, IO_TYPE_VALUE_MEMORY_IO, std::string(), true);
+            auto transformed = FlattenInterface::MakeInstance(transform_param, common_param);
+            REQUIRE(transformed != nullptr);
+            CHECK(transformed->GetQuantizerName() == QUANTIZATION_TYPE_VALUE_TQ);
+        }
+    }
+
+    CheckFlattenMetricTypes<MetricType::METRIC_TYPE_L2SQR>();
+    CheckFlattenMetricTypes<MetricType::METRIC_TYPE_IP>();
+    CheckFlattenMetricTypes<MetricType::METRIC_TYPE_COSINE>();
+
+    const std::array<std::tuple<DataTypes, const char*, const char*>, 8> typed_quantizations = {
+        std::make_tuple(
+            DataTypes::DATA_TYPE_INT8, QUANTIZATION_TYPE_VALUE_INT8, QUANTIZATION_TYPE_VALUE_INT8),
+        std::make_tuple(
+            DataTypes::DATA_TYPE_INT8, QUANTIZATION_TYPE_VALUE_PQ, "QUANTIZATION_ADAPTER_pq"),
+        std::make_tuple(
+            DataTypes::DATA_TYPE_FP16, QUANTIZATION_TYPE_VALUE_FP16, "QUANTIZATION_ADAPTER_fp16"),
+        std::make_tuple(
+            DataTypes::DATA_TYPE_FP16, QUANTIZATION_TYPE_VALUE_BF16, "QUANTIZATION_ADAPTER_bf16"),
+        std::make_tuple(
+            DataTypes::DATA_TYPE_FP16, QUANTIZATION_TYPE_VALUE_PQ, "QUANTIZATION_ADAPTER_pq"),
+        std::make_tuple(
+            DataTypes::DATA_TYPE_BF16, QUANTIZATION_TYPE_VALUE_FP16, "QUANTIZATION_ADAPTER_fp16"),
+        std::make_tuple(
+            DataTypes::DATA_TYPE_BF16, QUANTIZATION_TYPE_VALUE_BF16, "QUANTIZATION_ADAPTER_bf16"),
+        std::make_tuple(
+            DataTypes::DATA_TYPE_BF16, QUANTIZATION_TYPE_VALUE_PQ, "QUANTIZATION_ADAPTER_pq")};
+    for (const auto& [data_type, quantization, quantizer_name] : typed_quantizations) {
+        CAPTURE(data_type, quantization);
+        auto common_param = MakeFactoryCommonParam();
+        common_param.data_type_ = data_type;
+        auto param = MakeFlattenFactoryParam(quantization, IO_TYPE_VALUE_MEMORY_IO, std::string());
+        auto flatten = FlattenInterface::MakeInstance(param, common_param);
+        REQUIRE(flatten != nullptr);
+        CHECK(flatten->GetQuantizerName() == quantizer_name);
+    }
+}
+
+TEST_CASE("FlattenInterface factory preserves multi-vector and sparse metric dispatch",
+          "[ut][FlattenInterface][factory]") {
+    constexpr std::array<MetricType, 3> metrics = {
+        MetricType::METRIC_TYPE_L2SQR, MetricType::METRIC_TYPE_IP, MetricType::METRIC_TYPE_COSINE};
+    const std::array<const char*, 5> quantizations = {QUANTIZATION_TYPE_VALUE_FP32,
+                                                      QUANTIZATION_TYPE_VALUE_FP16,
+                                                      QUANTIZATION_TYPE_VALUE_BF16,
+                                                      QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM,
+                                                      QUANTIZATION_TYPE_VALUE_INT8};
+    for (const auto metric : metrics) {
+        for (const auto* quantization : quantizations) {
+            CAPTURE(metric, quantization);
+            auto common_param = MakeFactoryCommonParam(metric);
+            auto param =
+                MakeMultiVectorFactoryParam(quantization, IO_TYPE_VALUE_MEMORY_IO, std::string());
+            auto multi = FlattenInterface::MakeInstance(param, common_param);
+            REQUIRE(multi != nullptr);
+            CHECK(multi->GetQuantizerName() == quantization);
+            CHECK(multi->GetMetricType() == metric);
+        }
+    }
+
+    auto sparse_param = MakeSparseFactoryParam(IO_TYPE_VALUE_MEMORY_IO, std::string());
+    auto common_param = MakeFactoryCommonParam(MetricType::METRIC_TYPE_IP);
+    common_param.data_type_ = DataTypes::DATA_TYPE_SPARSE;
+    REQUIRE(FlattenInterface::MakeInstance(sparse_param, common_param) != nullptr);
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    REQUIRE_THROWS_AS(FlattenInterface::MakeInstance(sparse_param, common_param), VsagException);
+    common_param.metric_ = MetricType::METRIC_TYPE_COSINE;
+    REQUIRE_THROWS_AS(FlattenInterface::MakeInstance(sparse_param, common_param), VsagException);
+}
+
+}  // namespace vsag

--- a/src/datacell/multi_vector_datacell.h
+++ b/src/datacell/multi_vector_datacell.h
@@ -20,6 +20,7 @@
 #include "io/memory_block_io/memory_block_io.h"
 #include "layout/variable_record_layout.h"
 #include "quantization/multi_vector_computer.h"
+#include "quantization/quantizer.h"
 #include "typing.h"
 #include "vsag/dataset.h"
 

--- a/src/datacell/multi_vector_datacell_factory.cpp
+++ b/src/datacell/multi_vector_datacell_factory.cpp
@@ -1,0 +1,117 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_interface_factory.h"
+#include "inner_string_params.h"
+#include "io/io_headers.h"
+#include "multi_vector_datacell.h"
+#include "quantization/int8_quantizer.h"
+#include "quantization/quantizer_headers.h"
+
+namespace vsag {
+
+template <typename QuantizerT, typename IOTmpl>
+FlattenInterfacePtr
+make_multi_vector_data_cell_instance(const FlattenInterfaceParamPtr& param,
+                                     const IndexCommonParam& common_param) {
+    if (param->name == MULTI_VECTOR_DATA_CELL) {
+        return std::make_shared<MultiVectorDataCell<QuantizerT, IOTmpl>>(
+            param->quantizer_parameter, param->io_parameter, common_param);
+    }
+    throw VsagException(ErrorType::INVALID_ARGUMENT,
+                        fmt::format("Unknown flatten interface name: {}", param->name));
+}
+
+template <MetricType metric, typename IOTmpl>
+FlattenInterfacePtr
+make_multi_vector_data_cell_instance(const FlattenInterfaceParamPtr& param,
+                                     const IndexCommonParam& common_param) {
+    if (param->name != MULTI_VECTOR_DATA_CELL) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("Unknown flatten interface name: {}", param->name));
+    }
+    const auto& quantization = param->quantizer_parameter->GetTypeName();
+    if (quantization == QUANTIZATION_TYPE_VALUE_FP32) {
+        return make_multi_vector_data_cell_instance<FP32Quantizer<metric>, IOTmpl>(param,
+                                                                                   common_param);
+    }
+    if (quantization == QUANTIZATION_TYPE_VALUE_FP16) {
+        return make_multi_vector_data_cell_instance<FP16Quantizer<metric>, IOTmpl>(param,
+                                                                                   common_param);
+    }
+    if (quantization == QUANTIZATION_TYPE_VALUE_BF16) {
+        return make_multi_vector_data_cell_instance<BF16Quantizer<metric>, IOTmpl>(param,
+                                                                                   common_param);
+    }
+    if (quantization == QUANTIZATION_TYPE_VALUE_SQ8_UNIFORM) {
+        return make_multi_vector_data_cell_instance<SQ8UniformQuantizer<metric>, IOTmpl>(
+            param, common_param);
+    }
+    if (quantization == QUANTIZATION_TYPE_VALUE_INT8) {
+        return make_multi_vector_data_cell_instance<INT8Quantizer<metric>, IOTmpl>(param,
+                                                                                   common_param);
+    }
+    throw VsagException(
+        ErrorType::INVALID_ARGUMENT,
+        fmt::format("multi-vector datacell does not support quantization type: {}", quantization));
+}
+
+template <typename IOTmpl>
+FlattenInterfacePtr
+make_multi_vector_data_cell_for_io(const FlattenInterfaceParamPtr& param,
+                                   const IndexCommonParam& common_param) {
+    if (common_param.metric_ == MetricType::METRIC_TYPE_L2SQR) {
+        return make_multi_vector_data_cell_instance<MetricType::METRIC_TYPE_L2SQR, IOTmpl>(
+            param, common_param);
+    }
+    if (common_param.metric_ == MetricType::METRIC_TYPE_IP) {
+        return make_multi_vector_data_cell_instance<MetricType::METRIC_TYPE_IP, IOTmpl>(
+            param, common_param);
+    }
+    if (common_param.metric_ == MetricType::METRIC_TYPE_COSINE) {
+        return make_multi_vector_data_cell_instance<MetricType::METRIC_TYPE_COSINE, IOTmpl>(
+            param, common_param);
+    }
+    return nullptr;
+}
+
+FlattenInterfacePtr
+MakeMultiVectorDataCell(const FlattenInterfaceParamPtr& param,
+                        const IndexCommonParam& common_param) {
+    const auto& io_type = param->io_parameter->GetTypeName();
+    if (io_type == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        return make_multi_vector_data_cell_for_io<MemoryBlockIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_MEMORY_IO) {
+        return make_multi_vector_data_cell_for_io<MemoryIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_BUFFER_IO) {
+        return make_multi_vector_data_cell_for_io<BufferIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_ASYNC_IO) {
+        return make_multi_vector_data_cell_for_io<AsyncIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_URING_IO) {
+        return make_multi_vector_data_cell_for_io<UringIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_MMAP_IO) {
+        return make_multi_vector_data_cell_for_io<MMapIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_READER_IO) {
+        return make_multi_vector_data_cell_for_io<ReaderIO>(param, common_param);
+    }
+    return nullptr;
+}
+
+}  // namespace vsag

--- a/src/datacell/sparse_vector_datacell_factory.cpp
+++ b/src/datacell/sparse_vector_datacell_factory.cpp
@@ -1,0 +1,85 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "flatten_interface_factory.h"
+#include "inner_string_params.h"
+#include "io/io_headers.h"
+#include "quantization/sparse_quantization/sparse_quantizer.h"
+#include "sparse_vector_datacell.h"
+
+namespace vsag {
+
+template <typename IOTmpl>
+FlattenInterfacePtr
+make_sparse_vector_data_cell_instance(const FlattenInterfaceParamPtr& param,
+                                      const IndexCommonParam& common_param) {
+    if (param->name != SPARSE_VECTOR_DATA_CELL) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("Unknown flatten interface name: {}", param->name));
+    }
+    const auto& quantization = param->quantizer_parameter->GetTypeName();
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_INT8) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("INT8 data type does not support {} quantization", quantization));
+    }
+    if (common_param.data_type_ == DataTypes::DATA_TYPE_FP16 ||
+        common_param.data_type_ == DataTypes::DATA_TYPE_BF16) {
+        throw VsagException(
+            ErrorType::INVALID_ARGUMENT,
+            fmt::format("FP16/BF16 data type does not support {} quantization", quantization));
+    }
+    if (common_param.metric_ != MetricType::METRIC_TYPE_IP) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("Sparse quantization only supports IP metric, got {}",
+                                        static_cast<int>(common_param.metric_)));
+    }
+    if (quantization != QUANTIZATION_TYPE_VALUE_SPARSE) {
+        throw VsagException(ErrorType::INVALID_ARGUMENT,
+                            fmt::format("Unsupported quantization type: {}", quantization));
+    }
+    return std::make_shared<
+        SparseVectorDataCell<SparseQuantizer<MetricType::METRIC_TYPE_IP>, IOTmpl>>(
+        param->quantizer_parameter, param->io_parameter, common_param);
+}
+
+FlattenInterfacePtr
+MakeSparseVectorDataCell(const FlattenInterfaceParamPtr& param,
+                         const IndexCommonParam& common_param) {
+    const auto& io_type = param->io_parameter->GetTypeName();
+    if (io_type == IO_TYPE_VALUE_BLOCK_MEMORY_IO) {
+        return make_sparse_vector_data_cell_instance<MemoryBlockIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_MEMORY_IO) {
+        return make_sparse_vector_data_cell_instance<MemoryIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_BUFFER_IO) {
+        return make_sparse_vector_data_cell_instance<BufferIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_ASYNC_IO) {
+        return make_sparse_vector_data_cell_instance<AsyncIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_URING_IO) {
+        return make_sparse_vector_data_cell_instance<UringIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_MMAP_IO) {
+        return make_sparse_vector_data_cell_instance<MMapIO>(param, common_param);
+    }
+    if (io_type == IO_TYPE_VALUE_READER_IO) {
+        return make_sparse_vector_data_cell_instance<ReaderIO>(param, common_param);
+    }
+    return nullptr;
+}
+
+}  // namespace vsag


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Closes: #2798

## What Changed

- Keep `FlattenInterface::MakeInstance` as lightweight data-cell-family dispatch.
- Isolate multi-vector and sparse factory matrices, and shard the dense `FlattenDataCell` matrix into one translation unit per metric, following the existing RaBitQ factory pattern.
- Add focused regression coverage for every I/O route, dense metrics/quantizers/data types, transform quantization, multi-vector dispatch, and sparse IP-only dispatch.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
# Focused Debug, fallback UringIO alias
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=OFF -DENABLE_CCACHE=ON -DENABLE_TESTS=ON -DENABLE_LIBURING=OFF
cmake --build build --target unittests --parallel 96
./build/tests/unittests '[ut][FlattenInterface][factory]' -d yes --allow-running-no-tests
Result: 211 assertions in 3 test cases passed.

# Focused Debug, distinct liburing-enabled UringIO
cmake -S . -B build-uring -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=OFF -DENABLE_CCACHE=ON -DENABLE_TESTS=ON -DENABLE_LIBURING=ON
cmake --build build-uring --target unittests --parallel 96
./build-uring/tests/unittests '[ut][FlattenInterface][factory]' -d yes --allow-running-no-tests
Result: 211 assertions in 3 test cases passed.

# Broad Debug validation
cmake --build build --parallel 96
bash scripts/testing/test_parallel_bg.sh
Result: unit, HGraph functional, and other functional partitions passed. Unit: 85,352,059 assertions in 849 cases; other functional: 1,435,926 assertions in 209 cases.

./build/tests/eval_monitor_test -d yes --allow-running-no-tests
Result: 33 assertions in 5 test cases passed.

# Official Release build
make release COMPILE_JOBS=96
Result: passed.

git diff --check
python3 scripts/linters/check-struct-names.py --root . <changed C/C++ files>
Result: passed.
```

The required clang-format 15 and clang-tidy 15 were unavailable in the validation environment. No substitute version was used; the exact format/lint checks are left to CI.

Controlled compile benchmark environment: Linux x86_64, GCC/G++ 15.2.0, CMake 4.2.3, Ninja 1.13.2, Release/Debug as shown, liburing disabled, ccache bypassed, and warm filesystem cache for both variants.

| Measurement | Before | After (slowest shard) | Change |
| --- | ---: | ---: | ---: |
| Debug object compile wall | 53.08 s | 14.99 s | -71.8% |
| Debug peak RSS | 3,767 MB | 1,271 MB | -66.3% |
| Debug object size | 129,865,040 B | 39,176,416 B | -69.8% |
| Release object compile wall | 191.52 s | 52.53 s | -72.6% |
| Release peak RSS | 5,277 MB | 1,750 MB | -66.8% |
| Release object size | 224,971,736 B | 62,848,832 B | -72.1% |
| Clean Release build wall (`--parallel 96`) | 202.19 s | 75.55 s | -62.6% |
| Clean Release build total CPU | 1,175.60 s | 1,175.25 s | -0.03% |

The before object owned 546 relevant data-cell vtables. The final objects own 150 per dense metric shard, 90 in the multi-vector factory, and 6 in the sparse factory. Aggregate CPU is unchanged rather than shifted upward, while independent shards reduce critical-path wall time and per-compiler memory.

## Compatibility Impact

- API/ABI compatibility: no public API or ABI break; only internal factory organization changed.
- Behavior changes: none intended; all currently supported family, I/O, metric, data-type, quantizer, sparse, and transform-quantizer routes are preserved.

## Performance and Concurrency Impact

- Performance impact: build and lint scalability improved; runtime dispatch remains equivalent.
- Concurrency/thread-safety impact: none.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low; the change moves existing branches and adds matrix-wide regression coverage.
- Rollback plan: revert the single commit to restore the monolithic factory.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
