### PR TITLE
ci: make C++ coverage repository-scoped

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,13 +1,12 @@
 
 # Configuration for CodeCov
 codecov:
+  disable_default_path_fixes: true
   max_report_age: off
   require_ci_to_pass: no
   notify:
     require_ci_to_pass: no
     wait_for_ci: false
-fixes:
-  - "/__w/vsag/::/"
 
 
 coverage:
@@ -42,22 +41,51 @@ component_management:
         branches:
           - "!main"
   individual_components:  # in alphabetical
+    - component_id: module_analyzer
+      name: analyzer
+      paths:
+        - src/analyzer/**
+    - component_id: module_attr
+      name: attr
+      paths:
+        - src/attr/**
     - component_id: module_common
       name: common
       paths:
-        - src/*
+        - include/vsag/**
+        - ^src/[^/]+$
     - component_id: module_datacell
       name: datacell
       paths:
         - src/datacell/**
         - src/io/**
         - src/quantization/**
+    - component_id: module_factory
+      name: factory
+      paths:
+        - src/factory/**
+    - component_id: module_impl
+      name: impl
+      paths:
+        - src/impl/**
     - component_id: module_index
       name: index
       paths:
         - src/index/**
         - src/algorithm/**
+    - component_id: module_layout
+      name: layout
+      paths:
+        - src/layout/**
     - component_id: module_simd
       name: simd
       paths:
         - src/simd/**
+    - component_id: module_storage
+      name: storage
+      paths:
+        - src/storage/**
+    - component_id: module_utils
+      name: utils
+      paths:
+        - src/utils/**

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,6 +39,7 @@ jobs:
     env:
       VSAG_FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.ci-fetchcontent
       VSAG_THIRDPARTY_DOWNLOAD_DIR: ${{ github.workspace }}/.ci-downloads
+      VSAG_TEST_SEED: 424242
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,7 +76,10 @@ jobs:
         env:
           CMAKE_GENERATOR: Ninja
           EXTRA_DEFINED: -DVSAG_USE_SYSTEM_OPENBLAS=ON
-        run: ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/compile.log make cov
+        run: |
+          ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/compile.log make cov
+          ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/instrumentation.log \
+            python3 scripts/coverage/verify_cpp_coverage.py instrumentation build/compile_commands.json
       - name: Run Test
         run: >-
           ./scripts/ci/run-with-diagnostics.sh coverage-diagnostics/tests.log

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       cpp: ${{ steps.changes.outputs.cpp }}
       cmake: ${{ steps.changes.outputs.cmake }}
+      coverage: ${{ steps.changes.outputs.coverage }}
       python: ${{ steps.changes.outputs.python }}
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +47,18 @@ jobs:
               - 'CMakeLists.txt'
               - 'Makefile'
               - 'cmake/**'
+            coverage:
+              - '.github/codecov.yml'
+              - '.github/workflows/coverage.yml'
+              - '.github/workflows/pr-ci.yml'
+              - 'CMakeLists.txt'
+              - 'Makefile'
+              - 'cmake/**'
+              - 'scripts/coverage/**'
+              - 'scripts/testing/test_parallel_bg.sh'
+              - 'src/**/CMakeLists.txt'
+              - 'tests/CMakeLists.txt'
+              - 'tests/scripts/coverage_diagnostics_test.py'
             python:
               - 'python/**'
               - 'python_bindings/**'
@@ -70,6 +83,20 @@ jobs:
       - name: Run Clang format check
         run: ./scripts/format/check_format.sh
 
+  coverage-config:
+    name: Coverage Configuration
+    needs: changes
+    if: needs.changes.outputs.coverage == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test coverage configuration
+        run: |
+          python3 -m unittest tests/scripts/coverage_diagnostics_test.py
+          bash -n scripts/coverage/collect_cpp_coverage.sh
+          bash -n scripts/coverage/check_cov.sh
+          bash -n scripts/testing/test_parallel_bg.sh
+
   build-asan-x86:
     name: ASan Build X86
     needs: [changes, format]
@@ -90,7 +117,6 @@ jobs:
         run: |
           python3 -m unittest discover -s scripts/linters -p 'test_changed_source_filter.py'
           python3 -m unittest tests/scripts/configure_git_safe_directory_test.py
-          python3 -m unittest tests/scripts/coverage_diagnostics_test.py
       - name: Prepare Host
         run: |
           sudo env VSAG_INSTALL_INTEL_MKL=OFF bash ./scripts/deps/install_deps_ubuntu.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,9 +136,12 @@ $ sudo apt-get install lcov
 Compile with coverage flags, run tests, and collect the coverage report:
 ```shell
 $ make cov
-$ bash scripts/testing/test_parallel_bg.sh
+$ VSAG_TEST_SEED=424242 bash scripts/testing/test_parallel_bg.sh
 $ bash scripts/coverage/collect_cpp_coverage.sh
+$ bash scripts/coverage/check_cov.sh
 ```
+
+This matches the CI source population: maintained production code under `src/` and public headers under `include/`, excluding the generated `src/version.h` and vendored `include/vsag/expected.hpp`. The collector retains branch records and writes normalized repository-relative paths to `coverage/coverage.info`.
 
 ## Pull Request Labels
 

