### PR TITLE
[Backport 1.0] fix(build): stabilize x86 bundled OpenBLAS detection

### DIFF
--- a/.github/workflows/build_release_wheel.yml
+++ b/.github/workflows/build_release_wheel.yml
@@ -131,6 +131,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'VSAG_OPENBLAS_TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: "pip install numpy pytest && ls -alF /project/ && python /project/tests/python/run_test.py"
 
       - uses: actions/upload-artifact@v5
@@ -164,6 +165,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.cibw-build-id }}
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'VSAG_OPENBLAS_TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: |
             pip install numpy pytest && \
             echo "=== Running VSAG Python Tests ===" && \
@@ -211,6 +213,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: "cp36-*"
+          CIBW_ENVIRONMENT: ${{ matrix.arch == 'x86_64' && 'VSAG_OPENBLAS_TARGET=GENERIC' || '' }}
           CIBW_TEST_COMMAND: |
             pip install numpy pytest && \
             echo "=== Running VSAG Python Tests ===" && \

--- a/.github/workflows/python_build_and_test.yml
+++ b/.github/workflows/python_build_and_test.yml
@@ -31,7 +31,10 @@ jobs:
         run: |
             sudo apt update
             sudo apt install -y python3-venv
-            export CMAKE_GENERATOR="Ninja"; make pyvsag
+            export CMAKE_GENERATOR="Ninja"
+            export VSAG_OPENBLAS_TARGET=GENERIC
+            export CIBW_ENVIRONMENT="${CIBW_ENVIRONMENT:+$CIBW_ENVIRONMENT }VSAG_OPENBLAS_TARGET=GENERIC"
+            make pyvsag
       - name: Save Wheel
         uses: actions/upload-artifact@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ test:                    ## Build and run unit tests.
 .PHONY: test-cmake
 test-cmake:              ## Run focused CMake helper tests.
 	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/thirdparty_override_test.cmake
+	cmake -DVSAG_SOURCE_DIR=${CURDIR} -P tests/cmake/openblas_target_test.cmake
 
 .PHONY: asan
 asan:                    ## Build with AddressSanitizer option.

--- a/cmake/VSAGHelpers.cmake
+++ b/cmake/VSAGHelpers.cmake
@@ -126,6 +126,22 @@ function (vsag_fail_missing_system_dep dep package hint)
              "or set VSAG_USE_SYSTEM_${dep}=OFF to use the bundled copy.")
 endfunction ()
 
+# Translate the OpenBLAS CPU baseline override into one validated make argument.
+function (vsag_get_openblas_target_arg out_var)
+    set (_target_arg "")
+    if (DEFINED ENV{VSAG_OPENBLAS_TARGET}
+            AND NOT "$ENV{VSAG_OPENBLAS_TARGET}" STREQUAL "")
+        string (STRIP "$ENV{VSAG_OPENBLAS_TARGET}" _openblas_target)
+        if (NOT _openblas_target MATCHES "^[A-Za-z0-9_]+$")
+            message (FATAL_ERROR
+                     "VSAG_OPENBLAS_TARGET must contain only letters, digits, or underscores; "
+                     "got '$ENV{VSAG_OPENBLAS_TARGET}'.")
+        endif ()
+        set (_target_arg "TARGET=${_openblas_target}")
+    endif ()
+    set (${out_var} "${_target_arg}" PARENT_SCOPE)
+endfunction ()
+
 # Return TRUE when ${target}'s declared include directories contain ${header}.
 function (vsag_target_has_header target header out_var)
     set (_include_dirs "")

--- a/extern/openblas/openblas.cmake
+++ b/extern/openblas/openblas.cmake
@@ -186,6 +186,8 @@ if (NOT OPENBLAS_FOUND)
     string (STRIP "${_openblas_c_flags}" _openblas_c_flags)
     string (STRIP "${_openblas_cxx_flags}" _openblas_cxx_flags)
 
