### PR TITLE
docs: clarify SIMQ full name

### DIFF
--- a/docs/docs/en/src/indexes/simq.md
+++ b/docs/docs/en/src/indexes/simq.md
@@ -1,10 +1,10 @@
 # SIMQ
 
-SIMQ is VSAG's index for **multi-vector** retrieval — the kind of data where each
-document is a *set* of token-level vectors rather than a single embedding. This
-pattern arises in late-interaction models such as ColBERT, where a document is
-represented by one vector per token and relevance is computed via **MaxSim**
-(sum of maximum per-query-token similarities).
+SIMQ (Single Index for Multi-vector Query) is VSAG's index for **multi-vector**
+retrieval — the kind of data where each document is a *set* of token-level vectors
+rather than a single embedding. This pattern arises in late-interaction models such
+as ColBERT, where a document is represented by one vector per token and relevance
+is computed via **MaxSim** (sum of maximum per-query-token similarities).
 
 
 - Source: `src/algorithm/simq/`

--- a/docs/docs/zh/src/indexes/simq.md
+++ b/docs/docs/zh/src/indexes/simq.md
@@ -1,9 +1,9 @@
 # SIMQ
 
-SIMQ 是 VSAG 面向 **多向量（multi-vector）** 检索的索引——适用于每篇文档
-由一组 token 级向量（而非单个 embedding）表示的数据场景。这种模式常见于
-ColBERT 等 late-interaction 模型，其中文档由每个 token 对应一个向量表示，
-相关性通过 **MaxSim**（各查询 token 的最大相似度之和）计算。
+SIMQ（Single Index for Multi-vector Query）是 VSAG 面向 **多向量（multi-vector）**
+检索的索引——适用于每篇文档由一组 token 级向量（而非单个 embedding）表示的
+数据场景。这种模式常见于 ColBERT 等 late-interaction 模型，其中文档由每个 token
+对应一个向量表示，相关性通过 **MaxSim**（各查询 token 的最大相似度之和）计算。
 
 
 - 源码：`src/algorithm/simq/`

--- a/include/vsag/index.h
+++ b/include/vsag/index.h
@@ -63,7 +63,7 @@ enum class IndexType {
     SINDI = 7,
     WARP = 8,
     LAZY_HGRAPH = 9,
-    SIMQ = 10,
+    SIMQ = 10,  ///< Single Index for Multi-vector Query.
     SINDI_V2 = 11
 };
 #define DATA_FLAG_FLOAT32_VECTOR 0x01

--- a/src/algorithm/simq/simq.h
+++ b/src/algorithm/simq/simq.h
@@ -44,6 +44,7 @@ struct SplitTask {
     std::unordered_set<InnerIdType> new_docs;  // Docs moving to new cluster
 };
 
+/** Single Index for Multi-vector Query (SIMQ) implementation. */
 class SIMQ : public InnerIndexInterface {
 public:
     static ParamPtr


### PR DESCRIPTION
## Change Type

- [x] Documentation

## Linked Issue

No issue is required for this focused documentation clarification.

## What Changed

- expand SIMQ with its approved full name, "Single Index for Multi-vector Query," at the first introduction in the English and Chinese index pages
- add concise matching comments to the public index type and SIMQ implementation declaration
- leave index behavior and public API names unchanged

## Test Evidence

- [x] Other (described below)

Test details:

```text
git diff --check
Focused bilingual documentation summary/link checks
Exact-expansion, changed-file scope, trailing-newline, and added C++ line-length checks
```

Full mdBook builds were not run because mdBook is unavailable in the local environment. The required clang-format/tidy version 15 is also unavailable; no executable C++ code changed.

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: none

## Performance and Concurrency Impact

- Performance impact: none
- Concurrency/thread-safety impact: none

## Documentation Impact

- [x] Updated docs:
  - [x] Other: English and Chinese SIMQ index pages and concise source comments

## Risk and Rollback

- Risk level: low
- Rollback plan: revert the documentation commit

## Checklist

- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits and DCO sign-off)