--- a/docs/agents/build-and-test.md
+++ b/docs/agents/build-and-test.md
@@ -58,9 +58,9 @@ versions for consistent formatting and diagnostics. CI will fail otherwise.
   `make test` builds and runs the unit + functional suite but does **not**
   enable coverage instrumentation. To produce the coverage report locally use
   the `make cov` flow (which configures the build with `ENABLE_COVERAGE=ON`)
-  followed by running the test binaries and
-  `scripts/coverage/collect_cpp_coverage.sh`; the equivalent CI coverage
-  workflow enforces the 90% threshold. This threshold is based on the
-  unit-test suite; functional tests under `tests/` and Python code are not
-  currently included in the coverage metric unless explicitly documented
-  otherwise.
+  followed by `VSAG_TEST_SEED=424242 bash scripts/testing/test_parallel_bg.sh`
+  and `bash scripts/coverage/collect_cpp_coverage.sh`. The C++ report combines the
+  non-daily unit and functional suites, but measures only maintained production
+  sources under `src/` and `include/`; it excludes the generated
+  `src/version.h` and vendored `include/vsag/expected.hpp`. Python sources and
+  platform paths not compiled by the coverage job are not part of this metric.

--- a/docs/docs/en/src/development/testing.md
+++ b/docs/docs/en/src/development/testing.md
@@ -17,21 +17,27 @@ make test
 ```
 
 Note: `make test` does not enable coverage instrumentation. To produce a coverage report, use
-`make cov` — it configures the build with `ENABLE_COVERAGE=ON`; run the test binaries afterwards
-to collect and aggregate coverage data:
+`make cov` — it configures the build with `ENABLE_COVERAGE=ON`; then run the same non-daily unit
+and functional suites as coverage CI with its fixed seed before collecting the trace:
 
 ```bash
 make cov
-# then run the test binaries, e.g.:
-./build-debug/tests/functional_tests
-# open build-debug/coverage/index.html
+VSAG_TEST_SEED=424242 bash scripts/testing/test_parallel_bg.sh
+bash scripts/coverage/collect_cpp_coverage.sh
+bash scripts/coverage/check_cov.sh
 ```
+
+The collector writes `coverage/coverage.info` with repository-relative paths and branch data.
+It measures maintained production sources under `src/` and public headers under `include/`,
+excluding generated `src/version.h` and vendored `include/vsag/expected.hpp`. Code compiled only
+on another platform is explicitly outside the Linux x86 report and must be measured by a
+platform-specific coverage job rather than treated as covered.
 
 ## Run a Single Binary
 
 ```bash
-./build-debug/tests/functional_tests "[hgraph]"
-./build-debug/tests/functional_tests "[hgraph][concurrent]"
+./build/tests/functests "[hgraph]"
+./build/tests/functests "[hgraph][concurrent]"
 ```
 
 Catch2 supports filtering by name, tag, and wildcards — see `--help`.

--- a/docs/docs/zh/src/development/testing.md
+++ b/docs/docs/zh/src/development/testing.md
@@ -20,15 +20,16 @@ make test
 1. 运行 `src/` 下的单元测试；
 2. 运行 `tests/` 下的功能测试；
 3. `make test` 并未开启覆盖率（`ENABLE_COVERAGE=ON`）。需要覆盖率报告时请使用
-   `make cov`：该目标仅完成带覆盖率插桩的编译，随后需要手动运行测试二进制以生成报告。
+   `make cov`：该目标仅完成带覆盖率插桩的编译，随后按下文命令以固定随机种子运行
+   与覆盖率 CI 相同的非 daily 单元测试和功能测试并生成报告。
 
 ## 仅运行单个测试二进制
 
 构建完成后，可直接运行单个测试：
 
 ```bash
-./build-debug/tests/functional_tests "[hgraph]"
-./build-debug/tests/functional_tests "[hgraph][concurrent]"
+./build/tests/functests "[hgraph]"
+./build/tests/functests "[hgraph][concurrent]"
 ```
 
 Catch2 支持按名字、tag、通配符等方式筛选用例，详见 `--help`。
@@ -39,11 +40,15 @@ Catch2 支持按名字、tag、通配符等方式筛选用例，详见 `--help`�
 
 ```bash
 make cov
