### PR TITLE
perf(sindi): remove approximate evaluation tracking

### DIFF
--- a/docs/docs/en/src/api/dataset.md
+++ b/docs/docs/en/src/api/dataset.md
@@ -186,6 +186,9 @@ families such as `fp32`, `fp16`, `bf16`, `int8`, `sq8`, `sq4`, `pq`, `pq_fastsca
 
 The total equals the phase sum. Known backend values equal the total; unknown work is in `unknown`
 and sets `complete` to `false`. Values are unsigned 64-bit JSON integers with saturating addition.
+SINDI and SINDI_V2 omit approximate-phase evaluations to avoid per-posting-ID tracking in their
+search hot paths. Their measured phases remain available, but `complete` is `false` when
+approximate evaluations occur.
 Legacy `dist_cmp` and `reorder_distance_count` remain available unchanged for compatibility.
 Python preserves `(ids, distances)` tuple unpacking. Opt in with
 `knn_search_with_statistics`: the dense overload returns one statistics JSON string, while the

--- a/docs/docs/zh/src/api/dataset.md
+++ b/docs/docs/zh/src/api/dataset.md
@@ -171,7 +171,10 @@ struct MultiVector {
 和稀疏表示族，不包含 ISA 或批量变体。
 
 `distance_evaluations` 等于阶段之和；已知 backend 之和等于总数。未知工作记入 `unknown` 并使
-`complete` 为 `false`。数值是无符号 64 位 JSON 整数，加法饱和。旧的 `dist_cmp` 与
+`complete` 为 `false`。数值是无符号 64 位 JSON 整数，加法饱和。
+`SINDI` 和 `SINDI_V2` 为避免在搜索热路径中逐 posting ID 跟踪，不统计 approximate 阶段的
+evaluation；其他已测量阶段仍会返回，但发生 approximate evaluation 时 `complete` 为 `false`。
+旧的 `dist_cmp` 与
 `reorder_distance_count` 保持兼容且含义不变。Python 保留 `(ids, distances)` 解包方式；可通过
 `knn_search_with_statistics` 显式获取统计信息：稠密重载返回一个统计 JSON 字符串，稀疏 CSR
 重载为每个查询返回一个字符串。`range_search_with_statistics` 返回范围搜索数组及一个统计

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -106,18 +106,6 @@ has_sorted_posting_lists(const JsonType& basic_info) {
                SINDI_SORTED_POSTING_LIST_FORMAT_VERSION;
 }
 
-DistanceEvaluationBackend
-sparse_backend(SparseValueQuantizationType quant_type) {
-    switch (quant_type) {
-        case SparseValueQuantizationType::SQ8:
-            return DistanceEvaluationBackend::SPARSE_SQ8;
-        case SparseValueQuantizationType::FP16:
-            return DistanceEvaluationBackend::SPARSE_FP16;
-        default:
-            return DistanceEvaluationBackend::SPARSE_FP32;
-    }
-}
-
 uint32_t
 sparse_value_code_size(SparseValueQuantizationType type) {
     switch (type) {
@@ -846,11 +834,6 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         // compute
         term_datacell_->QueryWindow(
             dists.data(), window_id, computer, use_term_lists_heap_insert, query_context);
-        if (statistics != nullptr) {
-            statistics->AddDistance(SearchStatistics::DistancePhase::APPROXIMATE,
-                                    sparse_backend(sparse_value_quant_type_),
-                                    query_context.evaluation_tracker.Count());
-        }
 
         if (reasoning_ctx != nullptr) {
             selected_buckets->push_back(static_cast<BucketIdType>(cur));
@@ -900,6 +883,10 @@ SINDI::search_impl(const SparseTermComputerPtr& computer,
         if (filter_callback_limit_reached) {
             break;
         }
+    }
+
+    if (statistics != nullptr and query_context.has_untracked_approximate_evaluations) {
+        statistics->complete.store(false, std::memory_order_relaxed);
     }
 
     if (selected_buckets != nullptr and not selected_buckets->empty()) {

--- a/src/algorithm/sindi_v2/sindi_v2.cpp
+++ b/src/algorithm/sindi_v2/sindi_v2.cpp
@@ -54,19 +54,6 @@ constexpr const char* SINDI_V2_TERM_LAYOUT_KIND_KEY = "sindi_v2_term_layout_kind
 constexpr const char* SINDI_V2_TERM_LAYOUT_KIND = "term";
 constexpr uint64_t TERM_ID_MAPPER_ENTRY_MEMORY_BYTES = 54;
 
-DistanceEvaluationBackend
-sparse_backend(SparseValueQuantizationType quant_type) {
-    switch (quant_type) {
-        case SparseValueQuantizationType::FP16:
-            return DistanceEvaluationBackend::SPARSE_FP16;
-        case SparseValueQuantizationType::SQ8:
-            return DistanceEvaluationBackend::SPARSE_SQ8;
-        case SparseValueQuantizationType::FP32:
-        default:
-            return DistanceEvaluationBackend::SPARSE_FP32;
-    }
-}
-
 class BinaryReader : public Reader {
 public:
     explicit BinaryReader(Binary binary) : binary_(std::move(binary)) {
@@ -906,11 +893,6 @@ SINDIV2::search_impl(const SparseTermComputerPtr& computer,
             not metadata_filter_.RequiresFullTermScan(metadata_route, window_id, window_size_));
         term_datacell_->QueryWindow(
             dists.data(), window_id, computer, use_term_lists_heap_insert, query_context);
-        if (statistics != nullptr) {
-            statistics->AddDistance(SearchStatistics::DistancePhase::APPROXIMATE,
-                                    sparse_backend(sparse_value_quant_type_),
-                                    query_context.evaluation_tracker.Count());
-        }
 
         if (not has_effective_query_terms) {
             uint32_t valid_window_size = 0;
@@ -970,6 +952,10 @@ SINDIV2::search_impl(const SparseTermComputerPtr& computer,
                                               mode,
                                               inner_param.is_inner_id_allowed != nullptr);
         }
+    }
+
+    if (statistics != nullptr and query_context.has_untracked_approximate_evaluations) {
+        statistics->complete.store(false, std::memory_order_relaxed);
     }
 
     // rerank

--- a/src/algorithm/sindi_v2/sindi_v2_test.cpp
+++ b/src/algorithm/sindi_v2/sindi_v2_test.cpp
@@ -278,6 +278,17 @@ TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
         auto result = index.KnnSearch(query, 2, search_parameters, nullptr);
         REQUIRE(result->GetDim() == 1);
         REQUIRE(result->GetIds()[0] == 30);
+        auto statistics = JsonType::Parse(result->GetStatistics());
+        REQUIRE(statistics["distance_evaluations_by_phase"]["approximate"].GetUint64() == 0);
+        REQUIRE_FALSE(statistics["complete"].GetBool());
+
+        uint32_t unknown_term = 7;
+        query_vector.ids_ = &unknown_term;
+        result = index.KnnSearch(query, 2, search_parameters, nullptr);
+        statistics = JsonType::Parse(result->GetStatistics());
+        REQUIRE(statistics["distance_evaluations"].GetUint64() == 0);
+        REQUIRE(statistics["complete"].GetBool());
+        query_vector.ids_ = &term;
 
         query_host_id = 2;
         result = index.KnnSearch(query, 2, search_parameters, nullptr);
@@ -1187,6 +1198,10 @@ TEST_CASE("SINDIV2 ReaderIO Rerank Uses Section Offset", "[ut][SINDIV2]") {
     auto result = loaded.KnnSearch(query, k, search_param, nullptr);
     REQUIRE(result->GetDim() == k);
     REQUIRE(result->GetIds()[0] == 0);
+    auto statistics = JsonType::Parse(result->GetStatistics());
+    REQUIRE(statistics["distance_evaluations_by_phase"]["approximate"].GetUint64() == 0);
+    REQUIRE(statistics["distance_evaluations_by_phase"]["rerank"].GetUint64() > 0);
+    REQUIRE_FALSE(statistics["complete"].GetBool());
 
     for (auto& item : sv_base) {
         delete[] item.vals_;

--- a/src/datacell/disk_sindi_term_datacell.cpp
+++ b/src/datacell/disk_sindi_term_datacell.cpp
@@ -546,7 +546,6 @@ DiskSindiTermDataCell<IOTmpl>::QueryWindow(float* dists,
                                            SindiQueryContext& query_context) const {
     (void)use_term_lists_heap_insert;
     const auto& query_term_buffers = query_context.query_term_buffers;
-    query_context.evaluation_tracker.BeginWindow(window_size_);
     std::shared_lock lock(term_layout_mutex_);
     while (computer->HasNextTerm()) {
         auto it = computer->NextTermIter();
@@ -563,7 +562,7 @@ DiskSindiTermDataCell<IOTmpl>::QueryWindow(float* dists,
         if (count == 0) {
             continue;
         }
-        query_context.evaluation_tracker.Mark(tb->IdsData() + start, count);
+        query_context.has_untracked_approximate_evaluations = true;
 
         if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
             computer->ScanForAccumulateSQ8(

--- a/src/datacell/immutable_sindi_term_datacell.cpp
+++ b/src/datacell/immutable_sindi_term_datacell.cpp
@@ -320,7 +320,6 @@ ImmutableSindiTermDataCell::QueryWindow(float* dists,
                                         SindiQueryContext& query_context) const {
     CHECK_ARGUMENT(window_id < windows_.size(), "immutable SINDI window id out of range");
     const auto& window = windows_[window_id];
-    query_context.evaluation_tracker.BeginWindow(window_size_);
     auto& mapped_terms = query_context.mapped_query_terms;
     this->map_query_terms(window, computer, mapped_terms);
     for (uint32_t pos = 0; pos < mapped_terms.size(); ++pos) {
@@ -336,10 +335,10 @@ ImmutableSindiTermDataCell::QueryWindow(float* dists,
         }
         const auto begin = window.offsets[local_term];
         const auto count = computer->GetTermScanCount(window.offsets[local_term + 1] - begin);
+        query_context.has_untracked_approximate_evaluations |= count > 0;
         const auto* ids = window.id_payloads.data() + begin;
         const auto* values =
             window.value_payloads.data() + static_cast<uint64_t>(begin) * value_code_size_;
-        query_context.evaluation_tracker.Mark(ids, count);
         if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
             computer->ScanForAccumulateSQ8(query_term, ids, values, count, dists);
         } else if (sparse_value_quant_type_ == SparseValueQuantizationType::FP16) {

--- a/src/datacell/mutable_sindi_term_datacell.cpp
+++ b/src/datacell/mutable_sindi_term_datacell.cpp
@@ -219,7 +219,6 @@ MutableSindiTermDataCell::QueryWindow(float* dists,
     (void)use_term_lists_heap_insert;
     CHECK_ARGUMENT(window_id < windows_.size(), "mutable SINDI window id out of range");
     const auto& window = windows_[window_id];
-    query_context.evaluation_tracker.BeginWindow(window_size_);
     while (computer->HasNextTerm()) {
         auto it = computer->NextTermIter();
         auto term = computer->GetTerm(it);
@@ -237,7 +236,7 @@ MutableSindiTermDataCell::QueryWindow(float* dists,
 
         const auto posting_count = window.term_sizes_[term];
         const auto term_size = computer->GetTermScanCount(posting_count);
-        query_context.evaluation_tracker.Mark(window.term_ids_[term]->data(), term_size);
+        query_context.has_untracked_approximate_evaluations |= term_size > 0;
 
         if (sparse_value_quant_type_ == SparseValueQuantizationType::SQ8) {
             computer->ScanForAccumulateSQ8(it,

--- a/src/datacell/mutable_sindi_term_datacell_test.cpp
+++ b/src/datacell/mutable_sindi_term_datacell_test.cpp
@@ -27,14 +27,13 @@ using namespace vsag;
 
 namespace {
 
-uint64_t
+void
 QueryFirstWindow(const MutableSindiTermDataCellPtr& data_cell,
                  float* dists,
                  const SparseTermComputerPtr& computer,
                  Allocator* allocator) {
     SindiQueryContext query_context(allocator);
     data_cell->QueryWindow(dists, 0, computer, false, query_context);
-    return query_context.evaluation_tracker.Count();
 }
 
 }  // namespace
@@ -304,12 +303,12 @@ TEST_CASE("MutableSindiTermDataCell Basic Test", "[ut][MutableSindiTermDataCell]
 
     SECTION("test query") {
         std::vector<float> dists(count_base, 0);
-        REQUIRE(QueryFirstWindow(data_cell, dists.data(), computer, allocator.get()) == count_base);
+        QueryFirstWindow(data_cell, dists.data(), computer, allocator.get());
         for (auto i = 0; i < dists.size(); i++) {
             REQUIRE(std::abs(dists[i] - exp_dists[i]) < 1e-3);
         }
         std::fill(dists.begin(), dists.end(), 0.0F);
-        REQUIRE(QueryFirstWindow(data_cell, dists.data(), computer, allocator.get()) == count_base);
+        QueryFirstWindow(data_cell, dists.data(), computer, allocator.get());
     }
 
     SECTION("test insert heap in knn search") {

--- a/src/datacell/sindi_search_term_datacell.h
+++ b/src/datacell/sindi_search_term_datacell.h
@@ -48,14 +48,6 @@ public:
         } else {
             ++generation_;
         }
-        evaluated_ = 0;
-    }
-
-    void
-    Mark(const uint16_t* ids, uint32_t count) {
-        for (uint32_t i = 0; i < count; ++i) {
-            MarkOne(ids[i]);
-        }
     }
 
     bool
@@ -64,19 +56,12 @@ public:
             return false;
         }
         generations_[id] = generation_;
-        ++evaluated_;
         return true;
-    }
-
-    [[nodiscard]] uint64_t
-    Count() const {
-        return evaluated_;
     }
 
 private:
     Vector<uint16_t> generations_;
     uint16_t generation_{0};
-    uint64_t evaluated_{0};
 };
 
 struct SindiTermBuffer {
@@ -139,13 +124,12 @@ struct SindiQueryContext {
     explicit SindiQueryContext(Allocator* allocator)
         : query_term_buffers(allocator),
           mapped_query_terms(allocator),
-          evaluation_tracker(allocator),
           candidate_tracker(allocator) {
     }
 
     QueryTermBuffers query_term_buffers;
     MappedQueryTerms mapped_query_terms;
-    SparseEvaluationTracker evaluation_tracker;
+    bool has_untracked_approximate_evaluations{false};
     mutable SparseEvaluationTracker candidate_tracker;
 };
 

--- a/tests/test_sindi.cpp
+++ b/tests/test_sindi.cpp
@@ -577,9 +577,10 @@ TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,
     REQUIRE(result.value()->GetReasoning().find("expected_analysis") != std::string::npos);
     auto statistics = vsag::JsonType::Parse(result.value()->GetStatistics());
     REQUIRE(statistics["distance_evaluations"].GetUint64() > 0);
+    REQUIRE(statistics["distance_evaluations_by_phase"]["approximate"].GetUint64() == 0);
     REQUIRE(statistics["distance_evaluations"].GetUint64() ==
-            statistics["distance_evaluations_by_phase"]["approximate"].GetUint64() +
-                statistics["distance_evaluations_by_phase"]["rerank"].GetUint64());
+            statistics["distance_evaluations_by_phase"]["rerank"].GetUint64());
+    REQUIRE_FALSE(statistics["complete"].GetBool());
 }
 
 TEST_CASE_PERSISTENT_FIXTURE(fixtures::SINDITestIndex,


### PR DESCRIPTION
## What

- remove per-posting-ID approximate evaluation tracking from SINDI and SINDI_V2, including mutable, immutable, and disk term data cells
- retain candidate deduplication and rerank statistics
- report `complete=false` when a SINDI search performs untracked approximate evaluations
- document the statistics limitation in English and Chinese API docs

## Why

PR #2545 added `SparseEvaluationTracker::Mark()` to the SINDI posting-list hot path. A controlled Sparse38M comparison measured 49.709 QPS before that change and 30.970 QPS after it (-37.70%). Making only `Mark()` a no-op restored 49.367 QPS.

## Validation

- clang-format 15 dry-run and `git diff --check`
- Debug `unittests` and `functests` targets built successfully
- classic SINDI focused test: 1 case, 13 assertions
- SINDI_V2 mutable/immutable/ReaderIO focused tests: 3 cases, 380 assertions
- mutable/immutable/disk SINDI term data-cell tests: 24 cases, 932 assertions
- Release build
- Sparse38M, single thread pinned to CPU 2, Top-100, `query_prune_ratio=0.1`, `n_candidate=1500`, 1000 queries, three interleaved rounds per allocator:
  - default: 58.197 mean QPS (58.037-58.278), 17.183 ms mean latency
  - tracking: 58.108 mean QPS (58.037-58.195), 17.209 ms mean latency
  - all six measured passes produced checksum `20193861694`
  - tracked allocations fell by about 100 KB/query, from about 336 KB to 236 KB

The final-branch benchmark exceeds both the pre-regression 49.709 QPS and the earlier no-op ablation's 49.367 QPS. Absolute differences across historical commits are not attributed solely to this patch; the adjacent #2545/no-op ablation establishes causality.

An additional same-host A/B recheck on 2026-09-08 compared the final head `47ec2ec4` directly with parent `51545fbb`, which still contains `Mark()`. The host was slower in absolute terms for both builds, but the PR improved mean QPS from 21.757 to 36.059 (+65.73%) with the default allocator and from 23.976 to 36.133 (+50.71%) with the tracking allocator. Checksums remained `20193861694`; tracked allocations fell from 336,022.524 to 236,022.524 bytes/query. This controlled comparison confirms the regression is recovered despite cross-run host variance.
