### PR TITLE
fix(pyramid): avoid exclusive lock for child lookup

### DIFF
--- a/src/algorithm/pyramid/pyramid_index_node.cpp
+++ b/src/algorithm/pyramid/pyramid_index_node.cpp
@@ -91,13 +91,21 @@ IndexNode::AddChild(const std::string& key) {
 
 IndexNode*
 IndexNode::GetChild(const std::string& key, bool need_init) {
+    {
+        std::shared_lock lock(mutex_);
+        auto result = children_.find(key);
+        if (result != children_.end()) {
+            return result->second.get();
+        }
+        if (not need_init) {
+            return nullptr;
+        }
+    }
+
     std::unique_lock lock(mutex_);
     auto result = children_.find(key);
     if (result != children_.end()) {
         return result->second.get();
-    }
-    if (not need_init) {
-        return nullptr;
     }
     AddChild(key);
     return children_[key].get();

--- a/src/algorithm/pyramid/pyramid_test.cpp
+++ b/src/algorithm/pyramid/pyramid_test.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cmath>
 #include <future>
 #include <numeric>
@@ -1358,4 +1359,29 @@ TEST_CASE("Pyramid applies hops limit to non-root graphs", "[ut][pyramid][hops_l
     const auto limited_stats = vsag::JsonType::Parse(limited->GetStatistics());
     REQUIRE(unlimited_stats["hops"].GetInt() > limited_stats["hops"].GetInt());
     REQUIRE(limited_stats["hops"].GetInt() <= 3);
+}
+
+TEST_CASE("Pyramid IndexNode allows concurrent existing-child lookup",
+          "[ut][pyramid][index_node]") {
+    vsag::IndexCommonParam common_param;
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    common_param.allocator_ = allocator;
+    auto graph_param = std::make_shared<vsag::SparseGraphDatacellParameter>();
+    vsag::IndexNode node(allocator.get(), graph_param, 1, common_param, graph_param);
+    auto* expected = node.GetChild("existing", true);
+
+    std::shared_lock node_lock(node.mutex_);
+    std::promise<void> started;
+    auto started_future = started.get_future();
+    auto lookup = std::async(std::launch::async, [&]() {
+        started.set_value();
+        return node.GetChild("existing", true);
+    });
+    started_future.wait();
+    const bool completed_while_shared =
+        lookup.wait_for(std::chrono::seconds(1)) == std::future_status::ready;
+    node_lock.unlock();
+
+    REQUIRE(lookup.get() == expected);
+    REQUIRE(completed_while_shared);
 }


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2874

## What Changed

- Use a shared lock for the existing-child fast path in `IndexNode::GetChild()`.
- Acquire the exclusive lock only for a missing child and recheck before creation.
- Add a concurrency regression test covering lookup while another shared reader holds the node mutex.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
clang-format-15 -i src/algorithm/pyramid/pyramid_index_node.cpp src/algorithm/pyramid/pyramid_test.cpp
git diff --check
cmake --build build-release-perf --parallel 32
  Passed: Release shared and static libraries rebuilt successfully.

The pyramid test translation unit passed a GCC 11.4 -Werror syntax-only compile.
The focused standalone concurrency check passed:
  completed_while_shared=1 same_child=1

The full Debug test target was stopped before completion at the user's request after external dependency download delays. No test failure was observed.

Performance, identical 20k sample and 32-thread multi-layer compressed configuration:
  Before: 108.39s, 184.51 vectors/s, 155.28% process CPU
  After:    9.85s, 2031.48 vectors/s, 2087.24% process CPU
  Speedup: 11.0x

Additional 200k validation:
  Combined date + host: 85.21s, 2347.15 vectors/s, 86.45% average configured capacity
  Host multi-layer only: 68.84s, 2905.10 vectors/s; steady-state CPU 99.2%-99.5% of 32-thread capacity
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: existing child lookups no longer require exclusive access; child creation semantics are unchanged

## Performance and Concurrency Impact

- Performance impact: improves the measured Pyramid multi-layer root build by 11.0x on the sampled workload
- Concurrency/thread-safety impact: existing children are read under a shared lock; missing children retain exclusive locking and double-checked creation

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the commit to restore exclusive locking for all child lookups

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for the bug fix
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