+    vsag_get_openblas_target_arg (_openblas_target_arg)
+
     ExternalProject_Add (
         ${name}
         URL ${openblas_urls}
@@ -204,9 +206,10 @@ if (NOT OPENBLAS_FOUND)
             OMP_NUM_THREADS=1
             PATH=/usr/lib/ccache:$ENV{PATH}
             LD_LIBRARY_PATH=/opt/alibaba-cloud-compiler/lib64/:$ENV{LD_LIBRARY_PATH}
-            make USE_THREAD=0 USE_LOCKING=1 DYNAMIC_ARCH=1 NOFORTRAN=1 -j${NUM_BUILDING_JOBS}
+            make USE_THREAD=0 USE_LOCKING=1 ${_openblas_target_arg} DYNAMIC_ARCH=1
+                 NOFORTRAN=1 -j${NUM_BUILDING_JOBS}
         INSTALL_COMMAND
-            make DYNAMIC_ARCH=1 NOFORTRAN=1 PREFIX=${install_dir} install
+            make ${_openblas_target_arg} DYNAMIC_ARCH=1 NOFORTRAN=1 PREFIX=${install_dir} install
         BUILD_IN_SOURCE 1
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE

--- a/tests/cmake/openblas_target_fixture.cmake
+++ b/tests/cmake/openblas_target_fixture.cmake
@@ -1,0 +1,8 @@
+if (NOT DEFINED VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+
+include ("${VSAG_SOURCE_DIR}/cmake/VSAGHelpers.cmake")
+
+vsag_get_openblas_target_arg (openblas_target_arg)
+message (STATUS "OPENBLAS_TARGET_ARG=${openblas_target_arg}")

--- a/tests/cmake/openblas_target_test.cmake
+++ b/tests/cmake/openblas_target_test.cmake
@@ -1,0 +1,62 @@
+if (NOT DEFINED VSAG_SOURCE_DIR)
+    message (FATAL_ERROR "VSAG_SOURCE_DIR is required")
+endif ()
+
+set (fixture "${VSAG_SOURCE_DIR}/tests/cmake/openblas_target_fixture.cmake")
+
+function (assert_match_count content pattern expected description)
+    string (REGEX MATCHALL "${pattern}" matches "${content}")
+    list (LENGTH matches actual)
+    if (NOT actual EQUAL expected)
+        message (FATAL_ERROR
+                 "${description}: expected ${expected} matches, got ${actual}")
+    endif ()
+endfunction ()
+
+function (run_fixture target expected_result expected_pattern)
+    unset (ENV{VSAG_OPENBLAS_TARGET})
+    if (NOT "${target}" STREQUAL "<UNSET>")
+        set (ENV{VSAG_OPENBLAS_TARGET} "${target}")
+    endif ()
+
+    execute_process (
+        COMMAND "${CMAKE_COMMAND}" "-DVSAG_SOURCE_DIR:PATH=${VSAG_SOURCE_DIR}" -P "${fixture}"
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE stdout
+        ERROR_VARIABLE stderr)
+    set (output "${stdout}\n${stderr}")
+    if (expected_result STREQUAL "PASS" AND NOT result EQUAL 0)
+        message (FATAL_ERROR "OpenBLAS target fixture failed (${result}):\n${output}")
+    elseif (expected_result STREQUAL "FAIL" AND result EQUAL 0)
+        message (FATAL_ERROR "OpenBLAS target fixture unexpectedly passed:\n${output}")
+    endif ()
+    if (NOT output MATCHES "${expected_pattern}")
+        message (FATAL_ERROR
+                 "OpenBLAS target fixture output did not match '${expected_pattern}':\n${output}")
+    endif ()
+endfunction ()
+
+run_fixture ("<UNSET>" PASS "OPENBLAS_TARGET_ARG=")
+run_fixture ("  GENERIC  " PASS "OPENBLAS_TARGET_ARG=TARGET=GENERIC")
+run_fixture ("RISCV64_GENERIC" PASS "OPENBLAS_TARGET_ARG=TARGET=RISCV64_GENERIC")
+run_fixture ("GENERIC;NOFORTRAN=0" FAIL "must contain only letters, digits, or underscores")
+run_fixture ("GENERIC NOFORTRAN=0" FAIL "must contain only letters, digits, or underscores")
+
+unset (ENV{VSAG_OPENBLAS_TARGET})
+
+file (READ "${VSAG_SOURCE_DIR}/extern/openblas/openblas.cmake" openblas_cmake)
+assert_match_count ("${openblas_cmake}" "\\$\\{_openblas_target_arg\\}" 2
+                    "OpenBLAS build and install target propagation")
+assert_match_count ("${openblas_cmake}" "DYNAMIC_ARCH=1" 2
+                    "OpenBLAS dynamic architecture preservation")
+
+file (READ "${VSAG_SOURCE_DIR}/.github/workflows/python_build_and_test.yml" python_workflow)
+assert_match_count ("${python_workflow}" "VSAG_OPENBLAS_TARGET=GENERIC" 2
+                    "Python x86 wheel target propagation")
+
+file (READ "${VSAG_SOURCE_DIR}/.github/workflows/build_release_wheel.yml" release_workflow)
+assert_match_count ("${release_workflow}"
+                    "matrix.arch == 'x86_64' && 'VSAG_OPENBLAS_TARGET=GENERIC'" 3
+                    "x86-only release wheel target propagation")
+
+message (STATUS "OpenBLAS target tests passed")


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Linked Issue

- Fixes: #2507

This fixes the 1.0 release-line portion only. The corresponding `main` work remains in #2819.

## What Changed

- Adapt the validated OpenBLAS `TARGET=GENERIC` mechanism from #2819 to the current 1.0 build.
- Trim and validate `VSAG_OPENBLAS_TARGET`, then pass it to bundled OpenBLAS build and install
  commands while retaining `DYNAMIC_ARCH=1` runtime dispatch.
- Forward the override only to 1.0's x86 Python push-wheel and release-wheel builds; AArch64 is
  unchanged.
- Add focused CMake coverage for mapping, validation, build/install propagation, and x86-only CI
  wiring.
- Leave the scheduled daily workflow unchanged because its 1.0 copy explicitly checks out `main`.

System-dependency routing is unchanged: `AUTO` may discover a preinstalled OpenBLAS, `ON` requires
one, and `OFF` intentionally uses the bundled copy. MKL selection is also unchanged.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
make test-cmake
  Third-party pinned-variable tests passed
  OpenBLAS target tests passed

actionlint 1.7.12 on both changed workflows
PyYAML parse on both changed workflows
  passed

Bundled configure with VSAG_USE_SYSTEM_DEPS=OFF and VSAG_OPENBLAS_TARGET=GENERIC
  selected bundled OpenBLAS
  generated TARGET=GENERIC DYNAMIC_ARCH=1 for build and install

cmake --build <bundled-build> --target openblas --parallel 2
  Completed 'openblas'

Explicit VSAG_USE_SYSTEM_OPENBLAS=ON configure
  selected system OpenBLAS

ENABLE_INTEL_MKL=ON configure
  selected dynamic MKL

cmake --build <system-build> --target vsag --parallel 4
  linked src/libvsag.so.1.0.0 (289 steps)

git diff --check
  passed
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: selected x86 bundled OpenBLAS CI builds use a generic common-code baseline;
  optimized runtime kernel dispatch remains enabled

## Performance and Concurrency Impact

- Performance impact: none expected; runtime-dispatched kernels remain available
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other

The 1.0 branch has no existing documentation for this CI-only override.

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this commit to restore build-host CPU auto-detection for these x86 jobs

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
