### PR TITLE
[bug](hgraph): backport duplicate candidate checks to 1.0

### DIFF
--- a/docs/docs/en/src/indexes/hgraph.md
+++ b/docs/docs/en/src/indexes/hgraph.md
@@ -73,7 +73,7 @@ most users need; the exhaustive list is in [Index Parameters](../resources/index
 | `base_pq_dim` | int | `1` | Number of PQ subspaces. When using `pq` / `pqfs`, set this explicitly instead of relying on the default. |
 | `build_thread_count` | int | `100` | Threads used to parallelise build |
 | `support_duplicate` | bool | `false` | Enable duplicate-ID detection on insert |
-| `duplicate_distance_threshold` | float | `0.0` | Duplicate-detection distance threshold. When greater than `0`, deduplicate by the nearest candidate distance; when `0`, fall back to the current code `memcmp` check |
+| `duplicate_distance_threshold` | float | `0.0` | Duplicate-detection distance threshold. When greater than `0`, deduplicate by the nearest candidate distance; when `0`, compare codes with the nearest candidate first, then check the remaining returned build candidates until a match is found |
 | `support_remove` | bool | `false` | Enable graph delete-tracking metadata used by mark-remove recovery paths |
 | `support_force_remove` | bool | `false` | Enable `RemoveMode::FORCE_REMOVE` and its extra synchronization on the built index |
 | `store_raw_vector` | bool | `false` | Keep the raw vector in addition to the quantized copy (useful for `cosine`) |

--- a/docs/docs/zh/src/indexes/hgraph.md
+++ b/docs/docs/zh/src/indexes/hgraph.md
@@ -67,7 +67,7 @@ auto result = index->KnnSearch(
 | `base_pq_dim` | int | `1` | PQ 子空间数（`pq` / `pqfs` 时必填） |
 | `build_thread_count` | int | `100` | 构建阶段并发线程数 |
 | `support_duplicate` | bool | `false` | 是否在插入时做重复 ID 检测 |
-| `duplicate_distance_threshold` | float | `0.0` | 重复判定距离阈值。大于 `0` 时按最近候选的距离判重；等于 `0` 时退化为当前编码 `memcmp` 判重 |
+| `duplicate_distance_threshold` | float | `0.0` | 重复判定距离阈值。大于 `0` 时按最近候选的距离判重；等于 `0` 时先比较最近候选的编码，不匹配则继续检查构建搜索返回的其余候选，直到找到匹配 |
 | `support_remove` | bool | `false` | 是否启用 mark-remove 恢复路径所需的图删除追踪元数据 |
 | `support_force_remove` | bool | `false` | 是否启用 `RemoveMode::FORCE_REMOVE` 及其额外同步 |
 | `store_raw_vector` | bool | `false` | 除量化副本外再保留原始向量（`cosine` 场景有用） |

--- a/src/impl/searcher/basic_searcher.cpp
+++ b/src/impl/searcher/basic_searcher.cpp
@@ -543,9 +543,20 @@ BasicSearcher::search_impl(const GraphInterfacePtr& graph,
             if (min_distance <= inner_search_param.duplicate_distance_threshold) {
                 inner_search_param.duplicate_id = min_index;
             }
-        } else if (inner_search_param.duplicate_query_id < flatten->TotalCount() &&
-                   flatten->CompareVectors(inner_search_param.duplicate_query_id, min_index)) {
-            inner_search_param.duplicate_id = min_index;
+        } else if (inner_search_param.duplicate_query_id < flatten->TotalCount()) {
+            if (flatten->CompareVectors(inner_search_param.duplicate_query_id, min_index)) {
+                inner_search_param.duplicate_id = min_index;
+            } else {
+                // Quantization can rank a different code ahead of an identical one.
+                for (uint32_t i = 0; i < top_candidates->Size(); ++i) {
+                    if (data[i].second != min_index &&
+                        flatten->CompareVectors(inner_search_param.duplicate_query_id,
+                                                data[i].second)) {
+                        inner_search_param.duplicate_id = data[i].second;
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/src/impl/searcher/basic_searcher_test.cpp
+++ b/src/impl/searcher/basic_searcher_test.cpp
@@ -22,10 +22,63 @@
 
 #include "datacell/flatten_interface.h"
 #include "impl/filter/iterator_filter.h"
+#include "quantization/scalar_quantization/scalar_quantizer.h"
 #include "searcher_test.h"
 #include "unittest.h"
 #include "utils/visited_list.h"
 using namespace vsag;
+
+TEST_CASE("BasicSearcher finds duplicate codes beyond the nearest SQ cosine candidate",
+          "[ut][BasicSearcher][duplicate]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    IndexCommonParam common;
+    common.dim_ = 2;
+    common.allocator_ = allocator;
+    common.metric_ = MetricType::METRIC_TYPE_COSINE;
+
+    auto quantizer_param =
+        QuantizerParameter::GetQuantizerParameterByJson(JsonType::Parse(R"({"type":"sq8"})"));
+    auto io_param = IOParameter::GetIOParameterByJson(JsonType::Parse(R"({"type":"memory_io"})"));
+    auto flatten =
+        std::make_shared<FlattenDataCell<SQ8Quantizer<MetricType::METRIC_TYPE_COSINE>, MemoryIO>>(
+            quantizer_param, io_param, common);
+
+    // Fix both SQ intervals to [-1, 1] without depending on random training data.
+    const std::vector<float> training = {1.0F, 0.0F, -1.0F, 0.0F, 0.0F, 1.0F, 0.0F, -1.0F};
+    flatten->Train(training.data(), 4);
+    // IDs 0 and 2 are identical A vectors. ID 2 is stored but not yet in the graph.
+    // Only IDs 0 and 1 (a different B vector) are graph candidates.
+    const std::vector<float> vectors = {0.599F, 0.801F, 0.6F, 0.8F, 0.599F, 0.801F};
+    flatten->BatchInsertVector(vectors.data(), 3, nullptr);
+    REQUIRE(flatten->CompareVectors(2, 0));
+    REQUIRE_FALSE(flatten->CompareVectors(2, 1));
+
+    const auto* query = vectors.data() + 4;
+    auto computer = flatten->FactoryComputer(query);
+    const InnerIdType candidate_ids[] = {0, 1};
+    float distances[2];
+    flatten->Query(distances, computer, candidate_ids, 2);
+    // Quantization makes B closer to the raw A query than A's own code.
+    REQUIRE(distances[1] < distances[0]);
+
+    auto graph =
+        std::make_shared<MockGraphDataCell>(std::vector<std::vector<InnerIdType>>{{1}, {0}});
+    auto pool = std::make_shared<VisitedListPool>(1, allocator.get(), 3, allocator.get());
+    BasicSearcher searcher(common);
+    InnerSearchParam param;
+    param.ep = 0;
+    param.ef = 2;
+    param.topk = 2;
+    param.find_duplicate = true;
+    param.duplicate_query_id = 2;
+    param.duplicate_distance_threshold = 0.0F;
+
+    auto visited = pool->TakeOne();
+    auto result = searcher.Search(graph, flatten, visited, query, param, LabelTablePtr{}, nullptr);
+    pool->ReturnOne(visited);
+    REQUIRE(result->Size() == 2);
+    REQUIRE(param.duplicate_id == 0);
+}
 
 TEST_CASE("BasicSearcher traverses through a non-finite-distance bridge",
           "[ut][BasicSearcher][nonfinite]") {


### PR DESCRIPTION
## Change Type

- [x] Bug fix

## Linked Issue

Fixes: #2889

## What Changed

- At threshold zero, check the nearest build candidate first, then the remaining returned candidates until matching codes are found.
- Keep positive distance-threshold behavior unchanged. No quantization, pruning, serialization, or concurrency changes.
- Add a deterministic 2D SQ8 cosine regression and update the English/Chinese parameter documentation. No customer data is included.

## Test Evidence

- Red: the matching candidate is present, but the original code returns duplicate ID -1 instead of 0.
- Green: 6 relevant cases passed (143888 assertions), including the regression, nearest/positive-threshold checks, normal search, and iterator drain.
- clang-format 15 and clang-tidy 15 checks on changed code passed.
- Built against current upstream/1.0 (ce2a985d) in Release mode.
- Full-suite and coverage checks are left to CI.

### Existing Release test failure

The existing "BasicSearcher traverses through a non-finite-distance bridge" case fails two assertions in this Release configuration. I restored the original production source at ce2a985d, rebuilt with identical settings, and reproduced exactly the same failure (4/6 assertions pass). The same failure remains with this fix; it is not introduced here. No unrelated non-finite-distance or compiler-flag fix is included.

## Compatibility and Performance

No API/ABI or persisted-format changes. No additional candidate comparisons when duplicate detection is disabled, the positive threshold path is selected, or the nearest code already matches. A mismatch can add a bounded scan of the returned candidates; build-performance impact has not been benchmarked. This does not guarantee finding representatives outside that set or repair existing graphs.

## Related delivery

- 0.18: #2615.
- main: #2891.

## Risk and Rollback

Localized build-grouping behavior change. Revert this commit to restore nearest-only detection; no format migration is needed.
