### PR TITLE
feat(sindi): accept string host metadata

### DIFF
--- a/docs/docs/en/src/advanced/new_serialization.md
+++ b/docs/docs/en/src/advanced/new_serialization.md
@@ -203,13 +203,14 @@ SINDI writes these streaming blocks in order:
 | `label_table` | external labels and label remap | yes |
 | `sindi_rerank_index` | optional rerank flat index when rerank is enabled | conditional |
 | `sindi_term_id_mapper` | optional term-id remapping table | conditional |
-| `sindi_host_metadata` | optional host IDs and one-or-more inner-ID ranges per host | conditional |
+| `sindi_host_metadata` | optional host dictionary and one-or-more inner-ID ranges per host | conditional |
 | `sindi_date_metadata` | optional encoded date buckets and quarter/host interval directories | conditional |
 
 `DeserializeStreaming` restores the full in-memory SINDI index. `Index::Load` can create the SINDI
 index directly from streaming metadata and currently loads all emitted SINDI blocks into memory.
 Mutable and immutable SINDI runtimes both support this streaming path. Legacy serialization stores
-standalone host metadata or date-routing metadata for mutable and immutable indexes. These
+standalone host metadata, including its persisted string-to-ID dictionary, or date-routing metadata
+for mutable and immutable indexes. These
 top-level payloads are mutually exclusive; combined date-and-host routing stores its host directory
 inside the date payload. A restored mutable date-aware index rejects incremental `Add()`.
 
@@ -224,13 +225,14 @@ SINDI_V2 writes these streaming blocks in order:
 | `sindi_rerank_index` | optional rerank index when rerank is enabled | conditional |
 | `extra_info` | optional per-document extra information | conditional |
 | `sindi_term_id_mapper` | optional term-id remapping table | conditional |
-| `sindi_host_metadata` | optional host IDs and one-or-more inner-ID ranges per host | conditional |
+| `sindi_host_metadata` | optional host dictionary and one-or-more inner-ID ranges per host | conditional |
 | `sindi_date_metadata` | optional encoded date buckets and quarter/host interval directories | conditional |
 
 `DeserializeStreaming` and `Index::Load` restore mutable or immutable SINDI_V2 runtimes from these
-blocks. Legacy serialization stores standalone host metadata or date-routing metadata for mutable
-and immutable indexes. These top-level payloads are mutually exclusive; combined date-and-host
-routing stores its host directory inside the date payload. A restored mutable date-aware index
+blocks. Legacy serialization stores standalone host metadata, including its persisted string-to-ID
+dictionary, or date-routing metadata for mutable and immutable indexes. These top-level payloads are
+mutually exclusive; combined date-and-host routing stores its host dictionary and directory inside
+the date payload. A restored mutable date-aware index
 rejects incremental `Add()`.
 
 ## Pyramid Blocks

--- a/docs/docs/en/src/api/dataset.md
+++ b/docs/docs/en/src/api/dataset.md
@@ -152,8 +152,9 @@ destructor frees each `vectors_` separately.
 ## Named metadata
 
 `UInt32Metadata(name, values)` attaches one unsigned integer per dataset element, and
-`GetUInt32Metadata` returns the named array or `nullptr`. SINDI and SINDI_V2 use `host_id` metadata
-for host filtering. Date filtering uses the existing named string-path API with
+`GetUInt32Metadata` returns the named array or `nullptr`. `StringMetadata(name, values)` and
+`GetStringMetadata(name)` provide the equivalent generic named string arrays. SINDI and SINDI_V2
+use string metadata named `host` for host filtering. Date filtering uses the existing named string-path API with
 `Paths("date", values)` and `GetPaths("date")`. A date range on a one-element query dataset uses
 the separate named paths `date_begin` and `date_end`; each points to one canonical `YYYY`,
 `YYYY/MM`, or `YYYY/MM/DD` string. These arrays follow the normal Dataset ownership, deep-copy, and

--- a/docs/docs/en/src/indexes/sindi.md
+++ b/docs/docs/en/src/indexes/sindi.md
@@ -140,22 +140,22 @@ Indexes written without this marker remain compatible and are normalized during 
 
 ### Host filtering
 
-Mutable and immutable SINDI and [SINDI_V2](sindi_v2.md) indexes can group documents by a single
-numeric host and avoid returning documents from other hosts. Attach a complete `uint32_t` `host_id`
-array to a host-aware `Build()` or mutable `Add()` batch. Use `0` for a document with no host:
+Mutable and immutable SINDI and [SINDI_V2](sindi_v2.md) indexes can group documents by their source
+host and avoid returning documents from other hosts. Attach a complete string `host` array to a
+host-aware `Build()` or mutable `Add()` batch. Use an empty string for a document with no host:
 
 ```cpp
 base->NumElements(n)
     ->SparseVectors(sparse_vectors)
     ->Ids(ids)
-    ->UInt32Metadata("host_id", base_host_ids)
+    ->StringMetadata("host", base_hosts)
     ->Owner(false);
 index->Build(base);
 
-uint32_t query_host_id = 42;
+std::string query_host = "example.com";
 query->NumElements(1)
     ->SparseVectors(&query_vec)
-    ->UInt32Metadata("host_id", &query_host_id)
+    ->StringMetadata("host", &query_host)
     ->Owner(false);
 ```
 
@@ -164,14 +164,15 @@ labels. Host queries scan the relevant posting windows and apply exact membershi
 host's one or more internal-ID ranges. Repeated mutable `Add()` calls may append disjoint ranges for
 the same host. Tombstones and an additional user `Filter` are applied together with host membership.
 
-Host ID `0` is the missing-host bucket; values from `1` through `UINT32_MAX` identify normal hosts.
-The number of distinct hosts cannot exceed the number of successfully indexed documents. Once a
-mutable index contains host metadata, every later `Add()` must provide a complete `host_id` array;
-host metadata cannot be introduced after host-unaware documents. A query with `host_id: 0` searches
-only missing-host documents, while omitting `host_id` preserves full-index KNN behavior. A host with
-no indexed documents returns an empty result. Indexes built without base host metadata ignore query
-host metadata and retain their previous behavior. Host filtering currently applies only to KNN;
-range search keeps its existing full-index behavior.
+Host strings are matched byte for byte without case folding or URL normalization. VSAG assigns
+compact internal IDs and persists the string-to-ID dictionary with the index; callers never provide
+those IDs. The empty string is the missing-host bucket. Once a mutable index contains host metadata,
+every later `Add()` must provide a complete `host` array; host metadata cannot be introduced after
+host-unaware documents. An empty-string query searches only missing-host documents, while omitting
+`host` preserves full-index KNN behavior. An unknown host returns an empty result. Indexes built
+without base host metadata ignore query host metadata and retain their previous behavior. The old
+numeric `host_id` input is rejected. Host filtering currently applies only to KNN; range search keeps
+its existing full-index behavior.
 
 ### Date-bucket filtering
 
@@ -205,7 +206,7 @@ range ending at `2026/08/01` can match a base day bucket on August 1, but not th
 `2026/08` bucket. The two range endpoints are required together, must be ordered after expansion,
 and cannot be combined with the single `date` selector.
 
-The date-aware build orders documents by calendar quarter and, when `host_id` is present, by host
+The date-aware build orders documents by calendar quarter and, when `host` is present, by host
 inside each quarter. For a mutable index, date metadata can be supplied by `Build()` or the first
 `Add()` while the index is empty. Once the index contains documents, date metadata cannot be
 introduced, and a date-aware mutable index rejects every later `Add()`. This build-once restriction

--- a/docs/docs/en/src/indexes/sindi_v2.md
+++ b/docs/docs/en/src/indexes/sindi_v2.md
@@ -98,12 +98,12 @@ requires `rerank_layout: 0` and the default `block_memory_io` rerank backend.
 
 ### Host filtering
 
