### PR TITLE
perf(pyramid): reuse RaBitQ split build session

### DIFF
--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -593,6 +593,10 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
         }
     }
 
+    auto codes = construction_codes();
+    FlattenOptimizedBuildContext build_context{thread_pool_, build_thread_count_};
+    auto build_session = codes->CreateOptimizedBuildSession(build_context);
+
     base_codes_->BatchInsertVector(data_vectors, data_num);
     if (has_precise_reorder()) {
         precise_codes_->BatchInsertVector(data_vectors, data_num);
@@ -612,22 +616,12 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
             }
         }
     }
-    auto codes = construction_codes();
-
     if (thread_pool_ != nullptr && hierarchies_.size() > 1) {
-        auto build_flatten = ODescent::CreateBuildFlatten(codes, data_vectors, data_num);
         Vector<std::future<void>> futures(allocator_);
         for (const auto& [hname, h_ptr] : hierarchies_) {
             auto* hierarchy = h_ptr.get();
-            futures.push_back(thread_pool_->GeneralEnqueue([&, codes, build_flatten, hierarchy]() {
-                ODescent builder(odescent_param_,
-                                 codes,
-                                 allocator_,
-                                 nullptr,
-                                 true,
-                                 data_vectors,
-                                 data_num,
-                                 build_flatten);
+            futures.push_back(thread_pool_->GeneralEnqueue([&, codes, hierarchy]() {
+                ODescent builder(odescent_param_, codes, allocator_, nullptr, true);
                 hierarchy->root->Build(builder);
             }));
         }
@@ -635,16 +629,13 @@ Pyramid::build_by_odescent(const DatasetPtr& base) {
             f.get();
         }
     } else {
-        ODescent graph_builder(odescent_param_,
-                               codes,
-                               allocator_,
-                               this->thread_pool_.get(),
-                               true,
-                               data_vectors,
-                               data_num);
+        ODescent graph_builder(odescent_param_, codes, allocator_, this->thread_pool_.get(), true);
         for (const auto& [hname, h_ptr] : hierarchies_) {
             h_ptr->root->Build(graph_builder);
         }
+    }
+    if (build_session != nullptr) {
+        build_session->Commit();
     }
     cur_element_count_ = data_num;
     return {};
@@ -1543,8 +1534,14 @@ Pyramid::ExportModel(const IndexCommonParam& param) const {
 
 std::vector<int64_t>
 Pyramid::Add(const DatasetPtr& base) {
+    auto codes = construction_codes();
+    FlattenOptimizedBuildContext build_context{thread_pool_, build_thread_count_};
+    auto build_session = codes->CreateOptimizedBuildSession(build_context);
     auto batch = prepare_add_batch(base);
     insert_add_batch(base, batch);
+    if (build_session != nullptr) {
+        build_session->Commit();
+    }
     return batch.failed_ids;
 }
 

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -2241,19 +2241,23 @@ Pyramid::add_to_path(Hierarchy& hierarchy,
         if (depth != static_cast<int>(path_slices.size())) {
             child = node->GetChild(path_slices[depth], true);
         }
-        if (no_build_level_index < static_cast<int>(hierarchy.no_build_levels.size()) &&
-            depth == hierarchy.no_build_levels[no_build_level_index]) {
-            node = child;
+        const bool skip_level =
+            no_build_level_index < static_cast<int>(hierarchy.no_build_levels.size()) &&
+            depth == hierarchy.no_build_levels[no_build_level_index];
+        if (skip_level) {
             ++no_build_level_index;
-            continue;
+        } else {
+            add_one_point(hierarchy,
+                          node,
+                          inner_id,
+                          vector,
+                          0,
+                          false,
+                          depth == 0 ? sampled_root_level : std::numeric_limits<int>::min());
         }
-        add_one_point(hierarchy,
-                      node,
-                      inner_id,
-                      vector,
-                      0,
-                      false,
-                      depth == 0 ? sampled_root_level : std::numeric_limits<int>::min());
+        if (child == nullptr) {
+            break;
+        }
         node = child;
     }
 }

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -755,8 +755,6 @@ TEST_CASE("RaBitQSplitDataCell optimized scalar-code build",
     common_param.metric_ = metric;
 
     auto flatten = FlattenInterface::MakeInstance(param, common_param);
-    auto optimized_build = std::dynamic_pointer_cast<FlattenOptimizedBuildInterface>(flatten);
-    REQUIRE(optimized_build != nullptr);
     flatten->Train(vectors.data(), count);
     std::vector<uint8_t> expected_codes(flatten->code_size_ * count);
     for (InnerIdType id = 0; id < count; ++id) {
@@ -768,15 +766,16 @@ TEST_CASE("RaBitQSplitDataCell optimized scalar-code build",
     auto finalize_pool = SafeThreadPool::FactoryDefaultThreadPool();
     finalize_pool->SetPoolSize(4);
     FlattenOptimizedBuildContext build_context{finalize_pool, 4};
-    REQUIRE(optimized_build->BeginOptimizedBuild(build_context));
-    REQUIRE(optimized_build->IsOptimizedBuildActive());
+    auto build_session = flatten->CreateOptimizedBuildSession(build_context);
+    REQUIRE(build_session != nullptr);
+    REQUIRE(flatten->IsOptimizedBuildActive());
     flatten->ShrinkToFit(0);
     REQUIRE_THROWS(flatten->InsertVector(vectors.data()));
     REQUIRE(flatten->TotalCount() == 0);
     flatten->Resize(count);
     flatten->BatchInsertVector(vectors.data(), count);
     REQUIRE(std::isfinite(flatten->ComputePairVectors(0, 1)));
-    auto build_computer = optimized_build->FactoryComputerForBuild(vectors.data(), 0);
+    auto build_computer = flatten->FactoryComputerForBuild(vectors.data(), 0);
     std::vector<InnerIdType> build_ids(count);
     std::iota(build_ids.begin(), build_ids.end(), 0);
     std::vector<float> pair_dists(count);
@@ -823,8 +822,8 @@ TEST_CASE("RaBitQSplitDataCell optimized scalar-code build",
 
     const float build_pair_distance = flatten->ComputePairVectors(0, 2);
 
-    optimized_build->FinalizeOptimizedBuild();
-    REQUIRE_FALSE(optimized_build->IsOptimizedBuildActive());
+    build_session->Commit();
+    REQUIRE_FALSE(flatten->IsOptimizedBuildActive());
     REQUIRE(std::abs(flatten->ComputePairVectors(0, 2) - build_pair_distance) <= 1e-5F);
     flatten->QueryById(id_dists.data(), 0, build_ids.data(), count, &ctx);
     statistics = JsonType::Parse(stats.Dump());
@@ -847,11 +846,23 @@ TEST_CASE("RaBitQSplitDataCell optimized scalar-code build",
     const uint64_t memory_after_finalize = flatten->GetMemoryUsage();
     REQUIRE(memory_after_finalize >=
             static_cast<uint64_t>(flatten->max_capacity_) * flatten->code_size_);
-    REQUIRE(optimized_build->BeginOptimizedBuild(build_context));
-    REQUIRE(flatten->GetMemoryUsage() > memory_after_finalize);
-    optimized_build->AbortOptimizedBuild();
-    REQUIRE_FALSE(optimized_build->IsOptimizedBuildActive());
+    {
+        auto abort_session = flatten->CreateOptimizedBuildSession(build_context);
+        REQUIRE(abort_session != nullptr);
+        REQUIRE(flatten->GetMemoryUsage() > memory_after_finalize);
+    }
+    REQUIRE_FALSE(flatten->IsOptimizedBuildActive());
     REQUIRE(flatten->GetMemoryUsage() == memory_after_finalize);
+
+    // A non-empty session rehydrates old split codes, then mixes them with a newly encoded row.
+    auto incremental_session = flatten->CreateOptimizedBuildSession(build_context);
+    REQUIRE(incremental_session != nullptr);
+    const float active_old_distance = flatten->ComputePairVectors(0, 1);
+    flatten->InsertVector(query.data(), count);
+    const float active_new_distance = flatten->ComputePairVectors(0, count);
+    incremental_session->Commit();
+    REQUIRE(std::abs(flatten->ComputePairVectors(0, 1) - active_old_distance) <= 1e-5F);
+    REQUIRE(std::abs(flatten->ComputePairVectors(0, count) - active_new_distance) <= 1e-5F);
 }
 
 TEST_CASE("RaBitQSplitDataCell waits submitted finalize tasks after enqueue failure",

--- a/src/datacell/flatten_interface.h
+++ b/src/datacell/flatten_interface.h
@@ -25,6 +25,7 @@
 #include "basic_types.h"
 #include "flatten_datacell_parameter.h"
 #include "flatten_interface_parameter.h"
+#include "flatten_optimized_build_interface.h"
 #include "hash_types.h"
 #include "impl/runtime_parameter.h"
 #include "index_common_param_fwd.h"
@@ -106,6 +107,24 @@ public:
 
     virtual ComputerInterfacePtr
     FactoryComputer(const void* query) = 0;
+
+    // Starts an optional temporary build-code representation. The returned session aborts on
+    // destruction unless Commit() succeeds. While it is alive, all regular distance APIs are
+    // required to address the temporary representation transparently.
+    virtual FlattenBuildSessionPtr
+    CreateOptimizedBuildSession(const FlattenOptimizedBuildContext&) {
+        return nullptr;
+    }
+
+    [[nodiscard]] virtual bool
+    IsOptimizedBuildActive() const {
+        return false;
+    }
+
+    virtual ComputerInterfacePtr
+    FactoryComputerForBuild(const void* query, InnerIdType) {
+        return this->FactoryComputer(query);
+    }
 
     virtual void
     Train(const void* data, uint64_t count) = 0;

--- a/src/datacell/flatten_optimized_build_interface.h
+++ b/src/datacell/flatten_optimized_build_interface.h
@@ -30,6 +30,16 @@ struct FlattenOptimizedBuildContext {
     uint64_t thread_count{1};
 };
 
+class FlattenBuildSession {
+public:
+    virtual ~FlattenBuildSession() = default;
+
+    virtual void
+    Commit() = 0;
+};
+
+using FlattenBuildSessionPtr = std::unique_ptr<FlattenBuildSession>;
+
 DEFINE_POINTER(FlattenOptimizedBuildInterface);
 
 class FlattenOptimizedBuildInterface {

--- a/src/datacell/rabitq_split_datacell.h
+++ b/src/datacell/rabitq_split_datacell.h
@@ -75,6 +75,29 @@ public:
         uint64_t code_sum_{0};
     };
 
+    class BuildSession final : public FlattenBuildSession {
+    public:
+        explicit BuildSession(RaBitQSplitDataCell* owner) : owner_(owner) {
+        }
+
+        ~BuildSession() override {
+            if (owner_ != nullptr) {
+                owner_->AbortOptimizedBuild();
+            }
+        }
+
+        void
+        Commit() override {
+            if (owner_ != nullptr) {
+                owner_->FinalizeOptimizedBuild();
+                owner_ = nullptr;
+            }
+        }
+
+    private:
+        RaBitQSplitDataCell* owner_;
+    };
+
     RaBitQSplitDataCell() = default;
 
     explicit RaBitQSplitDataCell(const QuantizerParamPtr& quantization_param,
@@ -469,6 +492,14 @@ public:
         return this->FactoryComputer(query);
     }
 
+    FlattenBuildSessionPtr
+    CreateOptimizedBuildSession(const FlattenOptimizedBuildContext& context) override {
+        if (not this->BeginOptimizedBuild(context)) {
+            return nullptr;
+        }
+        return std::make_unique<BuildSession>(this);
+    }
+
     void
     Train(const void* data, uint64_t count) override {
         if (this->quantizer_) {
@@ -489,6 +520,23 @@ public:
         if (this->max_capacity_ > 0) {
             build_codes->Resize(this->max_capacity_);
             code_sums->resize(this->max_capacity_, 0);
+        }
+
+        // A session may also be used for a non-empty incremental build. Rehydrate the scalar
+        // representation from persisted split codes so old and new IDs share exactly the same
+        // pairwise-distance path without requiring raw vectors.
+        if (this->total_count_ > 0) {
+            ByteBuffer full_code(this->code_size_, this->allocator_);
+            ByteBuffer scalar_code(this->bottom_quantizer().GetScalarCodeSize(), this->allocator_);
+            for (InnerIdType id = 0; id < this->total_count_; ++id) {
+                if (not this->GetCodesById(id, full_code.data)) {
+                    throw VsagException(ErrorType::INTERNAL_ERROR,
+                                        "failed to read persisted split RaBitQ build code");
+                }
+                (*code_sums)[id] =
+                    this->bottom_quantizer().UnpackScalarCode(full_code.data, scalar_code.data);
+                build_codes->Write(id, scalar_code.data);
+            }
         }
         this->optimized_build_scalar_layout_ = build_codes;
         this->optimized_build_code_sums_ = std::move(code_sums);

--- a/src/impl/odescent/odescent_graph_builder.cpp
+++ b/src/impl/odescent/odescent_graph_builder.cpp
@@ -18,10 +18,7 @@
 #include <chrono>
 #include <ios>
 
-#include "datacell/flatten_datacell_parameter.h"
 #include "inner_string_params.h"
-#include "io/memory_io/memory_io_parameter.h"
-#include "quantization/scalar_quantization/scalar_quantizer_parameter.h"
 #include "simd/simd.h"
 #include "utils/linear_congruential_generator.h"
 
@@ -71,33 +68,7 @@ ODescent::Build(const Vector<InnerIdType>& ids_sequence, const GraphInterfacePtr
 
 void
 ODescent::prepare_build_flatten() {
-    if (this->build_flatten_interface_ == nullptr) {
-        this->build_flatten_interface_ = CreateBuildFlatten(
-            this->flatten_interface_, this->build_vectors_, this->build_vector_count_);
-    }
-    this->distance_flatten_interface_ = this->build_flatten_interface_ == nullptr
-                                            ? this->flatten_interface_.get()
-                                            : this->build_flatten_interface_.get();
-}
-
-FlattenInterfacePtr
-ODescent::CreateBuildFlatten(const FlattenInterfacePtr& flatten_interface,
-                             const float* build_vectors,
-                             int64_t build_vector_count) {
-    if (build_vectors == nullptr or build_vector_count <= 0 or
-        not flatten_interface->SupportSplitCodeStorage()) {
-        return nullptr;
-    }
-
-    auto sq8_param = std::make_shared<FlattenDataCellParameter>();
-    sq8_param->quantizer_parameter = std::make_shared<ScalarQuantizerParameter<8>>();
-    sq8_param->io_parameter = std::make_shared<MemoryIOParameter>();
-
-    auto common_param = flatten_interface->ExportCommonParam();
-    auto build_flatten = FlattenInterface::MakeInstance(sq8_param, common_param);
-    build_flatten->Train(build_vectors, build_vector_count);
-    build_flatten->BatchInsertVector(build_vectors, build_vector_count);
-    return build_flatten;
+    this->distance_flatten_interface_ = this->flatten_interface_.get();
 }
 
 void

--- a/src/impl/odescent/odescent_graph_builder.h
+++ b/src/impl/odescent/odescent_graph_builder.h
@@ -81,26 +81,15 @@ public:
              const FlattenInterfacePtr& flatten_interface,
              Allocator* allocator,
              SafeThreadPool* thread_pool,
-             bool pruning = true,
-             const float* build_vectors = nullptr,
-             int64_t build_vector_count = 0,
-             FlattenInterfacePtr build_flatten_interface = nullptr)
+             bool pruning = true)
         : odescent_param_(std::move(odescent_parameter)),
           flatten_interface_(flatten_interface),
           pruning_(pruning),
           allocator_(allocator),
           graph_(allocator),
           points_lock_(allocator),
-          thread_pool_(thread_pool),
-          build_flatten_interface_(std::move(build_flatten_interface)),
-          build_vectors_(build_vectors),
-          build_vector_count_(build_vector_count) {
+          thread_pool_(thread_pool) {
     }
-
-    static FlattenInterfacePtr
-    CreateBuildFlatten(const FlattenInterfacePtr& flatten_interface,
-                       const float* build_vectors,
-                       int64_t build_vector_count);
 
     bool
     Build(const GraphInterfacePtr& graph_storage = nullptr) {
@@ -182,13 +171,7 @@ private:
 
     const FlattenInterfacePtr& flatten_interface_;
 
-    // Build() initializes this before the first parallelize_task() call and never mutates it
-    // afterward. Task enqueue publishes the initialized pointer to workers, and each parallel phase
-    // waits on all futures before continuing, so get_distance() only performs concurrent reads.
-    FlattenInterfacePtr build_flatten_interface_{nullptr};
     FlattenInterface* distance_flatten_interface_{nullptr};
-    const float* build_vectors_{nullptr};
-    int64_t build_vector_count_{0};
 };
 
 }  // namespace vsag

--- a/src/quantization/rabitq_quantization/rabitq_quantizer.h
+++ b/src/quantization/rabitq_quantization/rabitq_quantizer.h
@@ -203,6 +203,10 @@ public:
                               uint8_t* one_bit_code,
                               uint8_t* supplement_code) const;
 
+    // Restores the scalar build representation from a persisted full code.
+    [[nodiscard]] uint64_t
+    UnpackScalarCode(const uint8_t* codes, uint8_t* scalar_code) const;
+
     void
     ComputeDistWithScalarCode(Computer<RaBitQuantizer>& computer,
                               const uint8_t* scalar_code,
@@ -332,9 +336,6 @@ private:
                       uint8_t* codes,
                       uint8_t* scalar_code,
                       uint64_t* code_sum) const;
-
-    uint64_t
-    UnpackScalarCode(const uint8_t* codes, uint8_t* scalar_code) const;
 
     struct SplitLayout {
         bool is_split{false};


### PR DESCRIPTION
## Summary

- expose an optional RAII optimized-build session through `FlattenInterface`
- let Pyramid use the RaBitQ split scalar-code representation during ODescent construction
- remove ODescent-specific temporary SQ8 build datacell policy
- restore persisted split codes when an optimized session is opened for incremental Add

## Performance

Release build on the 50,000-vector, 1536-dimensional OpenAI angular dataset, using Pyramid + ODescent, MRLE dim 768, RaBitQ split 3+5, and 16 build threads:

| Version | Median build time | Throughput |
| --- | ---: | ---: |
| `origin/main` | 17.437 s | 2867 vectors/s |
| This PR | 10.744 s | 4654 vectors/s |

This is a 1.62x speedup and a 38.38% reduction in build time across three runs. Index memory remained 265.37 MiB.

Search quality with `ef_search=100` and 1,000 queries remained equivalent:

| Version | Median Recall@10 | Median single-thread QPS |
| --- | ---: | ---: |
| `origin/main` | 0.7541 | 1400.77 |
| This PR | 0.7543 | 1394.27 |

## Validation

- Release build
- `RaBitQSplitDataCell optimized scalar-code build`
- `Pyramid MRLE split promotes flat nodes without raw vectors`
- `[MRLE][pyramid]`
- `Pyramid MRLE RaBitQ Split`
- `HGraph optimized build accepts MRLE RaBitQ split with raw-vector storage`
- `ODescent Build Test`

Fixes: #2783