### PR TITLE
feat(eval): report query-level recall coverage

### DIFF
--- a/docs/docs/en/src/resources/eval.md
+++ b/docs/docs/en/src/resources/eval.md
@@ -38,9 +38,9 @@ HDF5 must be installed on the system (Ubuntu: `apt install libhdf5-dev`; CentOS:
 ```
 
 Useful flags include `--search_mode` (`knn` / `range` / `knn_filter` / `range_filter`),
-`--search-query-count`, `--delete-index-after-search`, and the various `--disable_*` switches that
-turn off individual metrics. The reference template at `tools/eval/eval_template.yaml` shows the
-complete YAML shape.
+`--search-query-count`, `--recall_target`, `--delete-index-after-search`, and the various
+`--disable_*` switches that turn off individual metrics. The reference template at
+`tools/eval/eval_template.yaml` shows the complete YAML shape.
 
 ### 2. Config-file mode (batch comparisons)
 
@@ -76,6 +76,7 @@ eval_case1:
   search_params: '{"hgraph":{"ef_search":60}}'
   index_path: /tmp/vsag_eval/hgraph_fp32
   topk: 10
+  recall_target: 0.9
 ```
 
 Note: under `global.exporters`, each entry is a **named** exporter (a YAML map), not a list item.
@@ -83,9 +84,45 @@ Note: under `global.exporters`, each entry is a **named** exporter (a YAML map),
 ## Supported Dimensions
 
 - **Efficiency**: QPS, TPS
-- **Quality**: average recall and quantile recall (P0/P10/P50/P90...)
+- **Quality**: average recall, quantile recall (P0/P10/P50/P90...), and optional query-level recall
+  coverage
 - **Latency**: average, P50/P95/P99
 - **Resource**: peak memory usage
+
+### Query-level Recall Coverage
+
+Set the optional `recall_target` YAML field or `--recall_target` CLI option to a finite value in
+`[0, 1]`. The tool then reports the fraction of recorded query executions whose individual
+`recall@k` reaches the target:
+
+```text
+query_coverage(R) = reached_queries / query_count
+```
+
+`recall_target` is supported only for `knn` and `knn_filter`, the search modes that currently
+produce per-query `recall@k`. Configurations that combine it with `range` or `range_filter` are
+rejected.
+
+For a search with `topk: k`, reaching target `R` requires at least `ceil(R * k)` correct results.
+The per-query result follows the same distance-based or ID-based recall semantics selected for the
+evaluation. `query_count` counts executions in the recall-monitor pass, including repeated dataset
+queries when `search_query_count` exceeds the dataset query count; it is not a count of distinct
+query IDs.
+
+JSON exporters add the following object:
+
+```json
+{
+  "query_coverage": {
+    "recall_target": 0.9,
+    "reached_queries": 950,
+    "query_count": 1000,
+    "rate": 0.95
+  }
+}
+```
+
+If the target is omitted, `query_coverage` is omitted and existing output remains unchanged.
 
 ### Search Measurement Semantics
 

--- a/docs/docs/zh/src/resources/eval.md
+++ b/docs/docs/zh/src/resources/eval.md
@@ -35,8 +35,9 @@ cmake --build build-release -j
 ```
 
 常用参数还包括 `--search_mode`（`knn` / `range` / `knn_filter` / `range_filter`）、
-`--search-query-count`、`--delete-index-after-search`，以及一系列用于关闭单项指标的
-`--disable_*` 开关。参考模板 `tools/eval/eval_template.yaml` 展示了完整的 YAML 结构。
+`--search-query-count`、`--recall_target`、`--delete-index-after-search`，以及一系列用于
+关闭单项指标的 `--disable_*` 开关。参考模板 `tools/eval/eval_template.yaml` 展示了完整的
+YAML 结构。
 
 ### 2. 配置文件模式（适合批量对比）
 
@@ -71,6 +72,7 @@ eval_case1:
   search_params: '{"hgraph":{"ef_search":60}}'
   index_path: /tmp/vsag_eval/hgraph_fp32
   topk: 10
+  recall_target: 0.9
 ```
 
 注意：`global.exporters` 下每一项都是**具名**的导出器（即 YAML map），并不是数组。
@@ -78,9 +80,41 @@ eval_case1:
 ## 支持的评估维度
 
 - **效率**：QPS、TPS
-- **效果**：平均召回率、分位召回率（P0/P10/P50/P90...）
+- **效果**：平均召回率、分位召回率（P0/P10/P50/P90...）与可选的单查询召回覆盖率
 - **延迟**：平均延迟、P50/P95/P99 延迟
 - **资源**：峰值内存占用
+
+### 单查询召回覆盖率
+
+通过可选的 YAML 字段 `recall_target` 或 CLI 参数 `--recall_target` 设置 `[0, 1]` 范围内
+的有限数值。工具会输出单次 `recall@k` 达到目标的查询执行占比：
+
+```text
+query_coverage(R) = reached_queries / query_count
+```
+
+`recall_target` 仅支持当前能够产生逐查询 `recall@k` 的 `knn` 与 `knn_filter` 搜索模式；
+与 `range` 或 `range_filter` 组合时会拒绝该配置。
+
+当 `topk: k` 时，目标 `R` 要求单次查询至少有 `ceil(R * k)` 个正确结果。单查询结果沿用
+当前评估所选的基于距离或基于 ID 的 recall 语义。`query_count` 统计 recall monitor 阶段的
+查询执行次数；当 `search_query_count` 大于数据集查询数时，重复执行也会计入，因此它不是
+去重后的 query ID 数量。
+
+JSON 导出会新增以下对象：
+
+```json
+{
+  "query_coverage": {
+    "recall_target": 0.9,
+    "reached_queries": 950,
+    "query_count": 1000,
+    "rate": 0.95
+  }
+}
+```
+
+未配置 target 时不会输出 `query_coverage`，原有输出保持不变。
 
 ### 搜索指标计量语义
 

--- a/tools/eval/CMakeLists.txt
+++ b/tools/eval/CMakeLists.txt
@@ -62,7 +62,8 @@ add_dependencies (eval_performance hdf5)
 
 if (ENABLE_TESTS)
     add_executable (eval_dataset_test
-        eval_dataset_test.cpp)
+        eval_dataset_test.cpp
+        query_coverage_test.cpp)
     target_include_directories (eval_dataset_test PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries (eval_dataset_test PRIVATE

--- a/tools/eval/case/search_eval_case.cpp
+++ b/tools/eval/case/search_eval_case.cpp
@@ -111,6 +111,7 @@ SearchEvalCase::SearchEvalCase(const std::string& dataset_path,
     } else if (search_mode == "range_filter") {
         this->search_type_ = SearchType::RANGE_FILTER;
     }
+    config_.Validate();
     this->init_monitor();
 }
 
@@ -140,9 +141,12 @@ SearchEvalCase::init_latency_monitor() {
 
 void
 SearchEvalCase::init_recall_monitor() {
-    if (config_.enable_recall or config_.enable_percent_recall) {
-        auto recall_monitor = std::make_shared<RecallMonitor>(
-            this->dataset_ptr_->GetNumberOfQuery(), config_.use_id_based_recall);
+    if (config_.enable_recall or config_.enable_percent_recall or
+        config_.recall_target.has_value()) {
+        auto recall_monitor =
+            std::make_shared<RecallMonitor>(this->dataset_ptr_->GetNumberOfQuery(),
+                                            config_.use_id_based_recall,
+                                            config_.recall_target);
         if (config_.enable_recall) {
             recall_monitor->SetMetrics("avg_recall");
         }

--- a/tools/eval/eval_config.cpp
+++ b/tools/eval/eval_config.cpp
@@ -15,6 +15,9 @@
 
 #include "./eval_config.h"
 
+#include <cmath>
+#include <stdexcept>
+
 #include "./common.h"
 
 namespace vsag::eval {
@@ -26,6 +29,72 @@ check_and_get_value(const YAML::Node& node, const std::string& key, T& value) {
         value = node[key].as<T>();
     }
 };
+
+void
+EvalConfig::AddCliArguments(argparse::ArgumentParser& parser) {
+    // index
+    parser.add_argument<std::string>("--datapath", "-d")
+        .required()
+        .help("The hdf5 file path for eval");
+    parser.add_argument<std::string>("--type", "-t")
+        .required()
+        .choices("build", "search")
+        .help(R"(The eval method to select, choose from {"build", "search"})");
+    parser.add_argument<std::string>("--index_name", "-n")
+        .required()
+        .help("The name of index for create index");
+    parser.add_argument<std::string>("--create_params", "-c")
+        .required()
+        .help("The param for create index");
+    parser.add_argument<std::string>("--index_path", "-i")
+        .default_value("/tmp/performance/index")
+        .help("The index path for load or save");
+    parser.add_argument<std::string>("--search_params", "-s")
+        .default_value("")
+        .help("The param for search");
+    parser.add_argument<std::string>("--search_mode")
+        .default_value("knn")
+        .choices("knn", "range", "knn_filter", "range_filter")
+        .help(
+            "The mode supported while use 'search' type,"
+            " choose from {\"knn\", \"range\", \"knn_filter\", \"range_filter\"}");
+    parser.add_argument("--delete-index-after-search")
+        .default_value(false)
+        .help("Delete index after search");
+    parser.add_argument("--topk")
+        .default_value(10)
+        .help("The topk value for knn search or knn_filter search")
+        .scan<'i', int>();
+    parser.add_argument("--range")
+        .default_value(0.5F)
+        .help("The range value for range search or range_filter search")
+        .scan<'f', float>();
+    parser.add_argument("--search-query-count")
+        .default_value(100000)
+        .help("The number of queries to run for search performance evaluation")
+        .scan<'i', uint64_t>();
+
+    // metrics
+    parser.add_argument("--disable_recall")
+        .default_value(false)
+        .help("Disable average recall eval");
+    parser.add_argument("--disable_percent_recall")
+        .default_value(false)
+        .help("Disable percent recall eval, include p0, p10, p30, p50, p70, p90");
+    parser.add_argument("--recall_target")
+        .help(
+            "Report query coverage at this recall target in [0, 1] for knn and knn_filter searches")
+        .scan<'g', double>();
+    parser.add_argument("--disable_qps").default_value(false).help("Disable qps eval");
+    parser.add_argument("--disable_tps").default_value(false).help("Disable tps eval");
+    parser.add_argument("--disable_memory").default_value(false).help("Disable memory eval");
+    parser.add_argument("--disable_latency")
+        .default_value(false)
+        .help("Disable average latency eval");
+    parser.add_argument("--disable_percent_latency")
+        .default_value(false)
+        .help("Disable percent latency eval, include p50, p80, p90, p95, p99");
+}
 
 EvalConfig
 EvalConfig::Load(argparse::ArgumentParser& parser) {
@@ -42,6 +111,9 @@ EvalConfig::Load(argparse::ArgumentParser& parser) {
     config.top_k = parser.get<int>("--topk");
     config.radius = parser.get<float>("--range");
     config.search_query_count = parser.get<uint64_t>("--search-query-count");
+    if (parser.is_used("--recall_target")) {
+        config.recall_target = parser.get<double>("--recall_target");
+    }
 
     config.delete_index_after_search = parser.get<bool>("--delete-index-after-search");
 
@@ -67,6 +139,7 @@ EvalConfig::Load(argparse::ArgumentParser& parser) {
         config.enable_percent_latency = false;
     }
 
+    config.Validate();
     return config;
 }
 
@@ -94,6 +167,9 @@ EvalConfig::Load(YAML::Node& yaml_node, const EvalJob& global_options) {
     check_and_get_value<int>(yaml_node, "topk", config.top_k);
     check_and_get_value<float>(yaml_node, "range", config.radius);
     check_and_get_value<uint64_t>(yaml_node, "search_query_count", config.search_query_count);
+    if (yaml_node["recall_target"].IsDefined()) {
+        config.recall_target = yaml_node["recall_target"].as<double>();
+    }
 
     check_and_get_value<bool>(
         yaml_node, "delete_index_after_search", config.delete_index_after_search);
@@ -143,6 +219,7 @@ EvalConfig::Load(YAML::Node& yaml_node, const EvalJob& global_options) {
         disable = false;
     }
 
+    config.Validate();
     return config;
 }
 
@@ -159,6 +236,7 @@ EvalConfig::CheckKeyAndType(YAML::Node& yaml_node) {
     check_and_get_value<>(yaml_node, "index_path");
     check_and_get_value<int>(yaml_node, "topk");
     check_and_get_value<float>(yaml_node, "range");
+    check_and_get_value<double>(yaml_node, "recall_target");
     check_and_get_value<bool>(yaml_node, "disable_recall");
     check_and_get_value<bool>(yaml_node, "disable_percent_recall");
     check_and_get_value<bool>(yaml_node, "disable_qps");
@@ -166,6 +244,21 @@ EvalConfig::CheckKeyAndType(YAML::Node& yaml_node) {
     check_and_get_value<bool>(yaml_node, "disable_memory");
     check_and_get_value<bool>(yaml_node, "disable_latency");
     check_and_get_value<bool>(yaml_node, "disable_percent_latency");
+}
+
+void
+EvalConfig::Validate() const {
+    if (not recall_target.has_value()) {
+        return;
+    }
+    if (not std::isfinite(recall_target.value()) || recall_target.value() < 0.0 ||
+        recall_target.value() > 1.0) {
+        throw std::invalid_argument("recall_target must be finite and in [0, 1]");
+    }
+    if (search_mode != "knn" and search_mode != "knn_filter") {
+        throw std::invalid_argument(
+            "recall_target is supported only for knn and knn_filter search modes");
+    }
 }
 
 }  // namespace vsag::eval

--- a/tools/eval/eval_config.h
+++ b/tools/eval/eval_config.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "argparse/argparse.hpp"
 #include "eval_job.h"
 #include "yaml-cpp/yaml.h"
@@ -23,6 +25,9 @@ namespace vsag::eval {
 
 class EvalConfig {
 public:
+    static void
+    AddCliArguments(argparse::ArgumentParser& parser);
+
     static EvalConfig
     Load(argparse::ArgumentParser& parser);
 
@@ -31,6 +36,9 @@ public:
 
     static void
     CheckKeyAndType(YAML::Node& yaml_node);
+
+    void
+    Validate() const;
 
 public:
     std::string dataset_path;
@@ -57,6 +65,7 @@ public:
     bool enable_latency{true};
     bool enable_percent_latency{true};
     bool use_id_based_recall{false};
+    std::optional<double> recall_target;
 
     EvalConfig() = default;
 };

--- a/tools/eval/eval_dataset_test.cpp
+++ b/tools/eval/eval_dataset_test.cpp
@@ -466,17 +466,22 @@ TEST_CASE("EvaluateSearch validates inputs and propagates search errors", "[ut][
     config.num_threads_searching = caller_thread_count == 1 ? 2 : 1;
     config.enable_recall = false;
     config.enable_percent_recall = false;
+    config.recall_target = 1.0;
     config.enable_qps = true;
     config.enable_tps = false;
     config.enable_memory = false;
     config.enable_latency = false;
     config.enable_percent_latency = false;
 
-    const auto qps_only = vsag::eval::EvaluateSearch(index, dataset, config);
-    REQUIRE(qps_only.contains("qps"));
-    REQUIRE(qps_only["measurement_sample_count"].get<uint64_t>() == 2);
-    REQUIRE(qps_only["index_info"].is_object());
-    REQUIRE(qps_only["index_info"].empty());
+    const auto coverage_result = vsag::eval::EvaluateSearch(index, dataset, config);
+    REQUIRE(coverage_result.contains("qps"));
+    REQUIRE(coverage_result["measurement_sample_count"].get<uint64_t>() == 2);
+    REQUIRE(coverage_result["query_coverage"]["recall_target"].get<double>() == 1.0);
+    REQUIRE(coverage_result["query_coverage"]["reached_queries"].get<uint64_t>() == 2);
+    REQUIRE(coverage_result["query_coverage"]["query_count"].get<uint64_t>() == 2);
+    REQUIRE(coverage_result["query_coverage"]["rate"].get<double>() == 1.0);
+    REQUIRE(coverage_result["index_info"].is_object());
+    REQUIRE(coverage_result["index_info"].empty());
     REQUIRE(omp_get_max_threads() == caller_thread_count);
 
     config.search_param = R"({"hgraph":{"ef_search":0}})";
@@ -497,6 +502,7 @@ TEST_CASE("EvaluateSearch validates inputs and propagates search errors", "[ut][
                         "evaluation top_k must be positive");
 
     config.top_k = 1;
+    config.recall_target.reset();
     config.search_mode = "range";
     REQUIRE_THROWS_WITH(vsag::eval::EvaluateSearch(index, dataset, config),
                         "in-memory evaluation supports only knn search mode");
@@ -562,6 +568,7 @@ TEST_CASE("EvalCase builds and searches an in-memory dataset with original ids",
     })";
     config.top_k = 1;
     config.search_query_count = 1;
+    config.recall_target = 1.0;
     config.enable_memory = false;
     std::remove(config.index_path.c_str());
 
@@ -571,6 +578,8 @@ TEST_CASE("EvalCase builds and searches an in-memory dataset with original ids",
     const auto result = search->Run();
     REQUIRE(result["action"] == "search");
     REQUIRE(result["recall_avg"].get<double>() == 1.0);
+    REQUIRE(result["query_coverage"]["reached_queries"].get<uint64_t>() == 1);
+    REQUIRE(result["query_coverage"]["query_count"].get<uint64_t>() == 1);
     REQUIRE(result["statistics_query_count"].get<uint64_t>() == 1);
     REQUIRE(std::isfinite(result["qps"].get<double>()));
     REQUIRE(std::isfinite(result["latency_avg(ms)"].get<double>()));
@@ -590,13 +599,16 @@ TEST_CASE("EvalCase builds and searches an in-memory dataset with original ids",
         ->Owner(false);
     auto concurrent_dataset =
         EvalDataset::FromDatasets(base, concurrent_queries, concurrent_ground_truth, "l2");
-    config.search_query_count = 2;
+    config.search_query_count = 4;
     config.num_threads_searching = 2;
     auto concurrent_search =
         vsag::eval::EvalCase::MakeInstance(config, "search", concurrent_dataset);
     const auto concurrent_result = concurrent_search->Run();
     REQUIRE(concurrent_result["recall_avg"].get<double>() == 1.0);
-    REQUIRE(concurrent_result["statistics_query_count"].get<uint64_t>() == 2);
+    REQUIRE(concurrent_result["query_coverage"]["reached_queries"].get<uint64_t>() == 4);
+    REQUIRE(concurrent_result["query_coverage"]["query_count"].get<uint64_t>() == 4);
+    REQUIRE(concurrent_result["query_coverage"]["rate"].get<double>() == 1.0);
+    REQUIRE(concurrent_result["statistics_query_count"].get<uint64_t>() == 4);
     REQUIRE(std::isfinite(concurrent_result["qps"].get<double>()));
     REQUIRE(std::isfinite(concurrent_result["latency_avg(ms)"].get<double>()));
     REQUIRE(std::isfinite(concurrent_result["latency_detail(ms)"]["p99"].get<double>()));

--- a/tools/eval/eval_template.yaml
+++ b/tools/eval/eval_template.yaml
@@ -21,6 +21,7 @@ eval_case1:
     index_path: "/tmp/sift-128-euclidean/index/hgraph_index"
     search_mode: "knn" # ["knn", "range", "knn_filter", "range_filter"]
     topk: 10
+    recall_target: 0.9 # optional for knn/knn_filter, target in [0, 1]
     range: 0.5
     delete_index_after_search: false # free up storage space used by index
     num_threads_building: 16

--- a/tools/eval/evaluator.cpp
+++ b/tools/eval/evaluator.cpp
@@ -51,6 +51,7 @@ validate(const IndexPtr& index, const EvalDatasetPtr& dataset) {
 
 void
 validate_search(const EvalDatasetPtr& dataset, const EvalConfig& config) {
+    config.Validate();
     if (config.search_mode != "knn") {
         throw std::invalid_argument("in-memory evaluation supports only knn search mode");
     }
@@ -69,7 +70,7 @@ validate_search(const EvalDatasetPtr& dataset, const EvalConfig& config) {
     if (config.search_query_count > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
         throw std::invalid_argument("evaluation search query count exceeds the supported range");
     }
-    if (config.enable_recall or config.enable_percent_recall) {
+    if (config.enable_recall or config.enable_percent_recall or config.recall_target.has_value()) {
         const auto requested_top_k = static_cast<uint64_t>(config.top_k);
         if (dataset->GetGroundTruthK() < requested_top_k || dataset->GetNeighbors(0) == nullptr) {
             throw std::invalid_argument(

--- a/tools/eval/evaluator.cpp
+++ b/tools/eval/evaluator.cpp
@@ -51,7 +51,6 @@ validate(const IndexPtr& index, const EvalDatasetPtr& dataset) {
 
 void
 validate_search(const EvalDatasetPtr& dataset, const EvalConfig& config) {
-    config.Validate();
     if (config.search_mode != "knn") {
         throw std::invalid_argument("in-memory evaluation supports only knn search mode");
     }

--- a/tools/eval/main.cpp
+++ b/tools/eval/main.cpp
@@ -47,64 +47,7 @@ check_args(argparse::ArgumentParser& parser) {
 
 void
 parse_args(argparse::ArgumentParser& parser, int argc, char** argv) {
-    // index
-    parser.add_argument<std::string>("--datapath", "-d")
-        .required()
-        .help("The hdf5 file path for eval");
-    parser.add_argument<std::string>("--type", "-t")
-        .required()
-        .choices("build", "search")
-        .help(R"(The eval method to select, choose from {"build", "search"})");
-    parser.add_argument<std::string>("--index_name", "-n")
-        .required()
-        .help("The name of index for create index");
-    parser.add_argument<std::string>("--create_params", "-c")
-        .required()
-        .help("The param for create index");
-    parser.add_argument<std::string>("--index_path", "-i")
-        .default_value("/tmp/performance/index")
-        .help("The index path for load or save");
-    parser.add_argument<std::string>("--search_params", "-s")
-        .default_value("")
-        .help("The param for search");
-    parser.add_argument<std::string>("--search_mode")
-        .default_value("knn")
-        .choices("knn", "range", "knn_filter", "range_filter")
-        .help(
-            "The mode supported while use 'search' type,"
-            " choose from {\"knn\", \"range\", \"knn_filter\", \"range_filter\"}");
-    parser.add_argument("--delete-index-after-search")
-        .default_value(false)
-        .help("Delete index after search");
-    parser.add_argument("--topk")
-        .default_value(10)
-        .help("The topk value for knn search or knn_filter search")
-        .scan<'i', int>();
-    parser.add_argument("--range")
-        .default_value(0.5f)
-        .help("The range value for range search or range_filter search")
-        .scan<'f', float>();
-    parser.add_argument("--search-query-count")
-        .default_value(100000)
-        .help("The number of queries to run for search performance evaluation")
-        .scan<'i', uint64_t>();
-
-    // metrics
-    parser.add_argument("--disable_recall")
-        .default_value(false)
-        .help("Disable average recall eval");
-    parser.add_argument("--disable_percent_recall")
-        .default_value(false)
-        .help("Disable percent recall eval, include p0, p10, p30, p50, p70, p90");
-    parser.add_argument("--disable_qps").default_value(false).help("Disable qps eval");
-    parser.add_argument("--disable_tps").default_value(false).help("Disable tps eval");
-    parser.add_argument("--disable_memory").default_value(false).help("Disable memory eval");
-    parser.add_argument("--disable_latency")
-        .default_value(false)
-        .help("Disable average latency eval");
-    parser.add_argument("--disable_percent_latency")
-        .default_value(false)
-        .help("Disable percent latency eval, include p50, p80, p90, p95, p99");
+    vsag::eval::EvalConfig::AddCliArguments(parser);
 
     try {
         parser.parse_args(argc, argv);

--- a/tools/eval/monitor/recall_monitor.cpp
+++ b/tools/eval/monitor/recall_monitor.cpp
@@ -16,11 +16,9 @@
 #include "recall_monitor.h"
 
 #include <algorithm>
-#include <cmath>
 #include <limits>
 #include <mutex>
 #include <numeric>
-#include <stdexcept>
 #include <unordered_set>
 #include <vector>
 
@@ -69,11 +67,6 @@ RecallMonitor::RecallMonitor(uint64_t max_record_counts,
     : Monitor("recall_monitor"),
       use_id_based_recall_(use_id_based_recall),
       recall_target_(recall_target) {
-    if (recall_target_.has_value() &&
-        (not std::isfinite(recall_target_.value()) || recall_target_.value() < 0.0 ||
-         recall_target_.value() > 1.0)) {
-        throw std::invalid_argument("recall_target must be finite and in [0, 1]");
-    }
     if (max_record_counts > 0) {
         this->recall_records_.reserve(max_record_counts);
     }

--- a/tools/eval/monitor/recall_monitor.cpp
+++ b/tools/eval/monitor/recall_monitor.cpp
@@ -16,9 +16,11 @@
 #include "recall_monitor.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <mutex>
 #include <numeric>
+#include <stdexcept>
 #include <unordered_set>
 #include <vector>
 
@@ -61,8 +63,17 @@ get_id_recall(const int64_t* neighbors,
     return static_cast<double>(count) / static_cast<double>(top_k);
 }
 
-RecallMonitor::RecallMonitor(uint64_t max_record_counts, bool use_id_based_recall)
-    : Monitor("recall_monitor"), use_id_based_recall_(use_id_based_recall) {
+RecallMonitor::RecallMonitor(uint64_t max_record_counts,
+                             bool use_id_based_recall,
+                             std::optional<double> recall_target)
+    : Monitor("recall_monitor"),
+      use_id_based_recall_(use_id_based_recall),
+      recall_target_(recall_target) {
+    if (recall_target_.has_value() &&
+        (not std::isfinite(recall_target_.value()) || recall_target_.value() < 0.0 ||
+         recall_target_.value() > 1.0)) {
+        throw std::invalid_argument("recall_target must be finite and in [0, 1]");
+    }
     if (max_record_counts > 0) {
         this->recall_records_.reserve(max_record_counts);
     }
@@ -81,6 +92,16 @@ RecallMonitor::GetResult() {
     for (auto& metric : metrics_) {
         this->cal_and_set_result(metric, result);
     }
+    if (recall_target_.has_value()) {
+        const auto query_count = static_cast<uint64_t>(recall_records_.size());
+        const double rate = query_count == 0 ? 0.0
+                                             : static_cast<double>(reached_queries_) /
+                                                   static_cast<double>(query_count);
+        result["query_coverage"] = {{"recall_target", recall_target_.value()},
+                                    {"reached_queries", reached_queries_},
+                                    {"query_count", query_count},
+                                    {"rate", rate}};
+    }
     return result;
 }
 void
@@ -95,12 +116,11 @@ RecallMonitor::Record(void* input) {
     const auto requested_top_k = record.requested_top_k;
     const auto result_count = std::min(record.result_count, requested_top_k);
     if (requested_top_k == 0) {
-        this->recall_records_.emplace_back(0.0);
+        this->record_recall(0.0);
         return;
     }
     if (use_id_based_recall_) {
-        this->recall_records_.emplace_back(
-            get_id_recall(neighbors, gt_neighbors, result_count, requested_top_k));
+        this->record_recall(get_id_recall(neighbors, gt_neighbors, result_count, requested_top_k));
         return;
     }
     uint64_t dim = dataset->GetDim();
@@ -119,9 +139,8 @@ RecallMonitor::Record(void* input) {
                               : distance_func(query_data, ground_truth_vector, &dim);
     }
 
-    const double val =
-        get_recall(distances.data(), gt_distances.data(), result_count, requested_top_k);
-    this->recall_records_.emplace_back(val);
+    this->record_recall(
+        get_recall(distances.data(), gt_distances.data(), result_count, requested_top_k));
 }
 void
 RecallMonitor::SetMetrics(std::string metric) {
@@ -154,5 +173,13 @@ RecallMonitor::cal_recall_rate(double rate) {
     std::sort(this->recall_records_.begin(), this->recall_records_.end());
     auto pos = static_cast<uint64_t>(rate * static_cast<double>(this->recall_records_.size() - 1));
     return recall_records_[pos];
+}
+
+void
+RecallMonitor::record_recall(double recall) {
+    recall_records_.emplace_back(recall);
+    if (recall_target_.has_value() && recall >= recall_target_.value()) {
+        ++reached_queries_;
+    }
 }
 }  // namespace vsag::eval

--- a/tools/eval/monitor/recall_monitor.h
+++ b/tools/eval/monitor/recall_monitor.h
@@ -16,13 +16,16 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 
 #include "monitor.h"
 namespace vsag::eval {
 
 class RecallMonitor : public Monitor {
 public:
-    explicit RecallMonitor(uint64_t max_record_counts = 0, bool use_id_based_recall = false);
+    explicit RecallMonitor(uint64_t max_record_counts = 0,
+                           bool use_id_based_recall = false,
+                           std::optional<double> recall_target = std::nullopt);
 
     ~RecallMonitor() override = default;
 
@@ -51,11 +54,16 @@ private:
     double
     cal_recall_rate(double rate);
 
+    void
+    record_recall(double recall);
+
 private:
     std::vector<double> recall_records_;
 
     std::vector<std::string> metrics_;
     bool use_id_based_recall_{false};
+    std::optional<double> recall_target_;
+    uint64_t reached_queries_{0};
 };
 
 }  // namespace vsag::eval

--- a/tools/eval/query_coverage_test.cpp
+++ b/tools/eval/query_coverage_test.cpp
@@ -1,0 +1,195 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <string>
+#include <vector>
+
+#include "eval_config.h"
+#include "eval_dataset.h"
+#include "eval_job.h"
+#include "monitor/recall_monitor.h"
+
+namespace vsag::eval {
+namespace {
+
+EvalConfig
+LoadCliConfig(const std::vector<std::string>& extra_arguments) {
+    std::vector<std::string> arguments{"eval_performance",
+                                       "--datapath",
+                                       "/tmp/eval.hdf5",
+                                       "--type",
+                                       "search",
+                                       "--index_name",
+                                       "hgraph",
+                                       "--create_params",
+                                       "{}",
+                                       "--search_params",
+                                       "{}",
+                                       "--index_path",
+                                       "/tmp/eval.index",
+                                       "--search_mode",
+                                       "knn",
+                                       "--search-query-count",
+                                       "1"};
+    arguments.insert(arguments.end(), extra_arguments.begin(), extra_arguments.end());
+
+    argparse::ArgumentParser parser("eval_performance");
+    EvalConfig::AddCliArguments(parser);
+    parser.parse_args(arguments);
+    return EvalConfig::Load(parser);
+}
+
+EvalConfig
+LoadYamlConfig(const std::string& extra_yaml = "") {
+    auto yaml = YAML::Load(
+        "datapath: /tmp/eval.hdf5\n"
+        "type: search\n"
+        "index_name: hgraph\n"
+        "create_params: '{}'\n"
+        "search_params: '{}'\n" +
+        extra_yaml);
+    EvalConfig::CheckKeyAndType(yaml);
+    EvalJob global_options;
+    return EvalConfig::Load(yaml, global_options);
+}
+
+void
+RequireCoverage(const Monitor::JsonType& result,
+                double target,
+                uint64_t reached_queries,
+                uint64_t query_count,
+                double rate) {
+    const auto& coverage = result.at("query_coverage");
+    REQUIRE(coverage.at("recall_target").get<double>() == Catch::Approx(target));
+    REQUIRE(coverage.at("reached_queries").get<uint64_t>() == reached_queries);
+    REQUIRE(coverage.at("query_count").get<uint64_t>() == query_count);
+    REQUIRE(coverage.at("rate").get<double>() == Catch::Approx(rate));
+}
+
+}  // namespace
+
+TEST_CASE("EvalConfig parses optional recall targets from CLI and YAML",
+          "[ut][eval][query_coverage]") {
+    REQUIRE_FALSE(LoadCliConfig({}).recall_target.has_value());
+    REQUIRE(LoadCliConfig({"--recall_target", "0.9"}).recall_target.value() == Catch::Approx(0.9));
+    REQUIRE_THROWS_WITH(LoadCliConfig({"--recall_target", "1.01"}),
+                        "recall_target must be finite and in [0, 1]");
+
+    REQUIRE_FALSE(LoadYamlConfig().recall_target.has_value());
+    REQUIRE(LoadYamlConfig("recall_target: 0\n").recall_target.value() == Catch::Approx(0.0));
+    REQUIRE(LoadYamlConfig("recall_target: 1\n").recall_target.value() == Catch::Approx(1.0));
+    REQUIRE_THROWS_WITH(LoadYamlConfig("recall_target: -0.01\n"),
+                        "recall_target must be finite and in [0, 1]");
+    REQUIRE_THROWS_WITH(LoadYamlConfig("recall_target: .nan\n"),
+                        "recall_target must be finite and in [0, 1]");
+}
+
+TEST_CASE("EvalConfig rejects recall targets for modes without recall at k",
+          "[ut][eval][query_coverage]") {
+    const auto knn_filter = LoadYamlConfig("search_mode: knn_filter\nrecall_target: 0.9\n");
+    REQUIRE(knn_filter.search_mode == "knn_filter");
+    REQUIRE(knn_filter.recall_target.value() == Catch::Approx(0.9));
+
+    REQUIRE_THROWS_WITH(LoadYamlConfig("search_mode: range\nrecall_target: 0.9\n"),
+                        "recall_target is supported only for knn and knn_filter search modes");
+    REQUIRE_THROWS_WITH(LoadYamlConfig("search_mode: range_filter\nrecall_target: 0.9\n"),
+                        "recall_target is supported only for knn and knn_filter search modes");
+
+    REQUIRE(LoadYamlConfig("search_mode: range\n").search_mode == "range");
+}
+
+TEST_CASE("Recall coverage uses the discrete per-query boundary", "[ut][eval][query_coverage]") {
+    constexpr int64_t dim = 2;
+    std::vector<float> query_vectors{0.0F, 0.0F, 1.0F, 1.0F};
+    auto queries = vsag::Dataset::Make()
+                       ->NumElements(2)
+                       ->Dim(dim)
+                       ->Float32Vectors(query_vectors.data())
+                       ->Owner(false);
+    std::vector<int64_t> ground_truth_ids{10, 11, 12, 13, 14, 20, 21, 22, 23, 24};
+    auto ground_truth =
+        vsag::Dataset::Make()->NumElements(2)->Dim(5)->Ids(ground_truth_ids.data())->Owner(false);
+    auto dataset = EvalDataset::FromSearchDatasets(queries, ground_truth);
+
+    int64_t perfect_result[]{10, 11, 12, 13, 14};
+    int64_t four_match_result[]{20, 21, 22, 23, 99};
+    SearchRecord perfect_record{
+        perfect_result, dataset->GetNeighbors(0), dataset.get(), dataset->GetOneTest(0), 5, 5};
+    SearchRecord four_match_record{
+        four_match_result, dataset->GetNeighbors(1), dataset.get(), dataset->GetOneTest(1), 5, 5};
+
+    RecallMonitor monitor(2, true, 0.9);
+    monitor.SetMetrics("avg_recall");
+    monitor.Record(&perfect_record);
+    monitor.Record(&four_match_record);
+    const auto result = monitor.GetResult();
+
+    REQUIRE(result.at("recall_avg").get<double>() == Catch::Approx(0.9));
+    RequireCoverage(result, 0.9, 1, 2, 0.5);
+
+    RecallMonitor exact_boundary_monitor(1, true, 0.8);
+    exact_boundary_monitor.Record(&four_match_record);
+    RequireCoverage(exact_boundary_monitor.GetResult(), 0.8, 1, 1, 1.0);
+}
+
+TEST_CASE("Recall coverage preserves distance-based and ID-based semantics",
+          "[ut][eval][query_coverage]") {
+    constexpr int64_t dim = 2;
+    std::vector<float> base_vectors{0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F};
+    std::vector<int64_t> base_ids{10, 20, 30};
+    auto base = vsag::Dataset::Make()
+                    ->NumElements(3)
+                    ->Dim(dim)
+                    ->Ids(base_ids.data())
+                    ->Float32Vectors(base_vectors.data())
+                    ->Owner(false);
+    std::vector<float> query_vectors{0.0F, 0.0F};
+    auto queries = vsag::Dataset::Make()
+                       ->NumElements(1)
+                       ->Dim(dim)
+                       ->Float32Vectors(query_vectors.data())
+                       ->Owner(false);
+    std::vector<int64_t> ground_truth_ids{10, 20};
+    auto ground_truth =
+        vsag::Dataset::Make()->NumElements(1)->Dim(2)->Ids(ground_truth_ids.data())->Owner(false);
+    auto dataset = EvalDataset::FromDatasets(base, queries, ground_truth, "l2");
+
+    int64_t result_ids[]{10, 30};
+    SearchRecord record{
+        result_ids, dataset->GetNeighbors(0), dataset.get(), dataset->GetOneTest(0), 2, 2};
+
+    RecallMonitor distance_monitor(1, false, 0.75);
+    distance_monitor.SetMetrics("avg_recall");
+    distance_monitor.Record(&record);
+    const auto distance_result = distance_monitor.GetResult();
+    REQUIRE(distance_result.at("recall_avg").get<double>() == Catch::Approx(1.0));
+    RequireCoverage(distance_result, 0.75, 1, 1, 1.0);
+
+    RecallMonitor id_monitor(1, true, 0.75);
+    id_monitor.SetMetrics("avg_recall");
+    id_monitor.Record(&record);
+    const auto id_result = id_monitor.GetResult();
+    REQUIRE(id_result.at("recall_avg").get<double>() == Catch::Approx(0.5));
+    RequireCoverage(id_result, 0.75, 0, 1, 0.0);
+
+    RecallMonitor unconfigured_monitor(1, true);
+    unconfigured_monitor.SetMetrics("avg_recall");
+    unconfigured_monitor.Record(&record);
+    REQUIRE_FALSE(unconfigured_monitor.GetResult().contains("query_coverage"));
+}
+
+}  // namespace vsag::eval


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2841

## What Changed

- Add an optional `recall_target` setting for CLI and YAML search evaluation, validated as a finite value in `[0, 1]` for `knn` and `knn_filter` searches.
- Report `query_coverage` in JSON with the target, reached query executions, recorded query executions, and empirical coverage rate.
- Reuse the existing distance-based or ID-based per-query recall semantics, including the discrete `recall@k` boundary.
- Keep existing output unchanged when no target is configured.
- Add focused configuration, semantic, compatibility, repeated-query, and multi-threaded integration coverage.
- Document the option and output in the English and Chinese eval guides and YAML template.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details (Debug build):

```text
cmake --build build --target eval_dataset_test eval_performance --parallel 8
  passed

./build/tools/eval/eval_dataset_test --rng-seed 12345
  All tests passed (165 assertions in 18 test cases)

clang-format 15 --dry-run --Werror on the modified C++ files
  passed

git diff --check
  passed
```

Configuration tests exercise CLI/YAML values at search construction; the in-memory integration test also rejects an invalid target without going through a config loader. Full repository tests, coverage collection, and sanitizers were not run locally for this revision.

## Compatibility Impact

- API/ABI compatibility: No installed VSAG API or ABI change; the affected types are internal to `eval_performance`.
- Behavior changes: Adds opt-in CLI/YAML configuration and an additive JSON object. Without `recall_target`, existing output is unchanged. Configuring the target for `range` or `range_filter` is rejected because those modes do not currently produce per-query `recall@k`.

## Performance and Concurrency Impact

- Performance impact: Production index search paths are unchanged. Coverage adds one comparison and conditional increment to the existing recall pass; configuring only coverage activates the recall pass needed to compute it. Recall processing remains outside latency/QPS measurement.
- Concurrency/thread-safety impact: The reached-query counter is updated under the existing recall-record mutex. Integration coverage includes repeated queries executed with multiple OpenMP workers.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: `docs/docs/{en,zh}/src/resources/eval.md` and `tools/eval/eval_template.yaml`

## Risk and Rollback

- Risk level: low
- Rollback plan: Revert this PR to remove the option, JSON metric, tests, and documentation together.

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior
- [x] I have considered API compatibility impact
- [x] I have updated docs for the behavior change
- [x] My commit messages follow project conventions