-SINDI_V2 supports the same `uint32_t` `host_id` build and KNN-query metadata contract as
+SINDI_V2 supports the same string `host` build and KNN-query metadata contract as
 [SINDI](sindi.md#host-filtering). Both mutable and immutable indexes are supported. It uses the
 shared host grouping and routing component while retaining its own term-first posting storage.
 Host membership is enforced during posting-window search, including multiple ranges created by
-mutable `Add()`. Missing host ID `0`, mutable `Add()` metadata rules, streaming serialization, and
-the KNN-only scope are the same as SINDI.
+mutable `Add()`. The empty-string missing-host value, persisted internal dictionary, mutable `Add()`
+metadata rules, streaming serialization, and the KNN-only scope are the same as SINDI.
 
 ### Date-bucket filtering
 

--- a/docs/docs/zh/src/advanced/new_serialization.md
+++ b/docs/docs/zh/src/advanced/new_serialization.md
@@ -182,13 +182,14 @@ SINDI 按顺序写入以下 streaming blocks：
 | `label_table` | 外部 label 和 label remap | 是 |
 | `sindi_rerank_index` | rerank 开启时的可选 rerank flat index | 条件必需 |
 | `sindi_term_id_mapper` | 可选 term-id remap 表 | 条件必需 |
-| `sindi_host_metadata` | 可选 host ID 及每个 host 的一个或多个 inner-ID 区间 | 条件必需 |
+| `sindi_host_metadata` | 可选 host 字典及每个 host 的一个或多个 inner-ID 区间 | 条件必需 |
 | `sindi_date_metadata` | 可选编码日期 bucket 以及季度/host 区间目录 | 条件必需 |
 
 `DeserializeStreaming` 会恢复完整的内存 SINDI 索引。`Index::Load` 可以直接从 streaming metadata
 创建 SINDI 索引对象，当前会把写出的 SINDI blocks 都加载到内存中。mutable 与 immutable SINDI
 运行态均支持该 streaming 路径。旧版序列化会保存 mutable 与 immutable 索引的独立 host metadata
-或日期路由 metadata。这两种顶层 payload 互斥；日期与 host 组合路由会把 host 目录保存在日期
+（包含持久化的字符串到 ID 字典）或日期路由 metadata。这两种顶层 payload 互斥；日期与 host
+组合路由会把 host 字典和目录保存在日期
 payload 内。恢复后的 mutable 日期索引会拒绝增量 `Add()`。
 
 ## SINDI_V2 Blocks
@@ -202,12 +203,13 @@ SINDI_V2 按顺序写入以下 streaming blocks：
 | `sindi_rerank_index` | rerank 开启时的可选 rerank index | 条件必需 |
 | `extra_info` | 可选逐文档 extra information | 条件必需 |
 | `sindi_term_id_mapper` | 可选 term-id remap 表 | 条件必需 |
-| `sindi_host_metadata` | 可选 host ID 及每个 host 的一个或多个 inner-ID 区间 | 条件必需 |
+| `sindi_host_metadata` | 可选 host 字典及每个 host 的一个或多个 inner-ID 区间 | 条件必需 |
 | `sindi_date_metadata` | 可选编码日期 bucket 以及季度/host 区间目录 | 条件必需 |
 
 `DeserializeStreaming` 与 `Index::Load` 可以从这些 blocks 恢复 mutable 或 immutable SINDI_V2。
-旧版序列化会保存 mutable 与 immutable 索引的独立 host metadata 或日期路由 metadata。这两种顶层
-payload 互斥；日期与 host 组合路由会把 host 目录保存在日期 payload 内。恢复后的 mutable 日期索引
+旧版序列化会保存 mutable 与 immutable 索引的独立 host metadata（包含持久化的字符串到 ID 字典）
+或日期路由 metadata。这两种顶层 payload 互斥；日期与 host 组合路由会把 host 字典和目录保存在日期
+payload 内。恢复后的 mutable 日期索引
 会拒绝增量 `Add()`。
 
 ## Pyramid Blocks

--- a/docs/docs/zh/src/api/dataset.md
+++ b/docs/docs/zh/src/api/dataset.md
@@ -149,8 +149,9 @@ struct MultiVector {
 ## 命名 metadata
 
 `UInt32Metadata(name, values)` 为每个 dataset 元素附加一个无符号整数，
-`GetUInt32Metadata` 返回对应命名数组，不存在时返回 `nullptr`。SINDI 和 SINDI_V2 使用
-`host_id` metadata 实现 host 过滤。日期过滤复用现有命名字符串 path API，通过
+`GetUInt32Metadata` 返回对应命名数组，不存在时返回 `nullptr`。`StringMetadata(name, values)`
+和 `GetStringMetadata(name)` 提供对应的通用命名字符串数组。SINDI 和 SINDI_V2 使用名为
+`host` 的字符串 metadata 实现 host 过滤。日期过滤复用现有命名字符串 path API，通过
 `Paths("date", values)` 和 `GetPaths("date")` 传递日期 bucket。单元素查询 Dataset 的日期范围
 使用独立的 `date_begin` 和 `date_end` 命名 path；两者各指向一个规范的 `YYYY`、`YYYY/MM` 或
 `YYYY/MM/DD` 字符串。这些数组遵循 Dataset 通用的 ownership、深拷贝和 Append 规则。

--- a/docs/docs/zh/src/indexes/sindi.md
+++ b/docs/docs/zh/src/indexes/sindi.md
@@ -130,22 +130,22 @@ mutable 和 immutable 运行态均支持 `SerializeStreaming`、`DeserializeStre
 
 ### Host 过滤
 
-mutable 和 immutable SINDI 及 [SINDI_V2](sindi_v2.md) 索引都可以按单值数值 host 对文档
+mutable 和 immutable SINDI 及 [SINDI_V2](sindi_v2.md) 索引都可以按来源 host 对文档
 分组，避免返回其他 host 的文档。host-aware `Build()` 或 mutable `Add()` 批次需要提供完整的
-`uint32_t` `host_id` 数组；没有 host 的文档使用 `0`：
+字符串 `host` 数组；没有 host 的文档使用空字符串：
 
 ```cpp
 base->NumElements(n)
     ->SparseVectors(sparse_vectors)
     ->Ids(ids)
-    ->UInt32Metadata("host_id", base_host_ids)
+    ->StringMetadata("host", base_hosts)
     ->Owner(false);
 index->Build(base);
 
-uint32_t query_host_id = 42;
+std::string query_host = "example.com";
 query->NumElements(1)
     ->SparseVectors(&query_vec)
-    ->UInt32Metadata("host_id", &query_host_id)
+    ->StringMetadata("host", &query_host)
     ->Owner(false);
 ```
 
@@ -154,12 +154,13 @@ query->NumElements(1)
 精确成员检查。多次 mutable `Add()` 可以为同一 host 追加互不连续的区间；删除标记和额外的
 用户 `Filter` 会与 host 成员检查共同生效。
 
-host ID `0` 是缺失 host 分组，`1` 到 `UINT32_MAX` 表示普通 host；不同 host 的数量不能超过
-成功写入索引的文档数。mutable 索引一旦包含 host metadata，后续每次 `Add()` 都必须提供
-完整的 `host_id` 数组；已有 host-unaware 文档后不能再引入 host metadata。查询
-`host_id: 0` 时只检索缺失 host 的文档，不提供 `host_id` 时保留全索引 KNN 行为；查询没有
-已索引文档的 host 返回空结果。构建时没有 base host metadata 的索引会忽略查询 host
-metadata，行为保持不变。host 过滤当前仅适用于 KNN；范围搜索仍使用原有全索引路径。
+host 字符串按字节精确匹配，不做大小写折叠或 URL 归一化。VSAG 在内部为字符串分配紧凑 ID，
+并将字符串到 ID 的字典随索引落盘；调用方不需要接触这些 ID。空字符串是缺失 host 分组。
+mutable 索引一旦包含 host metadata，后续每次 `Add()` 都必须提供完整的 `host` 数组；已有
+host-unaware 文档后不能再引入 host metadata。空字符串查询只检索缺失 host 的文档，不提供
+`host` 时保留全索引 KNN 行为；未知 host 返回空结果。构建时没有 base host metadata 的索引会
+忽略查询 host metadata，行为保持不变。旧的数值 `host_id` 输入会被拒绝。host 过滤当前仅适用于
+KNN；范围搜索仍使用原有全索引路径。
 
 ### 日期 bucket 过滤
 
@@ -190,7 +191,7 @@ query->Paths("date_begin", &date_begin)
 因此结束于 `2026/08/01` 的范围可以命中 8 月 1 日的日 bucket，但不能命中较粗的
 `2026/08` bucket。两个端点缺一不可，扩展后必须保持正序，并且不能与单值 `date` 同时使用。
 
-日期构建按自然季度排序；同时提供 `host_id` 时，再在每个季度内按 host 排序。mutable 索引只能在
+日期构建按自然季度排序；同时提供 `host` 时，再在每个季度内按 host 排序。mutable 索引只能在
 索引为空时通过 `Build()` 或第一次 `Add()` 提供日期 metadata。索引已有文档后不能再引入日期
 metadata，已经包含日期 metadata 的 mutable 索引会拒绝之后的所有 `Add()`，从而避免增量维护季度
 分区。仅使用 host 的 mutable 索引仍保留原有的增量 `Add()` 能力。

--- a/docs/docs/zh/src/indexes/sindi_v2.md
+++ b/docs/docs/zh/src/indexes/sindi_v2.md
@@ -96,11 +96,11 @@ auto result = index->KnnSearch(
 
 ### Host 过滤
 
-SINDI_V2 支持与 [SINDI](sindi.md#host-过滤) 相同的 `uint32_t` `host_id` 构建数据和 KNN 查询
+SINDI_V2 支持与 [SINDI](sindi.md#host-过滤) 相同的字符串 `host` 构建数据和 KNN 查询
 metadata 约定。mutable 与 immutable 索引均支持该功能。两者共用 host 分组与路由组件，同时
 SINDI_V2 保持自己的 term-first posting 存储。host 成员检查统一在 posting-window 检索中执行，
-并支持 mutable `Add()` 产生的多个区间。缺失 host ID `0`、mutable `Add()` metadata、streaming
-序列化及仅支持 KNN 的规则均与 SINDI 相同。
+并支持 mutable `Add()` 产生的多个区间。空字符串缺失 host、持久化内部字典、mutable `Add()`
+metadata、streaming 序列化及仅支持 KNN 的规则均与 SINDI 相同。
 
 ### 日期 bucket 过滤
 

--- a/include/vsag/dataset.h
+++ b/include/vsag/dataset.h
@@ -377,6 +377,28 @@ public:
     GetUInt32Metadata(const std::string& name) const = 0;
 
     /**
+     * @brief Sets a named array of string metadata values.
+     *
+     * The array contains one value per dataset element. It follows the same ownership rules as
+     * the other pointer-backed Dataset fields.
+     *
+     * @param name Metadata name.
+     * @param values Pointer to the metadata values.
+     * @return DatasetPtr A shared pointer to the dataset with updated metadata.
+     */
+    virtual DatasetPtr
+    StringMetadata(const std::string& name, const std::string* values) = 0;
+
+    /**
+     * @brief Retrieves a named array of string metadata values.
+     *
+     * @param name Metadata name.
+     * @return const std::string* Pointer to the metadata values, or nullptr when absent.
+     */
+    virtual const std::string*
+    GetStringMetadata(const std::string& name) const = 0;
+
+    /**
      * @brief Sets the extra info for the dataset.
      *
      * @param paths Pointer to extra info.

--- a/src/algorithm/sindi/sindi.cpp
+++ b/src/algorithm/sindi/sindi.cpp
@@ -1526,8 +1526,8 @@ SINDI::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) {
                                        basic_info[SINDI_HAS_HOST_METADATA_KEY].GetBool();
     const bool expects_date_metadata = basic_info.Contains(SINDI_DATE_METADATA_FORMAT_VERSION_KEY);
     if (expects_date_metadata) {
-        CHECK_ARGUMENT(basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt() ==
-                           SINDI_DATE_METADATA_FORMAT_VERSION,
+        CHECK_ARGUMENT(IsSupportedSindiDateMetadataVersion(
+                           basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt()),
                        "unsupported SINDI streaming date metadata version");
     }
     CHECK_ARGUMENT(not(expects_host_metadata and expects_date_metadata),
@@ -1742,8 +1742,8 @@ SINDI::Deserialize(StreamReader& reader) {
                 }
                 if (jsonify_basic_info.Contains(SINDI_DATE_METADATA_FORMAT_VERSION_KEY)) {
                     CHECK_ARGUMENT(
-                        jsonify_basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt() ==
-                            SINDI_DATE_METADATA_FORMAT_VERSION,
+                        IsSupportedSindiDateMetadataVersion(
+                            jsonify_basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt()),
                         "unsupported SINDI date metadata version");
                     has_date_metadata = true;
                 }

--- a/src/algorithm/sindi_metadata_filter.cpp
+++ b/src/algorithm/sindi_metadata_filter.cpp
@@ -84,8 +84,160 @@ private:
 
 }  // namespace
 
+SindiHostDictionary::SindiHostDictionary(Allocator* allocator)
+    : allocator_(allocator), host_bytes_(allocator), host_offsets_(allocator) {
+}
+
+void
+SindiHostDictionary::Encode(const std::string* hosts,
+                            uint64_t count,
+                            Vector<uint32_t>& host_ids,
+                            std::vector<std::string_view>& new_hosts) const {
+    CHECK_ARGUMENT(hosts != nullptr, "SINDI host metadata must not be null");
+    host_ids.resize(count);
+    new_hosts.clear();
+    std::unordered_map<std::string_view, uint32_t> new_host_lookup;
+    // Host ID zero is reserved for the empty-string sentinel even before the dictionary is
+    // committed and Size() starts reporting it.
+    const uint64_t existing_count = host_offsets_.empty() ? 1 : this->Size();
+    for (uint64_t i = 0; i < count; ++i) {
+        const auto& host = hosts[i];
+        if (host.empty()) {
+            host_ids[i] = 0;
+            continue;
+        }
+        uint32_t host_id = 0;
+        if (this->Lookup(host, host_id)) {
+            host_ids[i] = host_id;
+            continue;
+        }
+        const auto new_host = new_host_lookup.find(host);
+        if (new_host != new_host_lookup.end()) {
+            host_ids[i] = new_host->second;
+            continue;
+        }
+        const auto next_id = existing_count + new_hosts.size();
+        CHECK_ARGUMENT(next_id <= std::numeric_limits<uint32_t>::max(),
+                       "SINDI host dictionary exceeds uint32_t capacity");
+        host_id = static_cast<uint32_t>(next_id);
+        new_host_lookup.emplace(host, host_id);
+        new_hosts.push_back(host);
+        host_ids[i] = host_id;
+    }
+}
+
+void
+SindiHostDictionary::Commit(const std::vector<std::string_view>& new_hosts) {
+    if (host_offsets_.empty()) {
+        host_offsets_.push_back(0);
+        host_offsets_.push_back(0);
+    }
+    for (const auto& host : new_hosts) {
+        CHECK_ARGUMENT(not host.empty(), "SINDI nonzero host dictionary entry must not be empty");
+        host_bytes_.insert(host_bytes_.end(), host.begin(), host.end());
+        host_offsets_.push_back(host_bytes_.size());
+    }
+    this->RebuildLookup();
+}
+
+bool
+SindiHostDictionary::Lookup(std::string_view host, uint32_t& host_id) const {
+    if (host.empty()) {
+        // An empty host maps to the reserved missing-host ID only after a dictionary exists.
+        host_id = 0;
+        return not host_offsets_.empty();
+    }
+    const auto found = host_lookup_.find(host);
+    if (found == host_lookup_.end()) {
+        return false;
+    }
+    host_id = found->second;
+    return true;
+}
+
+uint64_t
+SindiHostDictionary::GetMemoryUsage() const {
+    return host_bytes_.size() * sizeof(char) + host_offsets_.size() * sizeof(uint64_t) +
+           host_lookup_.size() *
+               (sizeof(std::pair<const std::string_view, uint32_t>) + sizeof(void*));
+}
+
+void
+SindiHostDictionary::Clear() {
+    Vector<char>(allocator_).swap(host_bytes_);
+    Vector<uint64_t>(allocator_).swap(host_offsets_);
+    host_lookup_.clear();
+    host_lookup_.rehash(0);
+}
+
+void
+SindiHostDictionary::RebuildLookup() {
+    host_lookup_.clear();
+    if (host_offsets_.empty()) {
+        return;
+    }
+    host_lookup_.reserve(this->Size());
+    for (uint64_t host_index = 0; host_index < this->Size(); ++host_index) {
+        const auto host_id = static_cast<uint32_t>(host_index);
+        const auto begin = host_offsets_[host_index];
+        const auto end = host_offsets_[host_index + 1];
+        const std::string_view host =
+            host_id == 0 ? std::string_view{}
+                         : std::string_view(host_bytes_.data() + begin, end - begin);
+        const auto [unused, inserted] = host_lookup_.emplace(host, host_id);
+        CHECK_ARGUMENT(inserted, "SINDI host dictionary entries must be unique");
+    }
+}
+
+void
+SindiHostDictionary::Serialize(StreamWriter& writer) const {
+    StreamWriter::WriteVector(writer, host_offsets_);
+    StreamWriter::WriteVector(writer, host_bytes_);
+}
+
+void
+SindiHostDictionary::Deserialize(StreamReader& reader, uint64_t element_count) {
+    (void)element_count;
+    uint64_t offset_count = 0;
+    StreamReader::ReadObj(reader, offset_count);
+    CHECK_ARGUMENT(reader.GetCursor() <= reader.Length(),
+                   "serialized SINDI host dictionary offset position is invalid");
+    const uint64_t remaining_offset_bytes = reader.Length() - reader.GetCursor();
+    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
+        offset_count >= 2 &&
+            offset_count <= static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 2 &&
+            offset_count <= remaining_offset_bytes / sizeof(uint64_t),
+        "serialized SINDI host dictionary offset count is invalid");
+    Vector<uint64_t> host_offsets(offset_count, allocator_);
+    reader.Read(reinterpret_cast<char*>(host_offsets.data()), offset_count * sizeof(uint64_t));
+    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
+        host_offsets[0] == 0 && host_offsets[1] == 0,
+        "serialized SINDI host dictionary must reserve ID zero for empty host");
+    CHECK_ARGUMENT(std::is_sorted(host_offsets.begin(), host_offsets.end()),
+                   "serialized SINDI host dictionary offsets must be ordered");
+
+    uint64_t byte_count = 0;
+    StreamReader::ReadObj(reader, byte_count);
+    CHECK_ARGUMENT(byte_count == host_offsets.back(),
+                   "serialized SINDI host dictionary byte count does not match offsets");
+    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
+        reader.GetCursor() <= reader.Length() && byte_count <= reader.Length() - reader.GetCursor(),
+        "serialized SINDI host dictionary exceeds the metadata payload");
+    Vector<char> host_bytes(byte_count, allocator_);
+    reader.Read(host_bytes.data(), byte_count);
+    for (uint64_t host_id = 1; host_id + 1 < host_offsets.size(); ++host_id) {
+        CHECK_ARGUMENT(host_offsets[host_id] < host_offsets[host_id + 1],
+                       "serialized SINDI nonzero host dictionary entry must not be empty");
+    }
+
+    host_offsets_ = std::move(host_offsets);
+    host_bytes_ = std::move(host_bytes);
+    this->RebuildLookup();
+}
+
 SindiHostBuildPlan::SindiHostBuildPlan(Allocator* allocator)
     : order_(allocator),
+      source_host_ids_(allocator),
       host_ids_(allocator),
       input_offsets_(allocator),
       successful_counts_(allocator) {
@@ -106,15 +258,20 @@ SindiHostBuildPlan::RecordSuccess(uint32_t ordered_position) {
 }
 
 SindiHostFilter::SindiHostFilter(Allocator* allocator)
-    : host_ids_(allocator), host_range_offsets_(allocator), host_ranges_(allocator) {
+    : host_dictionary_(allocator),
+      host_ids_(allocator),
+      host_range_offsets_(allocator),
+      host_ranges_(allocator) {
 }
 
 SindiHostBuildPlan
 SindiHostFilter::PrepareBuild(const DatasetPtr& base, uint64_t current_element_count) const {
     SindiHostBuildPlan plan(host_ids_.get_allocator().allocator_);
-    const auto* source_host_ids = base->GetUInt32Metadata(SINDI_HOST_ID_METADATA_NAME);
-    if (source_host_ids == nullptr) {
-        CHECK_ARGUMENT(not this->HasMetadata(), "SINDI host-aware Add requires host_id metadata");
+    CHECK_ARGUMENT(base->GetUInt32Metadata(SINDI_LEGACY_HOST_METADATA_NAME) == nullptr,
+                   "numeric SINDI host_id metadata is unsupported; use string metadata host");
+    const auto* source_hosts = base->GetStringMetadata(SINDI_HOST_METADATA_NAME);
+    if (source_hosts == nullptr) {
+        CHECK_ARGUMENT(not this->HasMetadata(), "SINDI host-aware Add requires host metadata");
         return plan;
     }
 
@@ -128,6 +285,9 @@ SindiHostFilter::PrepareBuild(const DatasetPtr& base, uint64_t current_element_c
                    "SINDI host-filtered build exceeds uint32_t document capacity");
 
     plan.enabled_ = true;
+    host_dictionary_.Encode(
+        source_hosts, static_cast<uint64_t>(data_num), plan.source_host_ids_, plan.new_hosts_);
+    const auto* source_host_ids = plan.source_host_ids_.data();
     plan.order_.resize(static_cast<uint64_t>(data_num));
     std::iota(plan.order_.begin(), plan.order_.end(), 0);
     std::sort(
@@ -168,6 +328,8 @@ SindiHostFilter::CommitBuild(SindiHostBuildPlan&& plan,
     }
     CHECK_ARGUMENT(next_inner_id == end_inner_id,
                    "SINDI host metadata count does not match inserted documents");
+
+    host_dictionary_.Commit(plan.new_hosts_);
 
     Vector<uint32_t> merged_host_ids(host_ids_.get_allocator().allocator_);
     Vector<uint32_t> merged_range_offsets(host_ids_.get_allocator().allocator_);
@@ -225,6 +387,7 @@ SindiHostFilter::CommitBuild(SindiHostBuildPlan&& plan,
 
 void
 SindiHostFilter::Clear() {
+    host_dictionary_.Clear();
     auto* allocator = host_ids_.get_allocator().allocator_;
     Vector<uint32_t>(allocator).swap(host_ids_);
     Vector<uint32_t>(allocator).swap(host_range_offsets_);
@@ -233,12 +396,18 @@ SindiHostFilter::Clear() {
 
 SindiHostSearchRoute
 SindiHostFilter::Classify(const DatasetPtr& query) const {
-    const auto* query_host_id = query->GetUInt32Metadata(SINDI_HOST_ID_METADATA_NAME);
-    if (host_ids_.empty() or query_host_id == nullptr) {
+    CHECK_ARGUMENT(query->GetUInt32Metadata(SINDI_LEGACY_HOST_METADATA_NAME) == nullptr,
+                   "numeric SINDI host_id metadata is unsupported; use string metadata host");
+    const auto* query_host = query->GetStringMetadata(SINDI_HOST_METADATA_NAME);
+    if (host_ids_.empty() or query_host == nullptr) {
         return {};
     }
-    const auto host = std::lower_bound(host_ids_.begin(), host_ids_.end(), query_host_id[0]);
-    if (host == host_ids_.end() or *host != query_host_id[0]) {
+    uint32_t query_host_id = 0;
+    if (not host_dictionary_.Lookup(query_host[0], query_host_id)) {
+        return {SindiHostRouteKind::EMPTY, 0, 0};
+    }
+    const auto host = std::lower_bound(host_ids_.begin(), host_ids_.end(), query_host_id);
+    if (host == host_ids_.end() or *host != query_host_id) {
         return {SindiHostRouteKind::EMPTY, 0, 0};
     }
     const auto host_index = static_cast<uint32_t>(host - host_ids_.begin());
@@ -328,6 +497,9 @@ SindiHostFilter::RequiresFullTermScan(const SindiHostSearchRoute& route,
 
 void
 SindiHostFilter::Serialize(StreamWriter& writer) const {
+    StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_MAGIC);
+    StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_FORMAT_VERSION);
+    host_dictionary_.Serialize(writer);
     StreamWriter::WriteVector(writer, host_ids_);
     StreamWriter::WriteVector(writer, host_range_offsets_);
     const uint64_t range_count = host_ranges_.size();
@@ -347,6 +519,16 @@ SindiHostFilter::Deserialize(StreamReader& reader, uint64_t element_count) {
                     element_count));
 
     auto* allocator = host_ids_.get_allocator().allocator_;
+    uint32_t magic = 0;
+    uint32_t version = 0;
+    StreamReader::ReadObj(reader, magic);
+    StreamReader::ReadObj(reader, version);
+    CHECK_ARGUMENT(magic == SINDI_HOST_METADATA_MAGIC,
+                   "serialized SINDI host metadata uses the unsupported numeric format");
+    CHECK_ARGUMENT(version == SINDI_HOST_METADATA_FORMAT_VERSION,
+                   fmt::format("unsupported SINDI host metadata version {}", version));
+    SindiHostDictionary host_dictionary(allocator);
+    host_dictionary.Deserialize(reader, element_count);
     Vector<uint32_t> host_ids(allocator);
     Vector<uint32_t> range_offsets(allocator);
     Vector<SindiHostRange> ranges(allocator);
@@ -364,6 +546,8 @@ SindiHostFilter::Deserialize(StreamReader& reader, uint64_t element_count) {
                            host_ids.end(),
                            [](uint32_t lhs, uint32_t rhs) { return lhs >= rhs; }) == host_ids.end(),
         "serialized SINDI host IDs must be strictly ordered");
+    CHECK_ARGUMENT(host_dictionary.Contains(host_ids.back()),
+                   "serialized SINDI host ID exceeds the host dictionary");
 
     uint64_t offset_count = 0;
     StreamReader::ReadObj(reader, offset_count);
@@ -433,6 +617,7 @@ SindiHostFilter::Deserialize(StreamReader& reader, uint64_t element_count) {
                                element_count,
                                next_inner_id));
 
+    host_dictionary_ = std::move(host_dictionary);
     host_ids_ = std::move(host_ids);
     host_range_offsets_ = std::move(range_offsets);
     host_ranges_ = std::move(ranges);
@@ -679,6 +864,7 @@ read_vector(StreamReader& reader, Vector<T>& values, uint64_t max_count, const c
 SindiDateBuildPlan::SindiDateBuildPlan(Allocator* allocator)
     : order_(allocator),
       source_buckets_(allocator),
+      source_host_ids_(allocator),
       group_quarters_(allocator),
       group_hosts_(allocator),
       input_offsets_(allocator),
@@ -701,12 +887,17 @@ SindiDateBuildPlan::RecordSuccess(uint32_t ordered_position) {
 }
 
 SindiDateFilter::SindiDateFilter(Allocator* allocator)
-    : allocator_(allocator), document_buckets_(allocator), partitions_(allocator) {
+    : allocator_(allocator),
+      host_dictionary_(allocator),
+      document_buckets_(allocator),
+      partitions_(allocator) {
 }
 
 SindiDateBuildPlan
 SindiDateFilter::PrepareBuild(const DatasetPtr& base) const {
     SindiDateBuildPlan plan(allocator_);
+    CHECK_ARGUMENT(base->GetUInt32Metadata(SINDI_LEGACY_HOST_METADATA_NAME) == nullptr,
+                   "numeric SINDI host_id metadata is unsupported; use string metadata host");
     const auto* date_buckets = base->GetPaths(SINDI_DATE_PATH_NAME);
     if (date_buckets == nullptr) {
         return plan;
@@ -716,9 +907,14 @@ SindiDateFilter::PrepareBuild(const DatasetPtr& base) const {
     CHECK_ARGUMENT(data_num <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
                    "SINDI date-filtered build exceeds uint32_t document capacity");
 
-    const auto* source_host_ids = base->GetUInt32Metadata(SINDI_HOST_ID_METADATA_NAME);
+    const auto* source_hosts = base->GetStringMetadata(SINDI_HOST_METADATA_NAME);
     plan.enabled_ = true;
-    plan.has_host_metadata_ = source_host_ids != nullptr;
+    plan.has_host_metadata_ = source_hosts != nullptr;
+    if (source_hosts != nullptr) {
+        host_dictionary_.Encode(
+            source_hosts, static_cast<uint64_t>(data_num), plan.source_host_ids_, plan.new_hosts_);
+    }
+    const auto* source_host_ids = plan.has_host_metadata_ ? plan.source_host_ids_.data() : nullptr;
     plan.order_.resize(static_cast<uint64_t>(data_num));
     plan.source_buckets_.resize(static_cast<uint64_t>(data_num));
     Vector<uint32_t> source_quarters(static_cast<uint64_t>(data_num), allocator_);
@@ -765,6 +961,9 @@ SindiDateFilter::CommitBuild(SindiDateBuildPlan&& plan, uint64_t element_count) 
                    "SINDI successful date bucket count does not match element count");
 
     has_host_metadata_ = plan.has_host_metadata_;
+    if (has_host_metadata_) {
+        host_dictionary_.Commit(plan.new_hosts_);
+    }
     document_buckets_ = std::move(plan.successful_buckets_);
     uint32_t inner_cursor = 0;
     for (uint64_t group_begin = 0; group_begin < plan.group_quarters_.size();) {
@@ -806,6 +1005,7 @@ SindiDateFilter::CommitBuild(SindiDateBuildPlan&& plan, uint64_t element_count) 
 
 void
 SindiDateFilter::Clear() {
+    host_dictionary_.Clear();
     Vector<uint32_t>(allocator_).swap(document_buckets_);
     Vector<Partition>(allocator_).swap(partitions_);
     has_host_metadata_ = false;
@@ -813,7 +1013,8 @@ SindiDateFilter::Clear() {
 
 uint64_t
 SindiDateFilter::GetMemoryUsage() const {
-    uint64_t memory = document_buckets_.size() * sizeof(uint32_t);
+    uint64_t memory = host_dictionary_.GetMemoryUsage();
+    memory += document_buckets_.size() * sizeof(uint32_t);
     memory += partitions_.size() * sizeof(Partition);
     for (const auto& partition : partitions_) {
         memory += (partition.host_ids.size() + partition.host_offsets.size()) * sizeof(uint32_t);
@@ -823,6 +1024,8 @@ SindiDateFilter::GetMemoryUsage() const {
 
 SindiDateSearchRoute
 SindiDateFilter::Classify(const DatasetPtr& query, uint32_t window_size) const {
+    CHECK_ARGUMENT(query->GetUInt32Metadata(SINDI_LEGACY_HOST_METADATA_NAME) == nullptr,
+                   "numeric SINDI host_id metadata is unsupported; use string metadata host");
     SindiDateSearchRoute route;
     if (partitions_.empty()) {
         return route;
@@ -855,8 +1058,13 @@ SindiDateFilter::Classify(const DatasetPtr& query, uint32_t window_size) const {
         end_quarter = date_bucket_to_quarter(route.query_end);
     }
 
-    const auto* query_host_id = query->GetUInt32Metadata(SINDI_HOST_ID_METADATA_NAME);
-    const bool use_host = has_host_metadata_ and query_host_id != nullptr;
+    const auto* query_host = query->GetStringMetadata(SINDI_HOST_METADATA_NAME);
+    const bool use_host = has_host_metadata_ and query_host != nullptr;
+    uint32_t query_host_id = 0;
+    if (use_host and not host_dictionary_.Lookup(query_host[0], query_host_id)) {
+        route.kind = SindiHostRouteKind::EMPTY;
+        return route;
+    }
     if (not route.has_date_bucket and not route.has_date_range and not use_host) {
         return route;
     }
@@ -874,8 +1082,8 @@ SindiDateFilter::Classify(const DatasetPtr& query, uint32_t window_size) const {
         uint32_t end = partition.end;
         if (use_host) {
             const auto host = std::lower_bound(
-                partition.host_ids.begin(), partition.host_ids.end(), query_host_id[0]);
-            if (host == partition.host_ids.end() or *host != query_host_id[0]) {
+                partition.host_ids.begin(), partition.host_ids.end(), query_host_id);
+            if (host == partition.host_ids.end() or *host != query_host_id) {
                 continue;
             }
             const auto host_index = static_cast<uint64_t>(host - partition.host_ids.begin());
@@ -973,6 +1181,9 @@ void
 SindiDateFilter::Serialize(StreamWriter& writer) const {
     StreamWriter::WriteObj(writer, SINDI_DATE_METADATA_FORMAT_VERSION);
     StreamWriter::WriteObj(writer, static_cast<uint32_t>(has_host_metadata_));
+    if (has_host_metadata_) {
+        host_dictionary_.Serialize(writer);
+    }
     StreamWriter::WriteVector(writer, document_buckets_);
     StreamWriter::WriteObj(writer, static_cast<uint64_t>(partitions_.size()));
     for (const auto& partition : partitions_) {
@@ -996,9 +1207,16 @@ SindiDateFilter::Deserialize(StreamReader& reader, uint64_t element_count) {
     uint32_t has_host = 0;
     StreamReader::ReadObj(reader, version);
     StreamReader::ReadObj(reader, has_host);
-    CHECK_ARGUMENT(version == SINDI_DATE_METADATA_FORMAT_VERSION,
-                   fmt::format("unsupported SINDI date metadata version {}", version));
     CHECK_ARGUMENT(has_host <= 1, "serialized SINDI date host flag is invalid");
+    CHECK_ARGUMENT(  // NOLINT(readability-simplify-boolean-expr)
+        version == SINDI_DATE_METADATA_FORMAT_VERSION ||
+            (version == SINDI_DATE_METADATA_LEGACY_FORMAT_VERSION && has_host == 0),
+        fmt::format("unsupported SINDI date metadata version {}", version));
+
+    SindiHostDictionary host_dictionary(allocator_);
+    if (has_host != 0) {
+        host_dictionary.Deserialize(reader, element_count);
+    }
 
     Vector<uint32_t> document_buckets(allocator_);
     read_vector(reader, document_buckets, element_count, "document date bucket");
@@ -1043,6 +1261,8 @@ SindiDateFilter::Deserialize(StreamReader& reader, uint64_t element_count) {
                                                   return lhs >= rhs;
                                               }) == partition.host_ids.end(),
                            "serialized SINDI partition host IDs must be strictly ordered");
+            CHECK_ARGUMENT(host_dictionary.Contains(partition.host_ids.back()),
+                           "serialized SINDI partition host ID exceeds the host dictionary");
             CHECK_ARGUMENT(partition.host_offsets.front() == 0,
                            "serialized SINDI partition host offsets must start at zero");
             CHECK_ARGUMENT(std::adjacent_find(partition.host_offsets.begin(),
@@ -1070,6 +1290,7 @@ SindiDateFilter::Deserialize(StreamReader& reader, uint64_t element_count) {
                    "serialized SINDI date partitions do not cover every indexed document");
 
     has_host_metadata_ = has_host != 0;
+    host_dictionary_ = std::move(host_dictionary);
     document_buckets_ = std::move(document_buckets);
     partitions_ = std::move(partitions);
 }

--- a/src/algorithm/sindi_metadata_filter.h
+++ b/src/algorithm/sindi_metadata_filter.h
@@ -15,6 +15,9 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -27,8 +30,59 @@
 
 namespace vsag {
 
-inline constexpr const char* SINDI_HOST_ID_METADATA_NAME = "host_id";
+inline constexpr const char* SINDI_HOST_METADATA_NAME = "host";
+inline constexpr const char* SINDI_LEGACY_HOST_METADATA_NAME = "host_id";
 inline constexpr const char* SINDI_HAS_HOST_METADATA_KEY = "has_host_metadata";
+inline constexpr uint32_t SINDI_HOST_METADATA_MAGIC = 0x48535452;
+inline constexpr uint32_t SINDI_HOST_METADATA_FORMAT_VERSION = 1;
+
+class SindiHostDictionary {
+public:
+    explicit SindiHostDictionary(Allocator* allocator);
+
+    void
+    Encode(const std::string* hosts,
+           uint64_t count,
+           Vector<uint32_t>& host_ids,
+           std::vector<std::string_view>& new_hosts) const;
+
+    void
+    Commit(const std::vector<std::string_view>& new_hosts);
+
+    [[nodiscard]] bool
+    Lookup(std::string_view host, uint32_t& host_id) const;
+
+    [[nodiscard]] bool
+    Contains(uint32_t host_id) const {
+        return host_id < this->Size();
+    }
+
+    [[nodiscard]] uint64_t
+    GetMemoryUsage() const;
+
+    void
+    Clear();
+
+    void
+    Serialize(StreamWriter& writer) const;
+
+    void
+    Deserialize(StreamReader& reader, uint64_t element_count);
+
+private:
+    void
+    RebuildLookup();
+
+    [[nodiscard]] uint64_t
+    Size() const {
+        return host_offsets_.empty() ? 0 : host_offsets_.size() - 1;
+    }
+
+    Allocator* allocator_{nullptr};
+    Vector<char> host_bytes_;
+    Vector<uint64_t> host_offsets_;
+    std::unordered_map<std::string_view, uint32_t> host_lookup_;
+};
 
 enum class SindiHostRouteKind : uint8_t {
     UNFILTERED,
@@ -71,9 +125,11 @@ private:
     bool enabled_{false};
     uint32_t successful_host_cursor_{0};
     Vector<uint32_t> order_;
+    Vector<uint32_t> source_host_ids_;
     Vector<uint32_t> host_ids_;
     Vector<uint32_t> input_offsets_;
     Vector<uint32_t> successful_counts_;
+    std::vector<std::string_view> new_hosts_;
 };
 
 class SindiHostFilter {
@@ -96,7 +152,8 @@ public:
 
     [[nodiscard]] uint64_t
     GetMemoryUsage() const {
-        return (host_ids_.size() + host_range_offsets_.size()) * sizeof(uint32_t) +
+        return host_dictionary_.GetMemoryUsage() +
+               (host_ids_.size() + host_range_offsets_.size()) * sizeof(uint32_t) +
                host_ranges_.size() * sizeof(SindiHostRange);
     }
 
@@ -130,6 +187,7 @@ public:
     Deserialize(StreamReader& reader, uint64_t element_count);
 
 private:
+    SindiHostDictionary host_dictionary_;
     Vector<uint32_t> host_ids_;
     Vector<uint32_t> host_range_offsets_;
     Vector<SindiHostRange> host_ranges_;
@@ -140,7 +198,14 @@ inline constexpr const char* SINDI_DATE_BEGIN_PATH_NAME = "date_begin";
 inline constexpr const char* SINDI_DATE_END_PATH_NAME = "date_end";
 inline constexpr const char* SINDI_DATE_METADATA_FORMAT_VERSION_KEY =
     "sindi_date_metadata_format_version";
-inline constexpr uint32_t SINDI_DATE_METADATA_FORMAT_VERSION = 1;
+inline constexpr uint32_t SINDI_DATE_METADATA_FORMAT_VERSION = 2;
+inline constexpr uint32_t SINDI_DATE_METADATA_LEGACY_FORMAT_VERSION = 1;
+
+inline bool
+IsSupportedSindiDateMetadataVersion(int64_t version) {
+    return version == SINDI_DATE_METADATA_LEGACY_FORMAT_VERSION ||
+           version == SINDI_DATE_METADATA_FORMAT_VERSION;
+}
 
 class SindiDateBuildPlan {
 public:
@@ -167,11 +232,13 @@ private:
     uint32_t successful_group_cursor_{0};
     Vector<uint32_t> order_;
     Vector<uint32_t> source_buckets_;
+    Vector<uint32_t> source_host_ids_;
     Vector<uint32_t> group_quarters_;
     Vector<uint32_t> group_hosts_;
     Vector<uint32_t> input_offsets_;
     Vector<uint32_t> successful_counts_;
     Vector<uint32_t> successful_buckets_;
+    std::vector<std::string_view> new_hosts_;
 };
 
 struct SindiDateSearchRoute {
@@ -254,6 +321,7 @@ private:
 
     Allocator* allocator_{nullptr};
     bool has_host_metadata_{false};
+    SindiHostDictionary host_dictionary_;
     Vector<uint32_t> document_buckets_;
     Vector<Partition> partitions_;
 };

--- a/src/algorithm/sindi_metadata_filter_test.cpp
+++ b/src/algorithm/sindi_metadata_filter_test.cpp
@@ -165,10 +165,10 @@ TEST_CASE("SINDI date bucket and host filters route and serialize",
     common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
     SmallSindiDataset data(0);
-    std::array<uint32_t, 4> host_ids = {2, 1, 2, 1};
+    std::array<std::string, 4> hosts = {"host-b", "host-a", "host-b", "host-a"};
     std::array<std::string, 4> date_buckets = {"2026", "2026/05", "2026/05/01", "2026/08"};
     auto base = data.Base()
-                    ->UInt32Metadata(SINDI_HOST_ID_METADATA_NAME, host_ids.data())
+                    ->StringMetadata(SINDI_HOST_METADATA_NAME, hosts.data())
                     ->Paths(SINDI_DATE_PATH_NAME, date_buckets.data());
     const bool immutable = GENERATE(false, true);
     auto parameter = CreateSindiParameter(immutable, false);
@@ -177,21 +177,21 @@ TEST_CASE("SINDI date bucket and host filters route and serialize",
     REQUIRE(index->Build(base) == std::vector<int64_t>{40});
 
     int64_t added_label = 50;
-    uint32_t added_host = 2;
+    std::string added_host = "host-b";
     std::string added_date = "2026/09";
     auto added_vector = data.sparse_vectors[0];
     auto dated_add = Dataset::Make()
                          ->NumElements(1)
                          ->SparseVectors(&added_vector)
                          ->Ids(&added_label)
-                         ->UInt32Metadata(SINDI_HOST_ID_METADATA_NAME, &added_host)
+                         ->StringMetadata(SINDI_HOST_METADATA_NAME, &added_host)
                          ->Paths(SINDI_DATE_PATH_NAME, &added_date)
                          ->Owner(false);
     auto undated_add = Dataset::Make()
                            ->NumElements(1)
                            ->SparseVectors(&added_vector)
                            ->Ids(&added_label)
-                           ->UInt32Metadata(SINDI_HOST_ID_METADATA_NAME, &added_host)
+                           ->StringMetadata(SINDI_HOST_METADATA_NAME, &added_host)
                            ->Owner(false);
     if (not immutable) {
         REQUIRE_THROWS_WITH(index->Add(dated_add),
@@ -260,8 +260,8 @@ TEST_CASE("SINDI date bucket and host filters route and serialize",
 
     query_date_begin = "2026/05/01";
     query_date_end = "2026/08";
-    uint32_t range_host_id = 2;
-    range_query->UInt32Metadata(SINDI_HOST_ID_METADATA_NAME, &range_host_id);
+    std::string range_host = "host-b";
+    range_query->StringMetadata(SINDI_HOST_METADATA_NAME, &range_host);
     auto host_range = index->KnnSearch(range_query, 3, kSindiSearchParameters, nullptr);
     REQUIRE(host_range->GetDim() == 1);
     REQUIRE(host_range->GetIds()[0] == 20);
@@ -270,8 +270,8 @@ TEST_CASE("SINDI date bucket and host filters route and serialize",
                     range_query, 3, kSindiSearchParameters, std::make_shared<AllowLabelFilter>(30))
                 ->GetDim() == 0);
 
-    uint32_t host_id = 2;
-    query->UInt32Metadata(SINDI_HOST_ID_METADATA_NAME, &host_id);
+    std::string host = "host-b";
+    query->StringMetadata(SINDI_HOST_METADATA_NAME, &host);
     auto combined = index->KnnSearch(query, 3, kSindiSearchParameters, nullptr);
     REQUIRE(combined->GetDim() == 2);
     REQUIRE(combined->GetIds()[0] == 10);
@@ -406,15 +406,14 @@ TEST_CASE("SINDI immutable host filter routes", "[ut][SINDI][host_filter]") {
     common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
     SmallSindiDataset data(0);
-    constexpr uint32_t sparse_host_id = std::numeric_limits<uint32_t>::max();
-    std::array<uint32_t, 4> host_ids = {sparse_host_id, 1, sparse_host_id, 1};
-    auto base = data.Base()->UInt32Metadata("host_id", host_ids.data());
+    std::array<std::string, 4> hosts = {"sparse.example", "host-a", "sparse.example", "host-a"};
+    auto base = data.Base()->StringMetadata("host", hosts.data());
     auto parameter = CreateSindiParameter(true, false);
     auto index = std::make_unique<SINDI>(parameter, common_param);
     REQUIRE(index->Build(base) == std::vector<int64_t>{40});
 
-    uint32_t host_id = 1;
-    auto query = data.Query()->UInt32Metadata("host_id", &host_id);
+    std::string host = "host-a";
+    auto query = data.Query()->StringMetadata("host", &host);
     auto host_result = index->KnnSearch(query, 2, kSindiSearchParameters, nullptr);
     REQUIRE(host_result->GetDim() == 1);
     REQUIRE(host_result->GetIds()[0] == 30);
@@ -430,7 +429,7 @@ TEST_CASE("SINDI immutable host filter routes", "[ut][SINDI][host_filter]") {
     REQUIRE(index->Remove({30}, RemoveMode::MARK_REMOVE) == 1);
     REQUIRE(index->KnnSearch(query, 2, kSindiSearchParameters, nullptr)->GetDim() == 0);
 
-    host_id = sparse_host_id;
+    host = "sparse.example";
     auto window_result = index->KnnSearch(query, 2, kSindiSearchParameters, nullptr);
     REQUIRE(window_result->GetDim() == 2);
     REQUIRE(window_result->GetIds()[0] == 10);
@@ -448,9 +447,11 @@ TEST_CASE("SINDI immutable host filter routes", "[ut][SINDI][host_filter]") {
     REQUIRE(deleted_result->GetDim() == 1);
     REQUIRE(deleted_result->GetIds()[0] == 20);
 
-    host_id = 0;
+    host = "";
     REQUIRE(index->KnnSearch(query, 2, kSindiSearchParameters, nullptr)->GetDim() == 0);
-    host_id = 2;
+    host = "unknown.example";
+    REQUIRE(index->KnnSearch(query, 2, kSindiSearchParameters, nullptr)->GetDim() == 0);
+    host = "SPARSE.EXAMPLE";
     REQUIRE(index->KnnSearch(query, 2, kSindiSearchParameters, nullptr)->GetDim() == 0);
 
     auto no_host_query = data.Query();
@@ -467,13 +468,13 @@ TEST_CASE("SINDI host filter spans immutable windows", "[ut][SINDI][host_filter]
     common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
     std::vector<int64_t> labels(num_elements);
-    std::vector<uint32_t> host_ids(num_elements);
+    std::vector<std::string> hosts(num_elements);
     std::vector<float> values(num_elements, 1.0F);
     std::vector<SparseVector> sparse_vectors(num_elements);
     uint32_t term_id = 1;
     for (uint32_t i = 0; i < num_elements; ++i) {
         labels[i] = static_cast<int64_t>(i + 1);
-        host_ids[i] = i < host_two_count ? 2 : 1;
+        hosts[i] = i < host_two_count ? "host-b" : "host-a";
         sparse_vectors[i].len_ = 1;
         sparse_vectors[i].ids_ = &term_id;
         sparse_vectors[i].vals_ = &values[i];
@@ -484,18 +485,18 @@ TEST_CASE("SINDI host filter spans immutable windows", "[ut][SINDI][host_filter]
                     ->NumElements(num_elements)
                     ->SparseVectors(sparse_vectors.data())
                     ->Ids(labels.data())
-                    ->UInt32Metadata("host_id", host_ids.data())
+                    ->StringMetadata("host", hosts.data())
                     ->Owner(false);
     auto parameter = CreateSindiParameter(true, false);
     auto index = std::make_unique<SINDI>(parameter, common_param);
     REQUIRE(index->Build(base).empty());
 
     SparseVector query_vector{1, &term_id, values.data()};
-    uint32_t host_id = 2;
+    std::string host = "host-b";
     auto query = Dataset::Make()
                      ->NumElements(1)
                      ->SparseVectors(&query_vector)
-                     ->UInt32Metadata("host_id", &host_id)
+                     ->StringMetadata("host", &host)
                      ->Owner(false);
     auto result = index->KnnSearch(query, 1, kSindiSearchParameters, nullptr);
     REQUIRE(result->GetDim() == 1);
@@ -512,7 +513,7 @@ TEST_CASE("SINDI host filter preserves term prune candidates at window boundarie
     uint32_t term_id = 1;
     std::array<float, 4> values{10.0F, 9.0F, 2.0F, 1.0F};
     std::array<int64_t, 4> labels{10, 11, 20, 21};
-    std::array<uint32_t, 4> host_ids{1, 1, 2, 2};
+    std::array<std::string, 4> hosts{"host-a", "host-a", "host-b", "host-b"};
     std::array<SparseVector, 4> vectors;
     for (uint32_t i = 0; i < vectors.size(); ++i) {
         vectors[i] = SparseVector{1, &term_id, &values[i]};
@@ -521,7 +522,7 @@ TEST_CASE("SINDI host filter preserves term prune candidates at window boundarie
                     ->NumElements(vectors.size())
                     ->SparseVectors(vectors.data())
                     ->Ids(labels.data())
-                    ->UInt32Metadata("host_id", host_ids.data())
+                    ->StringMetadata("host", hosts.data())
                     ->Owner(false);
     auto parameter = CreateSindiParameter(true, false);
     parameter->window_size = 4;
@@ -530,11 +531,11 @@ TEST_CASE("SINDI host filter preserves term prune candidates at window boundarie
 
     float query_value = 1.0F;
     SparseVector query_vector{1, &term_id, &query_value};
-    uint32_t query_host_id = 2;
+    std::string query_host = "host-b";
     auto query = Dataset::Make()
                      ->NumElements(1)
                      ->SparseVectors(&query_vector)
-                     ->UInt32Metadata("host_id", &query_host_id)
+                     ->StringMetadata("host", &query_host)
                      ->Owner(false);
     const auto query_prune_ratio = GENERATE(0.0F, 0.2F);
     auto search_parameters = JsonType::Parse(kSindiSearchParameters);
@@ -547,32 +548,63 @@ TEST_CASE("SINDI host filter preserves term prune candidates at window boundarie
     REQUIRE(result->GetIds()[1] == 21);
 }
 
-TEST_CASE("SINDI host metadata accepts missing host ID zero", "[ut][SINDI][host_filter]") {
+TEST_CASE("SINDI host metadata accepts an empty missing host", "[ut][SINDI][host_filter]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;
     common_param.allocator_ = allocator;
     common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
     SmallSindiDataset data(0);
-    std::array<uint32_t, 4> host_ids = {0, 1, 2, 0};
-    auto base = data.Base()->UInt32Metadata("host_id", host_ids.data());
+    std::array<std::string, 4> hosts = {"", "host-a", "host-b", ""};
+    auto base = data.Base()->StringMetadata("host", hosts.data());
 
     auto parameter = CreateSindiParameter(true, false);
     SINDI index(parameter, common_param);
     REQUIRE(index.Build(base) == std::vector<int64_t>{40});
 
-    uint32_t host_id = 0;
-    auto query = data.Query()->UInt32Metadata("host_id", &host_id);
+    std::string host;
+    auto query = data.Query()->StringMetadata("host", &host);
     auto result = index.KnnSearch(query, 2, kSindiSearchParameters, nullptr);
     REQUIRE(result->GetDim() == 2);
     REQUIRE(result->GetIds()[0] == 10);
     REQUIRE(result->GetIds()[1] == 30);
 }
 
+TEST_CASE("SINDI rejects numeric host metadata", "[ut][SINDI][host_filter]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+
+    SmallSindiDataset data(0);
+    std::array<uint32_t, 4> host_ids{1, 2, 1, 2};
+    auto parameter = CreateSindiParameter(true, false);
+    SINDI index(parameter, common_param);
+    REQUIRE_THROWS_WITH(
+        index.Build(data.Base()->UInt32Metadata("host_id", host_ids.data())),
+        Catch::Matchers::ContainsSubstring("numeric SINDI host_id metadata is unsupported"));
+
+    std::array<std::string, 4> hosts{"host-a", "host-b", "host-a", "host-b"};
+    REQUIRE(index.Build(data.Base()->StringMetadata("host", hosts.data())) ==
+            std::vector<int64_t>{40});
+    uint32_t query_host_id = 1;
+    REQUIRE_THROWS_WITH(
+        index.KnnSearch(data.Query()->UInt32Metadata("host_id", &query_host_id),
+                        2,
+                        kSindiSearchParameters,
+                        nullptr),
+        Catch::Matchers::ContainsSubstring("numeric SINDI host_id metadata is unsupported"));
+}
+
 TEST_CASE("SINDI host metadata rejects invalid serialized ranges",
           "[ut][SINDI][host_filter][streaming]") {
     std::stringstream stream;
     IOStreamWriter writer(stream);
+    StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_MAGIC);
+    StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_FORMAT_VERSION);
+    const std::vector<uint64_t> dictionary_offsets{0, 0};
+    StreamWriter::WriteVector(writer, dictionary_offsets);
+    StreamWriter::WriteVector(writer, std::vector<char>{});
     const uint64_t host_count = 1;
     const uint32_t host_id = 0;
     const uint64_t offset_count = 2;
@@ -595,6 +627,36 @@ TEST_CASE("SINDI host metadata rejects invalid serialized ranges",
     REQUIRE_THROWS(host_filter.Deserialize(reader, 1));
 }
 
+TEST_CASE("SINDI host metadata rejects numeric and duplicate dictionaries",
+          "[ut][SINDI][host_filter][serialization]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+
+    SECTION("numeric host payload") {
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        StreamWriter::WriteVector(writer, std::vector<uint32_t>{1});
+        SindiHostFilter host_filter(allocator.get());
+        IOStreamReader reader(stream);
+        REQUIRE_THROWS_WITH(host_filter.Deserialize(reader, 1),
+                            Catch::Matchers::ContainsSubstring("unsupported numeric format"));
+    }
+
+    SECTION("duplicate host strings") {
+        std::stringstream stream;
+        IOStreamWriter writer(stream);
+        StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_MAGIC);
+        StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_FORMAT_VERSION);
+        StreamWriter::WriteVector(writer, std::vector<uint64_t>{0, 0, 6, 12});
+        StreamWriter::WriteVector(
+            writer, std::vector<char>{'h', 'o', 's', 't', '-', 'a', 'h', 'o', 's', 't', '-', 'a'});
+        SindiHostFilter host_filter(allocator.get());
+        IOStreamReader reader(stream);
+        REQUIRE_THROWS_WITH(
+            host_filter.Deserialize(reader, 1),
+            Catch::Matchers::ContainsSubstring("host dictionary entries must be unique"));
+    }
+}
+
 TEST_CASE("SINDI date metadata rejects invalid element counts",
           "[ut][SINDI][metadata_filter][date_filter][serialization]") {
     const uint64_t element_count =
@@ -611,7 +673,14 @@ TEST_CASE("SINDI date metadata rejects invalid element counts",
 TEST_CASE("SINDI host route skips windows between disjoint ranges", "[ut][SINDI][host_filter]") {
     std::stringstream stream;
     IOStreamWriter writer(stream);
-    const std::array<uint32_t, 2> host_ids{7, 8};
+    StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_MAGIC);
+    StreamWriter::WriteObj(writer, SINDI_HOST_METADATA_FORMAT_VERSION);
+    const std::vector<uint64_t> dictionary_offsets{0, 0, 6, 12};
+    const std::vector<char> dictionary_bytes{
+        'h', 'o', 's', 't', '-', 'a', 'h', 'o', 's', 't', '-', 'b'};
+    StreamWriter::WriteVector(writer, dictionary_offsets);
+    StreamWriter::WriteVector(writer, dictionary_bytes);
+    const std::array<uint32_t, 2> host_ids{1, 2};
     const std::array<uint32_t, 3> offsets{0, 2, 3};
     const std::array<SindiHostRange, 3> ranges{
         SindiHostRange{0, 2}, SindiHostRange{10, 12}, SindiHostRange{2, 10}};
@@ -634,9 +703,8 @@ TEST_CASE("SINDI host route skips windows between disjoint ranges", "[ut][SINDI]
     IOStreamReader reader(stream);
     host_filter.Deserialize(reader, 12);
 
-    uint32_t query_host_id = 7;
-    auto query =
-        Dataset::Make()->NumElements(1)->UInt32Metadata("host_id", &query_host_id)->Owner(false);
+    std::string query_host = "host-a";
+    auto query = Dataset::Make()->NumElements(1)->StringMetadata("host", &query_host)->Owner(false);
     const auto route = host_filter.Classify(query);
     REQUIRE(route.kind == SindiHostRouteKind::WINDOW);
 
@@ -668,21 +736,21 @@ TEST_CASE("SINDI host filter supports mutable immutable and reorder modes",
         common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
         SmallSindiDataset data(0);
-        std::array<uint32_t, 4> host_ids = {2, 0, 2, 0};
-        auto base = data.Base()->UInt32Metadata("host_id", host_ids.data());
+        std::array<std::string, 4> hosts = {"host-b", "", "host-b", ""};
+        auto base = data.Base()->StringMetadata("host", hosts.data());
         auto parameter = CreateSindiParameter(immutable, false);
         parameter->use_reorder = use_reorder;
         parameter->rerank_type = SPARSE_RERANK_TYPE_FP32;
         SINDI index(parameter, common_param);
         REQUIRE(index.Build(base) == std::vector<int64_t>{40});
 
-        uint32_t host_id = 0;
-        auto query = data.Query()->UInt32Metadata("host_id", &host_id);
+        std::string host;
+        auto query = data.Query()->StringMetadata("host", &host);
         auto result = index.KnnSearch(query, 2, kSindiSearchParameters, nullptr);
         REQUIRE(result->GetDim() == 1);
         REQUIRE(result->GetIds()[0] == 30);
 
-        host_id = 2;
+        host = "host-b";
         result = index.KnnSearch(query, 2, kSindiSearchParameters, nullptr);
         REQUIRE(result->GetDim() == 2);
         for (int64_t i = 0; i < result->GetDim(); ++i) {
@@ -691,7 +759,7 @@ TEST_CASE("SINDI host filter supports mutable immutable and reorder modes",
 
         if (not immutable) {
             std::array<int64_t, 2> added_labels{50, 60};
-            std::array<uint32_t, 2> added_hosts{0, 2};
+            std::array<std::string, 2> added_hosts{"", "host-b"};
             std::array<SparseVector, 2> added_vectors{data.sparse_vectors[0],
                                                       data.sparse_vectors[0]};
             auto missing_host_metadata = Dataset::Make()
@@ -704,22 +772,22 @@ TEST_CASE("SINDI host filter supports mutable immutable and reorder modes",
                              ->NumElements(added_vectors.size())
                              ->SparseVectors(added_vectors.data())
                              ->Ids(added_labels.data())
-                             ->UInt32Metadata("host_id", added_hosts.data())
+                             ->StringMetadata("host", added_hosts.data())
                              ->Owner(false);
             REQUIRE(index.Add(added).empty());
-            host_id = 0;
+            host = "";
             result = index.KnnSearch(query, 2, kSindiSearchParameters, nullptr);
             REQUIRE(result->GetDim() == 2);
             REQUIRE(result->GetIds()[0] == 50);
             REQUIRE(result->GetIds()[1] == 30);
 
             std::array<int64_t, 2> second_added_labels{70, 80};
-            std::array<uint32_t, 2> second_added_hosts{2, 0};
+            std::array<std::string, 2> second_added_hosts{"host-b", ""};
             auto second_added = Dataset::Make()
                                     ->NumElements(added_vectors.size())
                                     ->SparseVectors(added_vectors.data())
                                     ->Ids(second_added_labels.data())
-                                    ->UInt32Metadata("host_id", second_added_hosts.data())
+                                    ->StringMetadata("host", second_added_hosts.data())
                                     ->Owner(false);
             REQUIRE(index.Add(second_added).empty());
             result = index.KnnSearch(query, 3, kSindiSearchParameters, nullptr);
@@ -737,15 +805,15 @@ TEST_CASE("SINDI small host uses posting scan", "[ut][SINDI][host_filter]") {
     common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
     SmallSindiDataset data(0);
-    std::array<uint32_t, 4> host_ids = {2, 1, 2, 1};
-    auto base = data.Base()->UInt32Metadata("host_id", host_ids.data());
+    std::array<std::string, 4> hosts = {"host-b", "host-a", "host-b", "host-a"};
+    auto base = data.Base()->StringMetadata("host", hosts.data());
     auto parameter = CreateSindiParameter(true, false);
     parameter->rerank_type = SPARSE_RERANK_TYPE_FP32;
     auto index = std::make_unique<SINDI>(parameter, common_param);
     REQUIRE(index->Build(base) == std::vector<int64_t>{40});
 
-    uint32_t host_id = 1;
-    auto query = data.Query()->UInt32Metadata("host_id", &host_id);
+    std::string host = "host-a";
+    auto query = data.Query()->StringMetadata("host", &host);
     auto result = index->KnnSearch(query, 2, kSindiSearchParameters, nullptr);
     REQUIRE(result->GetDim() == 1);
     REQUIRE(result->GetIds()[0] == 30);
@@ -768,8 +836,8 @@ TEST_CASE("SINDI legacy deserialize clears host metadata",
     SINDI legacy_source(parameter, common_param);
     REQUIRE(legacy_source.Build(data.Base()) == std::vector<int64_t>{40});
 
-    uint32_t query_host_id = 99;
-    auto query = data.Query()->UInt32Metadata("host_id", &query_host_id);
+    std::string query_host = "unknown.example";
+    auto query = data.Query()->StringMetadata("host", &query_host);
     auto expected = legacy_source.KnnSearch(query, 3, kSindiSearchParameters, nullptr);
     REQUIRE(expected->GetDim() == 3);
 
@@ -777,9 +845,9 @@ TEST_CASE("SINDI legacy deserialize clears host metadata",
     IOStreamWriter legacy_writer(legacy_stream);
     legacy_source.Serialize(legacy_writer);
 
-    std::array<uint32_t, 4> host_ids{2, 0, 2, 0};
+    std::array<std::string, 4> hosts{"host-b", "", "host-b", ""};
     SINDI restored(parameter, common_param);
-    REQUIRE(restored.Build(data.Base()->UInt32Metadata("host_id", host_ids.data())) ==
+    REQUIRE(restored.Build(data.Base()->StringMetadata("host", hosts.data())) ==
             std::vector<int64_t>{40});
     REQUIRE(restored.KnnSearch(query, 3, kSindiSearchParameters, nullptr)->GetDim() == 0);
 
@@ -799,8 +867,8 @@ TEST_CASE("SINDI host serialization supports mutable and immutable",
         common_param.allocator_ = allocator;
         common_param.metric_ = MetricType::METRIC_TYPE_IP;
 
-        std::array<uint32_t, 4> host_ids{2, 0, 2, 0};
-        auto base = data.Base()->UInt32Metadata("host_id", host_ids.data());
+        std::array<std::string, 4> hosts{"host-b", "", "host-b", ""};
+        auto base = data.Base()->StringMetadata("host", hosts.data());
         auto parameter = CreateSindiParameter(immutable, false);
         parameter->use_reorder = false;
         parameter->rerank_type = SPARSE_RERANK_TYPE_FP32;
@@ -809,20 +877,20 @@ TEST_CASE("SINDI host serialization supports mutable and immutable",
 
         if (!immutable) {
             std::array<int64_t, 2> added_labels{50, 60};
-            std::array<uint32_t, 2> added_hosts{0, 2};
+            std::array<std::string, 2> added_hosts{"host-new", "host-b"};
             std::array<SparseVector, 2> added_vectors{data.sparse_vectors[0],
                                                       data.sparse_vectors[0]};
             auto added = Dataset::Make()
                              ->NumElements(added_vectors.size())
                              ->SparseVectors(added_vectors.data())
                              ->Ids(added_labels.data())
-                             ->UInt32Metadata("host_id", added_hosts.data())
+                             ->StringMetadata("host", added_hosts.data())
                              ->Owner(false);
             REQUIRE(index.Add(added).empty());
         }
 
-        uint32_t host_id = 0;
-        auto query = data.Query()->UInt32Metadata("host_id", &host_id);
+        std::string host = immutable ? "host-b" : "host-new";
+        auto query = data.Query()->StringMetadata("host", &host);
         auto expected = index.KnnSearch(query, 3, kSindiSearchParameters, nullptr);
 
         std::stringstream legacy_stream;
@@ -852,15 +920,18 @@ TEST_CASE("SINDI host serialization supports mutable and immutable",
 
         if (!immutable) {
             int64_t added_label = 70;
-            uint32_t added_host = 0;
+            std::string added_host = "host-after-restore";
             auto added = Dataset::Make()
                              ->NumElements(1)
                              ->SparseVectors(&data.sparse_vectors[0])
                              ->Ids(&added_label)
-                             ->UInt32Metadata("host_id", &added_host)
+                             ->StringMetadata("host", &added_host)
                              ->Owner(false);
             REQUIRE(restored.Add(added).empty());
-            REQUIRE(restored.KnnSearch(query, 4, kSindiSearchParameters, nullptr)->GetDim() == 3);
+            host = added_host;
+            auto added_result = restored.KnnSearch(query, 4, kSindiSearchParameters, nullptr);
+            REQUIRE(added_result->GetDim() == 1);
+            REQUIRE(added_result->GetIds()[0] == added_label);
         }
 
         auto missing_host = EraseStreamingBlock(bytes, StreamSerializationTag::SINDI_HOST_METADATA);

--- a/src/algorithm/sindi_v2/sindi_v2.cpp
+++ b/src/algorithm/sindi_v2/sindi_v2.cpp
@@ -1337,8 +1337,8 @@ SINDIV2::read_streaming_body(StreamReader& reader, const MetadataPtr& metadata) 
                                        basic_info[SINDI_HAS_HOST_METADATA_KEY].GetBool();
     const bool expects_date_metadata = basic_info.Contains(SINDI_DATE_METADATA_FORMAT_VERSION_KEY);
     if (expects_date_metadata) {
-        CHECK_ARGUMENT(basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt() ==
-                           SINDI_DATE_METADATA_FORMAT_VERSION,
+        CHECK_ARGUMENT(IsSupportedSindiDateMetadataVersion(
+                           basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt()),
                        "unsupported SINDI_V2 streaming date metadata version");
     }
     CHECK_ARGUMENT(not(expects_host_metadata and expects_date_metadata),
@@ -1634,8 +1634,8 @@ SINDIV2::Deserialize(StreamReader& reader) {
     const bool has_host_metadata = jsonify_basic_info.Contains(SINDI_HAS_HOST_METADATA_KEY) &&
                                    jsonify_basic_info[SINDI_HAS_HOST_METADATA_KEY].GetBool();
     if (has_date_metadata) {
-        CHECK_ARGUMENT(jsonify_basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt() ==
-                           SINDI_DATE_METADATA_FORMAT_VERSION,
+        CHECK_ARGUMENT(IsSupportedSindiDateMetadataVersion(
+                           jsonify_basic_info[SINDI_DATE_METADATA_FORMAT_VERSION_KEY].GetInt()),
                        "unsupported SINDI_V2 date metadata version");
     }
     CHECK_ARGUMENT(not(has_host_metadata and has_date_metadata),

--- a/src/algorithm/sindi_v2/sindi_v2_test.cpp
+++ b/src/algorithm/sindi_v2/sindi_v2_test.cpp
@@ -183,8 +183,7 @@ TEST_CASE("SINDIV2 immutable host filter routes", "[ut][SINDIV2][host_filter]") 
     uint32_t term = 1;
     std::array<float, 4> values{4.0F, 0.0F, 2.0F, 3.0F};
     std::array<int64_t, 4> labels{10, 40, 20, 30};
-    std::array<uint32_t, 4> host_ids{
-        std::numeric_limits<uint32_t>::max(), 1, std::numeric_limits<uint32_t>::max(), 1};
+    std::array<std::string, 4> hosts = {"sparse.example", "host-a", "sparse.example", "host-a"};
     std::array<SparseVector, 4> vectors{};
     vectors[0] = SparseVector{1, &term, &values[0]};
     vectors[2] = SparseVector{1, &term, &values[2]};
@@ -193,7 +192,7 @@ TEST_CASE("SINDIV2 immutable host filter routes", "[ut][SINDIV2][host_filter]") 
                     ->NumElements(vectors.size())
                     ->SparseVectors(vectors.data())
                     ->Ids(labels.data())
-                    ->UInt32Metadata("host_id", host_ids.data())
+                    ->StringMetadata("host", hosts.data())
                     ->Owner(false);
 
     auto parameter = std::make_shared<SINDIV2Parameter>();
@@ -208,11 +207,11 @@ TEST_CASE("SINDIV2 immutable host filter routes", "[ut][SINDIV2][host_filter]") 
 
     float query_value = 1.0F;
     SparseVector query_vector{1, &term, &query_value};
-    uint32_t query_host_id = 1;
+    std::string query_host = "host-a";
     auto query = Dataset::Make()
                      ->NumElements(1)
                      ->SparseVectors(&query_vector)
-                     ->UInt32Metadata("host_id", &query_host_id)
+                     ->StringMetadata("host", &query_host)
                      ->Owner(false);
     const std::string search_parameters = R"({"sindi_v2": {"n_candidate": 3}})";
 
@@ -222,13 +221,44 @@ TEST_CASE("SINDIV2 immutable host filter routes", "[ut][SINDIV2][host_filter]") 
     REQUIRE(index.KnnSearch(query, 2, search_parameters, std::make_shared<AllowLabelFilter>(20))
                 ->GetDim() == 0);
 
-    query_host_id = std::numeric_limits<uint32_t>::max();
+    query_host = "sparse.example";
     auto window_result = index.KnnSearch(query, 2, search_parameters, nullptr);
     REQUIRE(window_result->GetDim() == 2);
     REQUIRE(window_result->GetIds()[0] == 10);
     REQUIRE(window_result->GetIds()[1] == 20);
-    query_host_id = 0;
+    query_host = "";
     REQUIRE(index.KnnSearch(query, 2, search_parameters, nullptr)->GetDim() == 0);
+    query_host = "unknown.example";
+    REQUIRE(index.KnnSearch(query, 2, search_parameters, nullptr)->GetDim() == 0);
+}
+
+TEST_CASE("SINDIV2 rejects numeric host metadata", "[ut][SINDIV2][host_filter]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common_param;
+    common_param.allocator_ = allocator;
+    common_param.metric_ = MetricType::METRIC_TYPE_IP;
+
+    uint32_t term = 1;
+    float value = 1.0F;
+    int64_t label = 10;
+    SparseVector vector{1, &term, &value};
+    uint32_t host_id = 1;
+    auto base = Dataset::Make()
+                    ->NumElements(1)
+                    ->SparseVectors(&vector)
+                    ->Ids(&label)
+                    ->UInt32Metadata("host_id", &host_id)
+                    ->Owner(false);
+    auto parameter = std::make_shared<SINDIV2Parameter>();
+    parameter->term_id_limit = 8;
+    parameter->window_size = 10000;
+    parameter->immutable = true;
+    parameter->term_io_parameter = std::make_shared<MemoryIOParameter>();
+    parameter->rerank_io_parameter = std::make_shared<MemoryBlockIOParameter>();
+    SINDIV2 index(parameter, common_param);
+    REQUIRE_THROWS_WITH(
+        index.Build(base),
+        Catch::Matchers::ContainsSubstring("numeric SINDI host_id metadata is unsupported"));
 }
 
 TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
@@ -244,7 +274,7 @@ TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
         uint32_t term = 1;
         std::array<float, 4> values{4.0F, 0.0F, 2.0F, 3.0F};
         std::array<int64_t, 4> labels{10, 40, 20, 30};
-        std::array<uint32_t, 4> host_ids{2, 0, 2, 0};
+        std::array<std::string, 4> hosts{"host-b", "", "host-b", ""};
         std::array<SparseVector, 4> vectors{};
         vectors[0] = SparseVector{1, &term, &values[0]};
         vectors[2] = SparseVector{1, &term, &values[2]};
@@ -253,7 +283,7 @@ TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
                         ->NumElements(vectors.size())
                         ->SparseVectors(vectors.data())
                         ->Ids(labels.data())
-                        ->UInt32Metadata("host_id", host_ids.data())
+                        ->StringMetadata("host", hosts.data())
                         ->Owner(false);
 
         auto parameter = std::make_shared<SINDIV2Parameter>();
@@ -268,18 +298,18 @@ TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
 
         float query_value = 1.0F;
         SparseVector query_vector{1, &term, &query_value};
-        uint32_t query_host_id = 0;
+        std::string query_host;
         auto query = Dataset::Make()
                          ->NumElements(1)
                          ->SparseVectors(&query_vector)
-                         ->UInt32Metadata("host_id", &query_host_id)
+                         ->StringMetadata("host", &query_host)
                          ->Owner(false);
         const std::string search_parameters = R"({"sindi_v2": {"n_candidate": 3}})";
         auto result = index.KnnSearch(query, 2, search_parameters, nullptr);
         REQUIRE(result->GetDim() == 1);
         REQUIRE(result->GetIds()[0] == 30);
 
-        query_host_id = 2;
+        query_host = "host-b";
         result = index.KnnSearch(query, 2, search_parameters, nullptr);
         REQUIRE(result->GetDim() == 2);
         REQUIRE(result->GetIds()[0] == 10);
@@ -290,7 +320,7 @@ TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
             std::array<SparseVector, 2> added_vectors{SparseVector{1, &term, &added_values[0]},
                                                       SparseVector{1, &term, &added_values[1]}};
             std::array<int64_t, 2> added_labels{50, 60};
-            std::array<uint32_t, 2> added_hosts{0, 2};
+            std::array<std::string, 2> added_hosts{"", "host-b"};
             auto missing_host_metadata = Dataset::Make()
                                              ->NumElements(added_vectors.size())
                                              ->SparseVectors(added_vectors.data())
@@ -301,10 +331,10 @@ TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
                              ->NumElements(added_vectors.size())
                              ->SparseVectors(added_vectors.data())
                              ->Ids(added_labels.data())
-                             ->UInt32Metadata("host_id", added_hosts.data())
+                             ->StringMetadata("host", added_hosts.data())
                              ->Owner(false);
             REQUIRE(index.Add(added).empty());
-            query_host_id = 0;
+            query_host = "";
             result = index.KnnSearch(query, 2, search_parameters, nullptr);
             REQUIRE(result->GetDim() == 2);
             REQUIRE(result->GetIds()[0] == 50);
@@ -315,12 +345,12 @@ TEST_CASE("SINDIV2 host filter supports mutable immutable and reorder modes",
                 SparseVector{1, &term, &second_added_values[0]},
                 SparseVector{1, &term, &second_added_values[1]}};
             std::array<int64_t, 2> second_added_labels{70, 80};
-            std::array<uint32_t, 2> second_added_hosts{2, 0};
+            std::array<std::string, 2> second_added_hosts{"host-b", ""};
             auto second_added = Dataset::Make()
                                     ->NumElements(second_added_vectors.size())
                                     ->SparseVectors(second_added_vectors.data())
                                     ->Ids(second_added_labels.data())
-                                    ->UInt32Metadata("host_id", second_added_hosts.data())
+                                    ->StringMetadata("host", second_added_hosts.data())
                                     ->Owner(false);
             REQUIRE(index.Add(second_added).empty());
             result = index.KnnSearch(query, 3, search_parameters, nullptr);
@@ -361,13 +391,13 @@ TEST_CASE("SINDIV2 legacy deserialize clears host metadata",
 
     SINDIV2 legacy_source(parameter, common_param);
     REQUIRE(legacy_source.Build(base).empty());
-    uint32_t query_host_id = 99;
+    std::string query_host = "unknown.example";
     float query_value = 1.0F;
     SparseVector query_vector{1, &term, &query_value};
     auto query = Dataset::Make()
                      ->NumElements(1)
                      ->SparseVectors(&query_vector)
-                     ->UInt32Metadata("host_id", &query_host_id)
+                     ->StringMetadata("host", &query_host)
                      ->Owner(false);
     const std::string search_parameters = R"({"sindi_v2": {"n_candidate": 3}})";
     auto expected = legacy_source.KnnSearch(query, 3, search_parameters, nullptr);
@@ -377,9 +407,9 @@ TEST_CASE("SINDIV2 legacy deserialize clears host metadata",
     IOStreamWriter legacy_writer(legacy_stream);
     legacy_source.Serialize(legacy_writer);
 
-    std::array<uint32_t, 3> host_ids{1, 2, 1};
+    std::array<std::string, 3> hosts{"host-a", "host-b", "host-a"};
     SINDIV2 restored(parameter, common_param);
-    REQUIRE(restored.Build(base->UInt32Metadata("host_id", host_ids.data())).empty());
+    REQUIRE(restored.Build(base->StringMetadata("host", hosts.data())).empty());
     REQUIRE(restored.KnnSearch(query, 3, search_parameters, nullptr)->GetDim() == 0);
 
     legacy_stream.seekg(0, std::ios::beg);
@@ -406,7 +436,7 @@ TEST_CASE("SINDIV2 host serialization supports mutable and immutable",
         uint32_t term = 1;
         std::array<float, 4> values{4.0F, 0.0F, 2.0F, 3.0F};
         std::array<int64_t, 4> labels{10, 40, 20, 30};
-        std::array<uint32_t, 4> host_ids{2, 0, 2, 0};
+        std::array<std::string, 4> hosts{"host-b", "", "host-b", ""};
         std::array<SparseVector, 4> vectors{};
         vectors[0] = SparseVector{1, &term, &values[0]};
         vectors[2] = SparseVector{1, &term, &values[2]};
@@ -415,7 +445,7 @@ TEST_CASE("SINDIV2 host serialization supports mutable and immutable",
                         ->NumElements(vectors.size())
                         ->SparseVectors(vectors.data())
                         ->Ids(labels.data())
-                        ->UInt32Metadata("host_id", host_ids.data())
+                        ->StringMetadata("host", hosts.data())
                         ->Owner(false);
 
         auto parameter = std::make_shared<SINDIV2Parameter>();
@@ -432,23 +462,23 @@ TEST_CASE("SINDIV2 host serialization supports mutable and immutable",
             std::array<SparseVector, 2> added_vectors{SparseVector{1, &term, &added_values[0]},
                                                       SparseVector{1, &term, &added_values[1]}};
             std::array<int64_t, 2> added_labels{50, 60};
-            std::array<uint32_t, 2> added_hosts{0, 2};
+            std::array<std::string, 2> added_hosts{"host-new", "host-b"};
             auto added = Dataset::Make()
                              ->NumElements(added_vectors.size())
                              ->SparseVectors(added_vectors.data())
                              ->Ids(added_labels.data())
-                             ->UInt32Metadata("host_id", added_hosts.data())
+                             ->StringMetadata("host", added_hosts.data())
                              ->Owner(false);
             REQUIRE(index.Add(added).empty());
         }
 
         float query_value = 1.0F;
         SparseVector query_vector{1, &term, &query_value};
-        uint32_t query_host_id = 0;
+        std::string query_host = immutable ? "host-b" : "host-new";
         auto query = Dataset::Make()
                          ->NumElements(1)
                          ->SparseVectors(&query_vector)
-                         ->UInt32Metadata("host_id", &query_host_id)
+                         ->StringMetadata("host", &query_host)
                          ->Owner(false);
         const std::string search_parameters = R"({"sindi_v2": {"n_candidate": 4}})";
         auto expected = index.KnnSearch(query, 4, search_parameters, nullptr);
@@ -495,15 +525,18 @@ TEST_CASE("SINDIV2 host serialization supports mutable and immutable",
             float added_value = 7.0F;
             SparseVector added_vector{1, &term, &added_value};
             int64_t added_label = 70;
-            uint32_t added_host = 0;
+            std::string added_host = "host-after-restore";
             auto added = Dataset::Make()
                              ->NumElements(1)
                              ->SparseVectors(&added_vector)
                              ->Ids(&added_label)
-                             ->UInt32Metadata("host_id", &added_host)
+                             ->StringMetadata("host", &added_host)
                              ->Owner(false);
             REQUIRE(restored.Add(added).empty());
-            REQUIRE(restored.KnnSearch(query, 4, search_parameters, nullptr)->GetIds()[0] == 70);
+            query_host = added_host;
+            auto added_result = restored.KnnSearch(query, 4, search_parameters, nullptr);
+            REQUIRE(added_result->GetDim() == 1);
+            REQUIRE(added_result->GetIds()[0] == added_label);
         }
 
         auto missing_host = EraseStreamingBlock(bytes, StreamSerializationTag::SINDI_HOST_METADATA);
@@ -529,7 +562,7 @@ TEST_CASE("SINDIV2 host filter preserves term prune candidates at window boundar
     uint32_t term_id = 1;
     std::array<float, 4> values{10.0F, 9.0F, 2.0F, 1.0F};
     std::array<int64_t, 4> labels{10, 11, 20, 21};
-    std::array<uint32_t, 4> host_ids{1, 1, 2, 2};
+    std::array<std::string, 4> hosts{"host-a", "host-a", "host-b", "host-b"};
     std::array<SparseVector, 4> vectors;
     for (uint32_t i = 0; i < vectors.size(); ++i) {
         vectors[i] = SparseVector{1, &term_id, &values[i]};
@@ -538,7 +571,7 @@ TEST_CASE("SINDIV2 host filter preserves term prune candidates at window boundar
                     ->NumElements(vectors.size())
                     ->SparseVectors(vectors.data())
                     ->Ids(labels.data())
-                    ->UInt32Metadata("host_id", host_ids.data())
+                    ->StringMetadata("host", hosts.data())
                     ->Owner(false);
 
     auto parameter = std::make_shared<SINDIV2Parameter>();
@@ -553,11 +586,11 @@ TEST_CASE("SINDIV2 host filter preserves term prune candidates at window boundar
 
     float query_value = 1.0F;
     SparseVector query_vector{1, &term_id, &query_value};
-    uint32_t query_host_id = 2;
+    std::string query_host = "host-b";
     auto query = Dataset::Make()
                      ->NumElements(1)
                      ->SparseVectors(&query_vector)
-                     ->UInt32Metadata("host_id", &query_host_id)
+                     ->StringMetadata("host", &query_host)
                      ->Owner(false);
     const auto query_prune_ratio = GENERATE(0.0F, 0.2F);
     const auto search_parameters = fmt::format(R"({{
@@ -584,7 +617,7 @@ TEST_CASE("SINDIV2 date bucket and host filtering routes and serializes",
     uint32_t term = 1;
     std::array<float, 4> values{4.0F, 0.0F, 2.0F, 3.0F};
     std::array<int64_t, 4> labels{10, 40, 20, 30};
-    std::array<uint32_t, 4> host_ids{2, 1, 2, 1};
+    std::array<std::string, 4> hosts{"host-b", "host-a", "host-b", "host-a"};
     std::array<std::string, 4> date_buckets = {"2026", "2026/05", "2026/05/01", "2026/08"};
     std::array<SparseVector, 4> vectors{};
     vectors[0] = SparseVector{1, &term, values.data()};
@@ -594,7 +627,7 @@ TEST_CASE("SINDIV2 date bucket and host filtering routes and serializes",
                     ->NumElements(vectors.size())
                     ->SparseVectors(vectors.data())
                     ->Ids(labels.data())
-                    ->UInt32Metadata("host_id", host_ids.data())
+                    ->StringMetadata("host", hosts.data())
                     ->Paths(SINDI_DATE_PATH_NAME, date_buckets.data())
                     ->Owner(false);
 
@@ -609,21 +642,21 @@ TEST_CASE("SINDIV2 date bucket and host filtering routes and serializes",
     REQUIRE(index.Build(base) == std::vector<int64_t>{40});
 
     int64_t added_label = 50;
-    uint32_t added_host = 2;
+    std::string added_host = "host-b";
     std::string added_date = "2026/09";
     SparseVector added_vector{1, &term, values.data()};
     auto dated_add = Dataset::Make()
                          ->NumElements(1)
                          ->SparseVectors(&added_vector)
                          ->Ids(&added_label)
-                         ->UInt32Metadata(SINDI_HOST_ID_METADATA_NAME, &added_host)
+                         ->StringMetadata(SINDI_HOST_METADATA_NAME, &added_host)
                          ->Paths(SINDI_DATE_PATH_NAME, &added_date)
                          ->Owner(false);
     auto undated_add = Dataset::Make()
                            ->NumElements(1)
                            ->SparseVectors(&added_vector)
                            ->Ids(&added_label)
-                           ->UInt32Metadata(SINDI_HOST_ID_METADATA_NAME, &added_host)
+                           ->StringMetadata(SINDI_HOST_METADATA_NAME, &added_host)
                            ->Owner(false);
     if (not parameter->immutable) {
         REQUIRE_THROWS_WITH(index.Add(dated_add),
@@ -699,8 +732,8 @@ TEST_CASE("SINDIV2 date bucket and host filtering routes and serializes",
     REQUIRE(partial_bucket_range->GetDim() == 1);
     REQUIRE(partial_bucket_range->GetIds()[0] == 20);
 
-    uint32_t host_id = 2;
-    query->UInt32Metadata("host_id", &host_id);
+    std::string host = "host-b";
+    query->StringMetadata("host", &host);
     auto combined = index.KnnSearch(query, 3, search_parameters, nullptr);
     REQUIRE(combined->GetDim() == 2);
     REQUIRE(combined->GetIds()[0] == 10);

--- a/src/dataset_impl.cpp
+++ b/src/dataset_impl.cpp
@@ -162,7 +162,7 @@ allocate_and_copy_multi_vectors(const MultiVector* src,
 }
 
 static std::string*
-allocate_and_copy_paths(const std::string* src, uint64_t count) {
+allocate_and_copy_strings(const std::string* src, uint64_t count) {
     if (src == nullptr) {
         return nullptr;
     }
@@ -305,19 +305,19 @@ DatasetImpl::~DatasetImpl() {  // NOLINT
             delete[] DatasetImpl::GetMultiVectors();
         }
     }
-    std::unordered_set<const std::string*> released_paths;
-    auto release_paths = [&released_paths](const std::string* paths) {
-        if (paths != nullptr && released_paths.insert(paths).second) {
-            delete[] paths;
+    std::unordered_set<const std::string*> released_strings;
+    auto release_strings = [&released_strings](const std::string* values) {
+        if (values != nullptr && released_strings.insert(values).second) {
+            delete[] values;
         }
     };
-    release_paths(DatasetImpl::GetPaths());
+    release_strings(DatasetImpl::GetPaths());
     for (const auto& [key, value] : this->data_) {
-        if (IsHierarchyPathsKey(key)) {
-            release_paths(std::get<const std::string*>(value));
+        if (IsHierarchyPathsKey(key) or IsStringMetadataKey(key)) {
+            release_strings(std::get<const std::string*>(value));
         }
     }
-    delete[] DatasetImpl::GetSourceID();
+    release_strings(DatasetImpl::GetSourceID());
     if (DatasetImpl::GetAttributeSets() != nullptr) {
         const auto* attrsets = DatasetImpl::GetAttributeSets();
         for (int i = 0; i < DatasetImpl::GetNumElements(); ++i) {
@@ -382,13 +382,13 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
     }
     if (this->GetPaths() != nullptr) {
         copy_dataset->Paths(
-            allocate_and_copy_paths(this->GetPaths(), static_cast<uint64_t>(num_elements)));
+            allocate_and_copy_strings(this->GetPaths(), static_cast<uint64_t>(num_elements)));
     }
     for (const auto& [key, value] : this->data_) {
         if (IsHierarchyPathsKey(key)) {
             copy_dataset->Paths(HierarchyNameFromPathsKey(key),
-                                allocate_and_copy_paths(std::get<const std::string*>(value),
-                                                        static_cast<uint64_t>(num_elements)));
+                                allocate_and_copy_strings(std::get<const std::string*>(value),
+                                                          static_cast<uint64_t>(num_elements)));
         }
     }
     for (const auto& [key, value] : this->data_) {
@@ -396,6 +396,14 @@ DatasetImpl::DeepCopy(Allocator* allocator) const {
         if (IsUInt32MetadataKey(key) and values != nullptr and *values != nullptr) {
             copy_dataset->UInt32Metadata(UInt32MetadataNameFromKey(key),
                                          allocate_and_copy(*values, num_elements, allocator_ref));
+        }
+    }
+    for (const auto& [key, value] : this->data_) {
+        const auto* values = std::get_if<const std::string*>(&value);
+        if (IsStringMetadataKey(key) and values != nullptr and *values != nullptr) {
+            copy_dataset->StringMetadata(
+                StringMetadataNameFromKey(key),
+                allocate_and_copy_strings(*values, static_cast<uint64_t>(num_elements)));
         }
     }
 
@@ -498,6 +506,32 @@ DatasetImpl::Append(const DatasetPtr& other) {
         }
     }
 
+    std::vector<std::string> string_metadata_keys;
+    for (const auto& [key, value] : this->data_) {
+        if (not IsStringMetadataKey(key) || std::get<const std::string*>(value) == nullptr) {
+            continue;
+        }
+        const auto name = StringMetadataNameFromKey(key);
+        if (other->GetStringMetadata(name) == nullptr) {
+            throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                "Cannot append dataset without string metadata " + name);
+        }
+        string_metadata_keys.push_back(key);
+    }
+    if (other_impl != nullptr) {
+        for (const auto& [key, value] : other_impl->data_) {
+            if (not IsStringMetadataKey(key) || std::get<const std::string*>(value) == nullptr) {
+                continue;
+            }
+            const auto name = StringMetadataNameFromKey(key);
+            if (this->GetStringMetadata(name) == nullptr) {
+                throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                    "Cannot append dataset with string metadata " + name +
+                                        " to dataset without it");
+            }
+        }
+    }
+
     std::vector<std::string> uint32_metadata_keys;
     for (const auto& [key, value] : this->data_) {
         if (not IsUInt32MetadataKey(key) || std::get<const uint32_t*>(value) == nullptr) {
@@ -596,20 +630,20 @@ DatasetImpl::Append(const DatasetPtr& other) {
     }
 
     // append paths
-    std::unordered_set<const std::string*> replaced_paths;
-    auto append_paths = [&](const std::string* current_paths, const std::string* other_paths) {
+    std::unordered_set<const std::string*> replaced_strings;
+    auto append_strings = [&](const std::string* current_values, const std::string* other_values) {
         auto* paths_copy = new std::string[old_num_elements + new_num_elements];
         for (int64_t i = 0; i < old_num_elements; ++i) {
-            paths_copy[i] = current_paths[i];
+            paths_copy[i] = current_values[i];
         }
         for (int64_t i = 0; i < new_num_elements; ++i) {
-            paths_copy[old_num_elements + i] = other_paths[i];
+            paths_copy[old_num_elements + i] = other_values[i];
         }
-        replaced_paths.insert(current_paths);
+        replaced_strings.insert(current_values);
         return paths_copy;
     };
     if (auto iter = this->data_.find(DATASET_PATHS); iter != this->data_.end()) {
-        this->Paths(append_paths(std::get<const std::string*>(iter->second), other->GetPaths()));
+        this->Paths(append_strings(std::get<const std::string*>(iter->second), other->GetPaths()));
     }
     for (const auto& key : hierarchy_path_keys) {
         auto iter = this->data_.find(key);
@@ -618,25 +652,24 @@ DatasetImpl::Append(const DatasetPtr& other) {
         }
         auto hierarchy_name = HierarchyNameFromPathsKey(key);
         this->Paths(hierarchy_name,
-                    append_paths(std::get<const std::string*>(iter->second),
-                                 other->GetPaths(hierarchy_name)));
+                    append_strings(std::get<const std::string*>(iter->second),
+                                   other->GetPaths(hierarchy_name)));
     }
-    for (const auto* paths : replaced_paths) {
-        delete[] paths;
+    for (const auto& key : string_metadata_keys) {
+        auto iter = this->data_.find(key);
+        const auto name = StringMetadataNameFromKey(key);
+        this->StringMetadata(name,
+                             append_strings(std::get<const std::string*>(iter->second),
+                                            other->GetStringMetadata(name)));
     }
 
     // append source-id
     if (auto iter = this->data_.find(SOURCE_ID); iter != this->data_.end()) {
         auto* ptr = const_cast<std::string*>(std::get<const std::string*>(iter->second));
-        auto* source_id_copy = new std::string[old_num_elements + new_num_elements];
-        for (int i = 0; i < old_num_elements; ++i) {
-            source_id_copy[i] = ptr[i];
-        }
-        for (int i = 0; i < new_num_elements; ++i) {
-            source_id_copy[old_num_elements + i] = other->GetSourceID()[i];
-        }
-        this->SourceID(source_id_copy);
-        delete[] ptr;
+        this->SourceID(append_strings(ptr, other->GetSourceID()));
+    }
+    for (const auto* values : replaced_strings) {
+        delete[] values;
     }
 
     // append sparse-vectors

--- a/src/dataset_impl.h
+++ b/src/dataset_impl.h
@@ -255,6 +255,20 @@ public:
     }
 
     DatasetPtr
+    StringMetadata(const std::string& name, const std::string* values) override {
+        this->data_[StringMetadataKey(name)] = values;
+        return shared_from_this();
+    }
+
+    const std::string*
+    GetStringMetadata(const std::string& name) const override {
+        if (auto iter = this->data_.find(StringMetadataKey(name)); iter != this->data_.end()) {
+            return std::get<const std::string*>(iter->second);
+        }
+        return nullptr;
+    }
+
+    DatasetPtr
     ExtraInfos(const char* extra_info) override {
         this->data_[EXTRA_INFOS] = extra_info;
         return shared_from_this();
@@ -406,6 +420,26 @@ private:
     static std::string
     UInt32MetadataNameFromKey(const std::string& key) {
         return key.substr(UInt32MetadataPrefix().size());
+    }
+
+    static constexpr std::string_view
+    StringMetadataPrefix() {
+        return "string_metadata:";
+    }
+
+    static std::string
+    StringMetadataKey(const std::string& name) {
+        return std::string(StringMetadataPrefix()) + name;
+    }
+
+    static bool
+    IsStringMetadataKey(const std::string& key) {
+        return key.rfind(StringMetadataPrefix(), 0) == 0;
+    }
+
+    static std::string
+    StringMetadataNameFromKey(const std::string& key) {
+        return key.substr(StringMetadataPrefix().size());
     }
 
 private:

--- a/src/dataset_impl_test.cpp
+++ b/src/dataset_impl_test.cpp
@@ -591,6 +591,56 @@ TEST_CASE("Dataset Named UInt32 Metadata Test", "[ut][dataset]") {
     REQUIRE(null_metadata_copy->GetUInt32Metadata("host_id") == nullptr);
 }
 
+TEST_CASE("Dataset Named String Metadata Test", "[ut][dataset]") {
+    {
+        auto* shared_metadata = new std::string[2]{"a.example", "b.example"};
+        auto aliased = vsag::Dataset::Make();
+        aliased->NumElements(2)
+            ->Dim(1)
+            ->Paths(shared_metadata)
+            ->StringMetadata("host", shared_metadata)
+            ->StringMetadata("tenant", shared_metadata)
+            ->SourceID(shared_metadata)
+            ->Owner(true);
+    }
+
+    auto* first_hosts = new std::string[2]{"a.example", "b.example"};
+    auto first = vsag::Dataset::Make();
+    first->NumElements(2)->Dim(1)->StringMetadata("host", first_hosts)->Owner(true);
+
+    REQUIRE(first->GetStringMetadata("host") == first_hosts);
+    REQUIRE(first->GetStringMetadata("missing") == nullptr);
+
+    auto copy = first->DeepCopy();
+    REQUIRE(copy->GetStringMetadata("host") != first_hosts);
+    REQUIRE(copy->GetStringMetadata("host")[0] == "a.example");
+    REQUIRE(copy->GetStringMetadata("host")[1] == "b.example");
+
+    auto* appended_hosts = new std::string[2]{"c.example", ""};
+    auto appended = vsag::Dataset::Make();
+    appended->NumElements(2)->Dim(1)->StringMetadata("host", appended_hosts)->Owner(true);
+    first->Append(appended);
+    REQUIRE(first->GetNumElements() == 4);
+    REQUIRE(first->GetStringMetadata("host")[2] == "c.example");
+    REQUIRE(first->GetStringMetadata("host")[3].empty());
+
+    auto slice = vsag::Dataset::Make();
+    slice->NumElements(2)
+        ->Dim(1)
+        ->StringMetadata("host", first->GetStringMetadata("host") + 1)
+        ->Owner(false);
+    REQUIRE(slice->GetStringMetadata("host")[0] == "b.example");
+    REQUIRE(slice->GetStringMetadata("host")[1] == "c.example");
+
+    auto missing_metadata = vsag::Dataset::Make()->NumElements(1)->Dim(1)->Owner(false);
+    REQUIRE_THROWS(first->Append(missing_metadata));
+
+    auto null_metadata = vsag::Dataset::Make();
+    null_metadata->NumElements(2)->StringMetadata("host", nullptr)->Owner(true);
+    auto null_metadata_copy = null_metadata->DeepCopy();
+    REQUIRE(null_metadata_copy->GetStringMetadata("host") == nullptr);
+}
+
 TEST_CASE("Dataset MultiVector Basic Test", "[ut][dataset]") {
     SECTION("MultiVectorDim default is 0") {
         auto dataset = vsag::Dataset::Make();


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2879

## What Changed

- add generic named string metadata to `Dataset`, including ownership, deep-copy, and append handling
- accept byte-exact string `host` metadata for SINDI/SINDI_V2 Build, mutable Add, and KNN queries
- encode hosts to compact internal IDs and persist the string dictionary in legacy and streaming formats
- reserve the empty string for missing hosts, return empty results for unknown hosts, and reject old numeric `host_id` inputs/index payloads
- preserve legacy date-only indexes while versioning date-and-host payloads
- update English and Chinese Dataset, SINDI, SINDI_V2, and serialization documentation

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (describe below)

Test details:

```text
cmake --build build --target unittests --parallel 6
./build/tests/unittests "[ut][dataset]"
  All tests passed (99740 assertions in 8 test cases)
./build/tests/unittests "[host_filter]"
  All tests passed (412 assertions in 18 test cases)
./build/tests/unittests "[date_filter]"
  All tests passed (540 assertions in 4 test cases)
develop.log/experiments/sindi_string_host_sparse38m/run.sh
  PASS: read and validated all 38,857,276 documents directly from the original source-site text file (full metrics are posted in the PR conversation).
```

## Compatibility Impact

- API/ABI compatibility: breaking for custom `Dataset` implementations and SINDI/SINDI_V2 host-filter callers; new pure virtual string metadata methods replace numeric host use
- Behavior changes: numeric `host_id` input and numeric host-aware serialized indexes are intentionally rejected; date-only historical indexes remain readable

## Performance and Concurrency Impact

- Performance impact: one string hash lookup per host query and a persistent compact host dictionary plus runtime lookup table; full Sparse38M validation measured 41,459,802 serialized bytes and 74,160,938 bytes of host-metadata memory
- Concurrency/thread-safety impact: none; build mutation and query routing retain the existing synchronization model

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: English and Chinese Dataset, SINDI, SINDI_V2, and streaming serialization pages

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert this PR commit; callers can continue using the prior numeric host API on the prior index format

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)