-# 然后运行测试二进制以采集覆盖率，例如：
-./build-debug/tests/functional_tests
+VSAG_TEST_SEED=424242 bash scripts/testing/test_parallel_bg.sh
+bash scripts/coverage/collect_cpp_coverage.sh
+bash scripts/coverage/check_cov.sh
 ```
 
-报告会输出到 `build-debug/coverage/` 下，可用浏览器打开 `index.html` 查看未覆盖的分支。
+采集脚本会生成包含分支数据和仓库相对路径的 `coverage/coverage.info`。统计范围仅包括
+`src/` 下的维护中生产代码和 `include/` 下的公共头文件，并排除构建时生成的
+`src/version.h` 与引入的兼容头文件 `include/vsag/expected.hpp`。仅在其他平台编译的路径
+明确不属于 Linux x86 报告的统计范围，必须由平台专用覆盖率任务统计，不能视为已覆盖。
 
 ## 内存泄漏与多线程
 

--- a/scripts/coverage/check_cov.sh
+++ b/scripts/coverage/check_cov.sh
@@ -4,7 +4,9 @@ set -eo pipefail
 
 MIN_LINE_COVERAGE=90
 
-line_coverage=$(lcov --summary coverage/coverage.info | \
+line_coverage=$(lcov --rc branch_coverage=1 \
+  --summary coverage/coverage.info \
+  --ignore-errors inconsistent,inconsistent | \
   grep "lines......" | \
   awk '/lines/ { print $2 }' | \
   cut -d '%' -f 1)

--- a/scripts/coverage/collect_cpp_coverage.sh
+++ b/scripts/coverage/collect_cpp_coverage.sh
@@ -7,41 +7,52 @@ SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$( cd "${SCRIPTS_DIR}/../../" && pwd )"
 
 COVERAGE_DIR="${ROOT_DIR}/coverage"
+COVERAGE_RAW_FILE="${COVERAGE_DIR}/coverage.raw.info"
+COVERAGE_SCOPED_FILE="${COVERAGE_DIR}/coverage.scoped.info"
+COVERAGE_FILE="${COVERAGE_DIR}/coverage.info"
 if [ -d "${COVERAGE_DIR}" ]; then
     rm -rf "${COVERAGE_DIR:?}"/*
 else
     mkdir -p "${COVERAGE_DIR}"
 fi
 
-# Exclude system headers before lcov runs consistency checks. The remove step below keeps the
-# same filter for compatibility with existing trace files.
+# Limit capture to repository-owned production sources before lcov runs consistency checks.
+# The later extract is a defense-in-depth check and normalizes paths for local and Codecov use.
 lcov --rc branch_coverage=1 \
      --rc geninfo_unexecuted_blocks=1 \
      --parallel 8 \
-     --directory . \
+     --directory "${ROOT_DIR}" \
      --capture \
      --exclude '/usr/*' \
-     --substitute "s#${ROOT_DIR}/##g" \
+     --include "${ROOT_DIR}/src/*" \
+     --include "${ROOT_DIR}/include/*" \
      --ignore-errors mismatch,mismatch \
      --ignore-errors count,count \
-     --output-file ${COVERAGE_DIR}/coverage.info
-lcov --remove ${COVERAGE_DIR}/coverage.info \
-     '/usr/*' \
-     'build/*' \
-     'tests/*' \
-     '*/expected.hpp' \
-     '*_test.cpp' \
-     '*/avx512.cpp' \
+     --output-file "${COVERAGE_RAW_FILE}"
+
+# These two files are not maintained production sources: version.h is generated at build time,
+# and expected.hpp is a vendored public compatibility header.
+lcov --rc branch_coverage=1 \
+     --remove "${COVERAGE_RAW_FILE}" \
+     "${ROOT_DIR}/src/version.h" \
+     "${ROOT_DIR}/include/vsag/expected.hpp" \
      --ignore-errors inconsistent,inconsistent \
      --ignore-errors unused,unused \
-     --output-file ${COVERAGE_DIR}/coverage.info
-lcov --list ${COVERAGE_DIR}/coverage.info \
-     --ignore-errors inconsistent,inconsistent,child
+     --output-file "${COVERAGE_SCOPED_FILE}"
 
-pushd "${COVERAGE_DIR}"
-coverages=$(ls coverage.info)
-if [ ! "$coverages" ];then
-    echo "no coverage file"
-    exit 0
-fi
-popd
+lcov --rc branch_coverage=1 \
+     --extract "${COVERAGE_SCOPED_FILE}" \
+     'src/*' \
+     'include/*' \
+     --substitute "s#${ROOT_DIR}/##g" \
+     --ignore-errors inconsistent,inconsistent \
+     --ignore-errors unused,unused \
+     --output-file "${COVERAGE_FILE}"
+
+rm -f "${COVERAGE_RAW_FILE}" "${COVERAGE_SCOPED_FILE}"
+
+python3 "${SCRIPTS_DIR}/verify_cpp_coverage.py" trace "${COVERAGE_FILE}"
+
+lcov --rc branch_coverage=1 \
+     --list "${COVERAGE_FILE}" \
+     --ignore-errors inconsistent,inconsistent,child

--- a/scripts/coverage/verify_cpp_coverage.py
+++ b/scripts/coverage/verify_cpp_coverage.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import shlex
+import subprocess
+import sys
+
+
+PRODUCTION_SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".cxx"}
+
+
+def fail(message: str) -> None:
+    print(f"coverage verification failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def verify_trace(trace_file: Path, source_root: Path) -> None:
+    if not trace_file.is_file() or trace_file.stat().st_size == 0:
+        fail(f"trace file is missing or empty: {trace_file}")
+
+    source_files: list[str] = []
+    branch_records = 0
+    with trace_file.open(encoding="utf-8") as trace:
+        for raw_line in trace:
+            line = raw_line.rstrip("\n")
+            if line.startswith("SF:"):
+                source_files.append(line.removeprefix("SF:"))
+            elif line.startswith("BRDA:"):
+                branch_records += 1
+
+    if not source_files:
+        fail("trace file contains no source records")
+
+    absolute_sources = [source for source in source_files if PurePosixPath(source).is_absolute()]
+    if absolute_sources:
+        fail("trace contains absolute source paths: " + ", ".join(absolute_sources[:5]))
+
+    unexpected_sources = []
+    for source in source_files:
+        path = PurePosixPath(source)
+        if not path.parts or path.parts[0] not in {"src", "include"} or ".." in path.parts:
+            unexpected_sources.append(source)
+    if unexpected_sources:
+        fail("trace contains non-production sources: " + ", ".join(unexpected_sources[:5]))
+
+    try:
+        tracked_sources = set(
+            subprocess.check_output(
+                ["git", "-C", str(source_root), "ls-files", "--", "src", "include"],
+                text=True,
+            ).splitlines()
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        fail(f"cannot read tracked source inventory from {source_root}: {error}")
+
+    untracked_sources = [source for source in source_files if source not in tracked_sources]
+    if untracked_sources:
+        fail("trace contains generated or untracked sources: " + ", ".join(untracked_sources[:5]))
+
+    if branch_records == 0:
+        fail("trace contains no branch records; branch coverage was lost during filtering")
+
+    print(
+        f"verified {len(source_files)} repository production source records "
+        f"and {branch_records} branch records"
+    )
+
+
+def source_path(entry: dict[str, object], compile_commands: Path) -> Path:
+    file_value = entry.get("file")
+    if not isinstance(file_value, str):
+        fail(f"compile command without a file in {compile_commands}")
+
+    path = Path(file_value)
+    if path.is_absolute():
+        return path.resolve()
+
+    directory_value = entry.get("directory")
+    if not isinstance(directory_value, str):
+        fail(f"relative compile command without a directory in {compile_commands}")
+    return (Path(directory_value) / path).resolve()
+
+
+def command_arguments(entry: dict[str, object], compile_commands: Path) -> list[str]:
+    arguments = entry.get("arguments")
+    if isinstance(arguments, list) and all(isinstance(argument, str) for argument in arguments):
+        return arguments
+
+    command = entry.get("command")
+    if isinstance(command, str):
+        return shlex.split(command)
+
+    fail(f"compile command has neither arguments nor command in {compile_commands}")
+
+
+def verify_instrumentation(compile_commands: Path, source_root: Path) -> None:
+    try:
+        database = json.loads(compile_commands.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot read {compile_commands}: {error}")
+
+    if not isinstance(database, list):
+        fail(f"compile command database is not a list: {compile_commands}")
+
+    production_root = (source_root / "src").resolve()
+    production_commands: list[tuple[Path, list[str]]] = []
+    for raw_entry in database:
+        if not isinstance(raw_entry, dict):
+            fail(f"compile command entry is not an object in {compile_commands}")
+        path = source_path(raw_entry, compile_commands)
+        try:
+            path.relative_to(production_root)
+        except ValueError:
+            continue
+        if path.suffix not in PRODUCTION_SOURCE_SUFFIXES or path.name.endswith("_test.cpp"):
+            continue
+        production_commands.append((path, command_arguments(raw_entry, compile_commands)))
+
+    if not production_commands:
+        fail(f"no maintained production compile commands found below {production_root}")
+
+    missing = [
+        str(path.relative_to(source_root))
+        for path, arguments in production_commands
+        if "--coverage" not in arguments
+    ]
+    if missing:
+        fail("maintained production sources lack --coverage: " + ", ".join(missing[:10]))
+
+    print(f"verified coverage instrumentation for {len(production_commands)} compile commands")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    trace_parser = subparsers.add_parser("trace")
+    trace_parser.add_argument("trace_file", type=Path)
+    trace_parser.add_argument(
+        "--source-root", type=Path, default=Path(__file__).resolve().parents[2]
+    )
+
+    instrumentation_parser = subparsers.add_parser("instrumentation")
+    instrumentation_parser.add_argument("compile_commands", type=Path)
+    instrumentation_parser.add_argument(
+        "--source-root", type=Path, default=Path(__file__).resolve().parents[2]
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    if arguments.mode == "trace":
+        verify_trace(arguments.trace_file, arguments.source_root.resolve())
+    else:
+        verify_instrumentation(arguments.compile_commands, arguments.source_root.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/testing/test_parallel_bg.sh
+++ b/scripts/testing/test_parallel_bg.sh
@@ -5,6 +5,12 @@ exit_codes=()
 logger_files=()
 parallel_tags="[hgraph]"
 othertag=""
+rng_args=()
+
+if [ -n "${VSAG_TEST_SEED:-}" ]; then
+  rng_args=(--rng-seed "${VSAG_TEST_SEED}")
+  echo "test random seed: ${VSAG_TEST_SEED}"
+fi
 
 rm -rf ./log
 mkdir ./log
@@ -20,20 +26,20 @@ else
 fi
 echo "addition_tag: ${addition_tag}"
 
-./build/tests/unittests -d yes ${UT_FILTER} -a --order rand --allow-running-no-tests -o "./log/unittest.log" &
+./build/tests/unittests -d yes ${UT_FILTER} -a --order rand "${rng_args[@]}" --allow-running-no-tests -o "./log/unittest.log" &
 pids+=($!)
 logger_files+=("./log/unittest.log")
 
 for tag in ${parallel_tags}
 do
   othertag="~"${tag}${othertag}
-  ./build/tests/functests -d yes ${UT_FILTER} -a --order rand --allow-running-no-tests ${tag} ${addition_tag} -o ./log/${tag}.log &
+  ./build/tests/functests -d yes ${UT_FILTER} -a --order rand "${rng_args[@]}" --allow-running-no-tests ${tag} ${addition_tag} -o ./log/${tag}.log &
   pids+=($!)
   logname="./log/"${tag}".log"
   logger_files+=($logname)
 done
 
-./build/tests/functests -d yes ${UT_FILTER} -a --order rand --allow-running-no-tests ${othertag} ${addition_tag} -o ./log/other.log &
+./build/tests/functests -d yes ${UT_FILTER} -a --order rand "${rng_args[@]}" --allow-running-no-tests ${othertag} ${addition_tag} -o ./log/other.log &
 pids+=($!)
 logger_files+=("./log/other.log")
 

--- a/src/analyzer/CMakeLists.txt
+++ b/src/analyzer/CMakeLists.txt
@@ -26,4 +26,4 @@ set (ANALYZER_SRC
 )
 
 add_library (analyzer OBJECT ${ANALYZER_SRC})
-target_link_libraries (analyzer PRIVATE vsag_src_common)
+target_link_libraries (analyzer PRIVATE coverage_config vsag_src_common)

--- a/src/impl/blas/CMakeLists.txt
+++ b/src/impl/blas/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 
 add_library (vsag_blas OBJECT blas_function.cpp)
+target_link_libraries (vsag_blas PRIVATE coverage_config)
 if (TARGET vsag_openmp)
     target_link_libraries (vsag_blas PRIVATE vsag_openmp)
 endif ()

--- a/src/impl/cluster/CMakeLists.txt
+++ b/src/impl/cluster/CMakeLists.txt
@@ -15,4 +15,4 @@
 
 
 add_library (cluster OBJECT kmeans_cluster.cpp nearest_centroid_assign.cpp kmedoids_cluster.cpp)
-target_link_libraries (cluster PRIVATE vsag_src_common)
+target_link_libraries (cluster PRIVATE coverage_config vsag_src_common)

--- a/src/impl/reorder/CMakeLists.txt
+++ b/src/impl/reorder/CMakeLists.txt
@@ -23,4 +23,4 @@ set (REORDER_SRC
 )
 
 add_library (reorder OBJECT ${REORDER_SRC})
-target_link_libraries (reorder PRIVATE vsag_src_common)
+target_link_libraries (reorder PRIVATE coverage_config vsag_src_common)

--- a/src/simd/CMakeLists.txt
+++ b/src/simd/CMakeLists.txt
@@ -124,8 +124,7 @@ simd_add_definitions (DIST_CONTAINS_NEON -DENABLE_NEON=1)
 simd_add_definitions (DIST_CONTAINS_SVE -DENABLE_SVE=1)
 
 target_link_libraries (simd
-    PRIVATE cpuinfo
-    INTERFACE coverage_config)
+    PRIVATE cpuinfo coverage_config)
 if (TARGET vsag_openmp)
     target_link_libraries (simd PRIVATE vsag_openmp)
 endif ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries (unittests
         simd_test vsag_test algorithm_test factory_test attr_test
         datacell_test layout_test quantizer_test storage_test io_test utils_test impl_test
         vsag_static
+        coverage_config
 )
 
 if (APPLE)
@@ -100,5 +101,6 @@ target_link_libraries (functests PRIVATE
         vsag 
         simd
         fmt::fmt
+        coverage_config
 )
 add_dependencies (functests Catch2)

--- a/tests/scripts/coverage_diagnostics_test.py
+++ b/tests/scripts/coverage_diagnostics_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import tempfile
@@ -11,6 +13,11 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 DIAGNOSTIC_RUNNER = ROOT / "scripts/ci/run-with-diagnostics.sh"
 COVERAGE_COLLECTOR = ROOT / "scripts/coverage/collect_cpp_coverage.sh"
+COVERAGE_CHECKER = ROOT / "scripts/coverage/check_cov.sh"
+COVERAGE_VERIFIER = ROOT / "scripts/coverage/verify_cpp_coverage.py"
+CODECOV_CONFIG = ROOT / ".github/codecov.yml"
+PARALLEL_TEST_RUNNER = ROOT / "scripts/testing/test_parallel_bg.sh"
+PR_CI_WORKFLOW = ROOT / ".github/workflows/pr-ci.yml"
 
 
 class DiagnosticRunnerTest(unittest.TestCase):
@@ -67,13 +74,24 @@ class DiagnosticRunnerTest(unittest.TestCase):
 
 
 class CoverageCollectorTest(unittest.TestCase):
-    def test_excludes_system_headers_during_capture(self):
+    def run_collector(
+        self, final_source: str = "src/example.cpp", include_branch: bool = True
+    ) -> tuple[subprocess.CompletedProcess[str], list[list[str]], str]:
         with tempfile.TemporaryDirectory() as directory:
             temporary_root = Path(directory)
             collector_dir = temporary_root / "scripts/coverage"
             collector_dir.mkdir(parents=True)
             collector = collector_dir / COVERAGE_COLLECTOR.name
             shutil.copy2(COVERAGE_COLLECTOR, collector)
+            shutil.copy2(COVERAGE_VERIFIER, collector_dir / COVERAGE_VERIFIER.name)
+
+            (temporary_root / "src").mkdir()
+            (temporary_root / "include").mkdir()
+            (temporary_root / "src/example.cpp").write_text("int example;\n", encoding="utf-8")
+            subprocess.run(["git", "init", "-q"], cwd=temporary_root, check=True)
+            subprocess.run(
+                ["git", "add", "src/example.cpp"], cwd=temporary_root, check=True
+            )
 
             fake_bin = temporary_root / "fake-bin"
             fake_bin.mkdir()
@@ -94,7 +112,20 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 if [[ -n "$output_file" ]]; then
-    printf 'TN:\\n' > "$output_file"
+    if [[ "$output_file" == "$LCOV_ROOT/coverage/coverage.info" ]]; then
+        source_path="$LCOV_FINAL_SOURCE"
+    else
+        source_path="$LCOV_ROOT/src/example.cpp"
+    fi
+    {
+        printf 'TN:\\n'
+        printf 'SF:%s\\n' "$source_path"
+        printf 'DA:1,1\\n'
+        if [[ "$LCOV_INCLUDE_BRANCH" == "true" ]]; then
+            printf 'BRDA:1,0,0,1\\n'
+        fi
+        printf 'end_of_record\\n'
+    } > "$output_file"
 fi
 """,
                 encoding="utf-8",
@@ -105,6 +136,9 @@ fi
             environment = os.environ.copy()
             environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
             environment["LCOV_CALLS"] = str(calls_file)
+            environment["LCOV_FINAL_SOURCE"] = final_source
+            environment["LCOV_INCLUDE_BRANCH"] = str(include_branch).lower()
+            environment["LCOV_ROOT"] = str(temporary_root)
             result = subprocess.run(
                 ["bash", str(collector)],
                 cwd=temporary_root,
@@ -117,16 +151,336 @@ fi
                 [argument for argument in line.split("\t") if argument]
                 for line in calls_file.read_text(encoding="utf-8").splitlines()
             ]
+            final_trace = temporary_root / "coverage/coverage.info"
+            trace_contents = (
+                final_trace.read_text(encoding="utf-8") if final_trace.exists() else ""
+            )
+
+        return result, calls, trace_contents
+
+    def test_scopes_trace_and_preserves_branch_configuration(self):
+        result, calls, trace_contents = self.run_collector()
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertEqual(len(calls), 3)
+        self.assertEqual(len(calls), 4)
+        for call in calls:
+            branch_setting = [
+                call[index + 1]
+                for index, argument in enumerate(call[:-1])
+                if argument == "--rc" and call[index + 1] == "branch_coverage=1"
+            ]
+            self.assertEqual(branch_setting, ["branch_coverage=1"], call)
+
         capture = calls[0]
         self.assertIn("--capture", capture)
         exclude_index = capture.index("--exclude")
         self.assertEqual(capture[exclude_index + 1], "/usr/*")
+        includes = [
+            capture[index + 1]
+            for index, argument in enumerate(capture[:-1])
+            if argument == "--include"
+        ]
+        self.assertEqual(len(includes), 2)
+        self.assertTrue(includes[0].endswith("/src/*"), includes)
+        self.assertTrue(includes[1].endswith("/include/*"), includes)
         self.assertNotIn("inconsistent,inconsistent", capture)
+
         self.assertIn("--remove", calls[1])
-        self.assertIn("/usr/*", calls[1])
+        self.assertTrue(any(value.endswith("/src/version.h") for value in calls[1]))
+        self.assertTrue(any(value.endswith("/include/vsag/expected.hpp") for value in calls[1]))
+        self.assertNotIn("*/avx512.cpp", calls[1])
+
+        self.assertIn("--extract", calls[2])
+        extract_index = calls[2].index("--extract")
+        self.assertEqual(calls[2][extract_index + 2 : extract_index + 4], ["src/*", "include/*"])
+        self.assertIn("--substitute", calls[2])
+        self.assertIn("--list", calls[3])
+        self.assertIn("SF:src/example.cpp", trace_contents)
+        self.assertIn("BRDA:1,0,0,1", trace_contents)
+
+    def test_rejects_non_repository_trace_source(self):
+        result, _, _ = self.run_collector(".ci-fetchcontent/dependency.cpp")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("non-production sources", result.stderr)
+
+        result, _, _ = self.run_collector("src/../.ci-fetchcontent/dependency.cpp")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("non-production sources", result.stderr)
+
+    def test_rejects_trace_without_branch_records(self):
+        result, _, _ = self.run_collector(include_branch=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no branch records", result.stderr)
+
+    def test_rejects_generated_or_untracked_trace_source(self):
+        result, _, _ = self.run_collector("src/generated.cpp")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("generated or untracked sources", result.stderr)
+
+
+class CoverageCMakeTest(unittest.TestCase):
+    @staticmethod
+    def coverage_scopes(cmake: str, target: str) -> list[str]:
+        scopes = []
+        pattern = rf"target_link_libraries\s*\(\s*{re.escape(target)}\b(?P<body>.*?)\)"
+        for match in re.finditer(pattern, cmake, flags=re.DOTALL):
+            current_scope = ""
+            for token in match.group("body").split():
+                if token in {"PRIVATE", "PUBLIC", "INTERFACE"}:
+                    current_scope = token
+                elif token == "coverage_config":
+                    scopes.append(current_scope)
+                else:
+                    variable = re.fullmatch(r"\$\{([A-Za-z0-9_]+)\}", token)
+                    if variable:
+                        definition = re.search(
+                            rf"set\s*\(\s*{variable.group(1)}\b(?P<body>.*?)\)",
+                            cmake,
+                            flags=re.DOTALL,
+                        )
+                        if definition and "coverage_config" in definition.group("body").split():
+                            scopes.append(current_scope)
+        return scopes
+
+    def test_every_production_target_owns_private_instrumentation(self):
+        production_targets: dict[str, Path] = {}
+        cmake_by_file: dict[Path, str] = {}
+        for cmake_path in (ROOT / "src").rglob("CMakeLists.txt"):
+            cmake = cmake_path.read_text(encoding="utf-8")
+            cmake_by_file[cmake_path] = cmake
+            targets = re.findall(
+                r"add_library\s*\(\s*([A-Za-z0-9_]+)\s+(?:OBJECT|STATIC|SHARED)\b",
+                cmake,
+            )
+            for target in targets:
+                if not target.endswith("_test") and target != "vsag_test":
+                    production_targets[target] = cmake_path
+
+        incorrect_scopes = {
+            target: self.coverage_scopes(cmake_by_file[path], target)
+            for target, path in production_targets.items()
+            if self.coverage_scopes(cmake_by_file[path], target) != ["PRIVATE"]
+        }
+
+        self.assertTrue(production_targets)
+        self.assertFalse(incorrect_scopes, incorrect_scopes)
+
+    def test_coverage_test_executables_link_runtime_privately(self):
+        cmake = (ROOT / "tests/CMakeLists.txt").read_text(encoding="utf-8")
+
+        self.assertEqual(self.coverage_scopes(cmake, "unittests"), ["PRIVATE"])
+        self.assertEqual(self.coverage_scopes(cmake, "functests"), ["PRIVATE"])
+
+
+class CoverageVerifierTest(unittest.TestCase):
+    def run_verifier(
+        self, source_root: Path, entries: list[dict[str, object]]
+    ) -> subprocess.CompletedProcess[str]:
+        compile_commands = source_root / "compile_commands.json"
+        compile_commands.write_text(json.dumps(entries), encoding="utf-8")
+        return subprocess.run(
+            [
+                "python3",
+                str(COVERAGE_VERIFIER),
+                "instrumentation",
+                str(compile_commands),
+                "--source-root",
+                str(source_root),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_accepts_instrumented_production_commands(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source_root = Path(directory)
+            (source_root / "src").mkdir()
+            source = source_root / "src/example.cpp"
+            source.write_text("int example;\n", encoding="utf-8")
+            result = self.run_verifier(
+                source_root,
+                [
+                    {
+                        "directory": str(source_root),
+                        "file": "src/example.cpp",
+                        "arguments": ["c++", "--coverage", "-c", str(source)],
+                    }
+                ],
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("verified coverage instrumentation for 1", result.stdout)
+
+    def test_rejects_uninstrumented_production_commands(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source_root = Path(directory)
+            (source_root / "src").mkdir()
+            source = source_root / "src/example.cpp"
+            source.write_text("int example;\n", encoding="utf-8")
+            result = self.run_verifier(
+                source_root,
+                [
+                    {
+                        "directory": str(source_root),
+                        "file": str(source),
+                        "command": f"c++ -c {source}",
+                    }
+                ],
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("src/example.cpp", result.stderr)
+
+
+class CoverageCheckerTest(unittest.TestCase):
+    def test_uses_branch_aware_summary_with_consistency_allowance(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary_root = Path(directory)
+            coverage_dir = temporary_root / "coverage"
+            coverage_dir.mkdir()
+            (coverage_dir / "coverage.info").write_text("TN:\n", encoding="utf-8")
+            fake_bin = temporary_root / "fake-bin"
+            fake_bin.mkdir()
+            fake_lcov = fake_bin / "lcov"
+            fake_lcov.write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" > \"$LCOV_CALL\"\n"
+                "printf '  lines.......: 90.0%% (90 of 100 lines)\\n'\n",
+                encoding="utf-8",
+            )
+            fake_lcov.chmod(0o755)
+            call_file = temporary_root / "lcov-call"
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+            environment["LCOV_CALL"] = str(call_file)
+            result = subprocess.run(
+                ["bash", str(COVERAGE_CHECKER)],
+                cwd=temporary_root,
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            call = call_file.read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("--rc branch_coverage=1", call)
+        self.assertIn("--ignore-errors inconsistent,inconsistent", call)
+
+
+class ParallelTestRunnerTest(unittest.TestCase):
+    def test_passes_and_reports_explicit_random_seed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary_root = Path(directory)
+            tests_dir = temporary_root / "build/tests"
+            tests_dir.mkdir(parents=True)
+            fake_test = tests_dir / "fake-test"
+            fake_test.write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$TEST_CALLS\"\n",
+                encoding="utf-8",
+            )
+            fake_test.chmod(0o755)
+            (tests_dir / "unittests").symlink_to(fake_test)
+            (tests_dir / "functests").symlink_to(fake_test)
+
+            calls_file = temporary_root / "test-calls"
+            environment = os.environ.copy()
+            environment["TEST_CALLS"] = str(calls_file)
+            environment["VSAG_TEST_SEED"] = "424242"
+            result = subprocess.run(
+                ["bash", str(PARALLEL_TEST_RUNNER)],
+                cwd=temporary_root,
+                text=True,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            calls = calls_file.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("test random seed: 424242", result.stdout)
+        self.assertEqual(len(calls), 3)
+        self.assertTrue(all("--rng-seed 424242" in call for call in calls), calls)
+
+
+class CodecovComponentTest(unittest.TestCase):
+    def component_patterns(self) -> dict[str, list[str]]:
+        components: dict[str, list[str]] = {}
+        component_id = ""
+        in_components = False
+        for line in CODECOV_CONFIG.read_text(encoding="utf-8").splitlines():
+            if line.startswith("  individual_components:"):
+                in_components = True
+                continue
+            if not in_components:
+                continue
+            component_match = re.fullmatch(r"    - component_id: (\S+)", line)
+            if component_match:
+                component_id = component_match.group(1)
+                components[component_id] = []
+                continue
+            path_match = re.fullmatch(r"        - (\S+)", line)
+            if path_match and component_id:
+                components[component_id].append(path_match.group(1))
+        return components
+
+    @staticmethod
+    def matches(pattern: str, path: str) -> bool:
+        if pattern.startswith("^"):
+            return re.fullmatch(pattern, path) is not None
+        if pattern.endswith("/**"):
+            return path.startswith(pattern.removesuffix("**"))
+        return path == pattern
+
+    def test_every_maintained_source_has_one_component_owner(self):
+        patterns = self.component_patterns()
+        tracked_files = subprocess.check_output(
+            ["git", "-C", str(ROOT), "ls-files", "--", "src", "include"], text=True
+        ).splitlines()
+        maintained_sources = [
+            path
+            for path in tracked_files
+            if Path(path).suffix in {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp"}
+            and "_test." not in Path(path).name
+            and path != "include/vsag/expected.hpp"
+        ]
+
+        ownership = {
+            path: [
+                component
+                for component, component_patterns in patterns.items()
+                if any(self.matches(pattern, path) for pattern in component_patterns)
+            ]
+            for path in maintained_sources
+        }
+        incorrectly_owned = {
+            path: owners for path, owners in ownership.items() if len(owners) != 1
+        }
+
+        self.assertTrue(patterns)
+        self.assertFalse(incorrectly_owned, incorrectly_owned)
+
+
+class CoverageWorkflowTest(unittest.TestCase):
+    def test_premerge_check_is_configuration_only(self):
+        workflow = PR_CI_WORKFLOW.read_text(encoding="utf-8")
+        job_match = re.search(
+            r"^  coverage-config:\n(?P<job>.*?)(?=^  [a-z][a-z0-9-]+:\n)",
+            workflow,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+
+        self.assertIsNotNone(job_match)
+        job = job_match.group("job")
+        self.assertIn("needs.changes.outputs.coverage == 'true'", job)
+        self.assertIn("coverage_diagnostics_test.py", job)
+        self.assertIn("bash -n scripts/testing/test_parallel_bg.sh", job)
+        self.assertNotIn("make cov", job)
+        self.assertNotIn("VSAG_TEST_SEED", job)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Refactor
- [ ] Documentation
- [x] CI/Build/Infra

## Issue #2884 phases

Refs: #2884

Implemented in this first phase:

- Phase 1 measurement integrity: capture only tracked maintained `src/` and `include/` sources, narrowly exclude generated `src/version.h` and vendored `expected.hpp`, normalize repository-relative paths, retain branch records through every LCOV stage and the upload input, and reject empty, branchless, absolute, untracked, or out-of-scope traces.
- Phase 1 instrumentation and reproducibility: attach coverage privately to analyzer, BLAS, cluster, reorder, and SIMD production targets; link the coverage runtime explicitly at final test executables; verify every compiled production translation unit; and use/report seed `424242` in coverage CI.
- Phase 2 ownership: assign every maintained reported source to exactly one Codecov component and disable server-side default path rewriting so local and uploaded source populations stay aligned.
- Phase 3 initial signal: add a lightweight PR configuration check using the existing change detector. It validates LCOV, CMake target scope, component ownership, workflow, and seed semantics without running `make cov` or duplicating the multi-hour suite.

Deferred #2884 phases:

- A real pre-merge patch/project coverage upload and regression gate. This needs a resource-aware suite design; this PR does not depend on still-open PR #2856.
- MCI legacy enumerator removal or active-path coverage. The no-argument path is internal and unused by current production call sites, but removing the mechanically imported implementation belongs in a separate algorithm-focused change.
- Maintained algorithm/error-path coverage additions, three consecutive full runs at 90%, branch ratcheting, and platform-specific coverage jobs for conditional backends.

## Validation

- `python3 -m unittest tests/scripts/coverage_diagnostics_test.py`: 15 tests passed.
- `make test-cmake`: passed all six helper suites.
- Codecov API configuration validation: valid.
- `make cov`: passed; the compile database verified 243/243 maintained production commands carry `--coverage`.
- Focused seeded coverage run for allocator, SIMD, BLAS, cluster, reorder, and analyzer paths: 85 test cases and 30,604,097 assertions passed.
- Repository-scoped LCOV collection: 495 tracked source files, 52,040 measured lines, and 80,305 branch records. The focused shard covered 10,698 lines and 7,599 branches; this is evidence for collection semantics, not a full-suite coverage claim.
- Separate non-coverage build of all newly instrumented targets: passed, with no `--coverage` flags.
- Workflow YAML parse, shell syntax checks, diff checks, and public-text hygiene checks: passed.
- Exact clang-format/tidy 15 were unavailable locally; CI is authoritative for those checks.

## Compatibility and risk

- Public API/ABI: unchanged.
- Normal builds: unchanged because `coverage_config` remains empty unless `ENABLE_COVERAGE=ON`.
- Runtime performance: unchanged outside coverage builds.
- Rollback: revert the single commit to restore the previous collection and CI configuration.
