### PR TITLE
fix(test): preserve async I/O mapping profiles

### DIFF
--- a/src/algorithm/hgraph/hgraph_parameter_test.cpp
+++ b/src/algorithm/hgraph/hgraph_parameter_test.cpp
@@ -773,12 +773,10 @@ TEST_CASE("HGraph maps RaBitQ x+y split params", "[ut][HGraphParameter]") {
     auto base_json = typed_param->base_codes_param->ToJson();
     REQUIRE(base_json["codes_type"].GetString() == std::string("rabitq_split"));
     REQUIRE(base_json["io_params"]["type"].GetString() == std::string("block_memory_io"));
-#if HAVE_LIBAIO
-    const std::string expected_supplement_io_type = "async_io";
-#else
-    const std::string expected_supplement_io_type = "buffer_io";
-#endif
-    REQUIRE(base_json["supplement_io_params"]["type"].GetString() == expected_supplement_io_type);
+    REQUIRE(typed_param->base_codes_param->supplement_io_parameter != nullptr);
+    REQUIRE(typed_param->base_codes_param->supplement_io_parameter->GetTypeName() ==
+            std::string("async_io"));
+    REQUIRE(base_json["supplement_io_params"]["type"].GetString() == std::string("async_io"));
     REQUIRE(base_json["supplement_io_params"]["file_path"].GetString() ==
             std::string("/tmp/vsag_rabitq_split_supplement"));
     REQUIRE(base_json["quantization_params"]["rabitq_version"].GetString() == std::string("split"));

--- a/src/algorithm/pyramid/pyramid_zparameters_test.cpp
+++ b/src/algorithm/pyramid/pyramid_zparameters_test.cpp
@@ -541,12 +541,10 @@ TEST_CASE("Pyramid maps RaBitQ x+y split params", "[ut][PyramidParameters]") {
     const auto base_json = typed_param->base_codes_param->ToJson();
     REQUIRE(base_json["codes_type"].GetString() == std::string("rabitq_split"));
     REQUIRE(base_json["io_params"]["type"].GetString() == std::string("block_memory_io"));
-#if HAVE_LIBAIO
-    const std::string expected_supplement_io_type = "async_io";
-#else
-    const std::string expected_supplement_io_type = "buffer_io";
-#endif
-    REQUIRE(base_json["supplement_io_params"]["type"].GetString() == expected_supplement_io_type);
+    REQUIRE(typed_param->base_codes_param->supplement_io_parameter != nullptr);
+    REQUIRE(typed_param->base_codes_param->supplement_io_parameter->GetTypeName() ==
+            std::string("async_io"));
+    REQUIRE(base_json["supplement_io_params"]["type"].GetString() == std::string("async_io"));
     REQUIRE(base_json["supplement_io_params"]["file_path"].GetString() ==
             std::string("/tmp/vsag_pyramid_rabitq_split_supplement"));
     REQUIRE(base_json["quantization_params"]["rabitq_version"].GetString() == std::string("split"));


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2866
- Fixes: #2868

## What Changed

- Align the Pyramid RaBitQ x+y split mapper regression with the stable configured `async_io` profile when libaio is unavailable.
- Assert both the mapped supplement parameter object and its serialized JSON profile.
- Apply the same shared-root correction to the HGraph regression reported by #2868, avoiding a duplicate PR.
- Leave production mapping and the buffered compatibility backend unchanged.

PR #2793 intentionally made configured I/O profile names stable across fallback builds: `async_io` remains the public parameter profile, while a no-libaio factory selects the buffered compatibility backend. The two older mapper tests retained the pre-refactor conditional expectation.

## Test Evidence

- [ ] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
No-libaio reproduction before the change:
  Pyramid maps RaBitQ x+y split params: failed, "async_io" == "buffer_io"
  HGraph maps RaBitQ x+y split params: failed, "async_io" == "buffer_io"
  AsyncIO Parameter: passed, 6,316 assertions

No-libaio focused validation after the change:
  Pyramid maps RaBitQ x+y split params: passed, 15 assertions
  HGraph maps RaBitQ x+y split params: passed, 13 assertions
  AsyncIO Parameter: passed, 6,316 assertions

git diff --check: passed
```

`clang-format-15` and `clang-tidy-15` are unavailable in the local environment. `make fmt` refused the installed clang-format 22 as required by the repository, and no unsupported formatter or linter was used.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: none; regression expectations now match the existing stable profile/fallback contract

## Performance and Concurrency Impact

- Performance impact: none from this test-only change
- Concurrency/thread-safety impact: none

The compiler SIGKILL symptom was investigated separately. PR #2857 split the factory instantiations: its controlled Debug comparison reduced peak compiler RSS from 3,767 MiB to 1,271 MiB. A fresh Debug measurement used 248 MiB for the dispatch object and 1,315 MiB for the dense L2 shard; a fresh sanitizer build used 295 MiB for dispatch and completed the dense L2 shard with an observed high-water mark of about 3,288 MiB. On the post-merge main workflow, x86, AArch64, and macOS ASan compiler jobs all passed. No unrelated source change is included for an external kill.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other: <!-- path -->

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the test-only commit

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)
