### PR TITLE
feat(pyramid): support intersection across named hierarchies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The result is as follows:
 ### gist-960-euclidean
 ![](./docs/gist-960-euclidean_10_euclidean.png)
 
+Pyramid supports path filtering across named hierarchies with OR within each hierarchy and AND across hierarchies. See the [intersection query example](docs/docs/en/src/indexes/pyramid.md#intersection-across-hierarchies).
+
 ## Getting Started
 
 ### Quickstart

--- a/docs/docs/en/src/indexes/pyramid.md
+++ b/docs/docs/en/src/indexes/pyramid.md
@@ -171,7 +171,7 @@ Search-time parameters live under the `pyramid` sub-object:
 | `hops_limit` | int | unlimited | Per-graph KNN hop cap for the root bottom graph and every non-root graph; ignored when it is not greater than `ef_search`. Sparse root routing layers are never hop-limited. FLAT scans and range search are unaffected. |
 | `subindex_ef_search` | int | `50` | Candidate list size used when traversing intermediate sub-graphs on the path. |
 | `hierarchies` | string[] | `[]` | Select which hierarchy to search. Empty means use the default (unnamed) hierarchy. |
-| `hierarchy_op` | string | `"single"` | How to combine results across hierarchies: `single` (search one hierarchy), `union`, or `intersection`. **Note:** `union` and `intersection` are not yet implemented — setting them will cause `KnnSearch`/`RangeSearch` to return an error. |
+| `hierarchy_op` | string | `"single"` | Use `intersection` with two or more selected hierarchies: paths within each hierarchy are OR scopes, and hierarchies are combined with AND before candidate truncation and reorder. Supported by `KnnSearch`, `RangeSearch`, and `SearchWithRequest`. `union` remains unsupported; omit this parameter when selecting one hierarchy. |
 | `rabitq_error_rate` | float | `1.9` | Positive lower-bound error multiplier for this search. The default `1.9` is relatively large; increasing it improves accuracy but slows down search. |
 
 ```cpp
@@ -320,6 +320,27 @@ auto result = index->RangeSearch(
     query, /*radius=*/20.0f,
     R"({"pyramid": {"ef_search": 100, "hierarchies": ["category"]}})").value();
 ```
+
+### Intersection across hierarchies
+
+Provide a named query path for **every** selected hierarchy. Separate OR alternatives with `|`;
+`/` separates path segments. For example, `(host1 OR host2) AND (finance/bank OR finance/insurance)`:
+
+```cpp
+std::string hosts[] = {"host1|host2"};
+std::string categories[] = {"finance/bank|finance/insurance"};
+query->Paths("site", hosts)->Paths("category", categories);
+auto result = index->KnnSearch(
+    query, 10,
+    R"({"pyramid":{"ef_search":100,"hierarchies":["site","category"],"hierarchy_op":"intersection"}})");
+```
+
+Missing named paths and unknown hierarchy names are errors. An empty path string or a path that
+does not exist contributes an empty scope. Single-hierarchy queries retain their existing default
+path fallback. External filters and deleted-label filtering also apply to intersection results.
+The first selected hierarchy drives approximate search; the remaining hierarchy trees filter its
+candidates before any final limit or reorder. Recall still depends on the usual search parameters.
+No `store_paths` setting or index rebuild is required for restored multi-hierarchy indexes.
 
 ### Serialize & Deserialize
 

--- a/docs/docs/zh/src/indexes/pyramid.md
+++ b/docs/docs/zh/src/indexes/pyramid.md
@@ -165,7 +165,7 @@ Pyramid 使用 split code 的 code-code 距离完成增量 FLAT→GRAPH 晋升�
 | `hops_limit` | int | 不限 | 根节点底图及每个非根 GRAPH 的逐图 KNN 跳数上限；不大于 `ef_search` 时忽略。根节点的稀疏路由层不受限制，FLAT 扫描与范围检索不受影响。 |
 | `subindex_ef_search` | int | `50` | 沿路径向下遍历中间子图时的候选集大小 |
 | `hierarchies` | string[] | `[]` | 指定检索哪个层级。空数组表示使用默认（匿名）层级。 |
-| `hierarchy_op` | string | `"single"` | 多层级结果合并方式：`single`（检索单个层级）、`union`、`intersection`。**注意：** `union` 和 `intersection` 尚未实现——设置后 `KnnSearch`/`RangeSearch` 会返回错误。 |
+| `hierarchy_op` | string | `"single"` | 选择两个或更多层级时使用 `intersection`：同一层级内路径为 OR，不同层级为 AND，约束在候选截断和重排前生效。支持 `KnnSearch`、`RangeSearch` 和 `SearchWithRequest`。`union` 仍不支持；仅选择一个层级时省略此参数。 |
 | `rabitq_error_rate` | float | `1.9` | 本次搜索使用的正数 lower-bound 误差倍率。默认值 `1.9` 较大；值越大，精度越高，但搜索速度越慢。 |
 
 ```cpp
@@ -307,6 +307,22 @@ auto result = index->RangeSearch(
     query, /*radius=*/20.0f,
     R"({"pyramid": {"ef_search": 100, "hierarchies": ["category"]}})").value();
 ```
+
+### 跨层级交集检索
+
+必须为**每个**选中的层级分别提供命名查询路径。`|` 分隔同层级内的 OR 条件，`/` 分隔路径段。例如 `(host1 OR host2) AND (finance/bank OR finance/insurance)`：
+
+```cpp
+std::string hosts[] = {"host1|host2"};
+std::string categories[] = {"finance/bank|finance/insurance"};
+query->Paths("site", hosts)->Paths("category", categories);
+auto result = index->KnnSearch(
+    query, 10,
+    R"({"pyramid":{"ef_search":100,"hierarchies":["site","category"],"hierarchy_op":"intersection"}})");
+```
+
+缺少命名路径或指定未知层级会报错；空路径字符串或不存在的路径对应空范围。单层级查询保留原有的默认路径回退行为。外部过滤器和已删除标签过滤同样作用于交集结果。
+第一个选中的层级驱动近似搜索，其余层级的路径树在最终截断和重排之前过滤候选；召回率仍取决于常规搜索参数。恢复已有多层级索引即可使用，无需启用 `store_paths` 或重建索引。
 
 ### 序列化与反序列化
 

--- a/src/algorithm/pyramid/pyramid.cpp
+++ b/src/algorithm/pyramid/pyramid.cpp
@@ -128,8 +128,8 @@ Pyramid::create_knn_search_param(const PyramidSearchParameters& parsed_param,
                                  const FilterPtr& filter,
                                  const std::optional<float>& threshold) const {
     CHECK_ARGUMENT(k > 0, fmt::format("k({}) must be greater than 0", k));
-    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
-                   "multi-hierarchy search (union/intersection) is not yet implemented");
+    CHECK_ARGUMENT(parsed_param.hierarchy_op != PyramidSearchParameters::HierarchyOp::UNION,
+                   "multi-hierarchy union search is not yet implemented");
     auto ef_search_threshold =
         std::max<uint64_t>(AMPLIFICATION_FACTOR * k, static_cast<uint64_t>(1000));
     CHECK_ARGUMENT(  // NOLINT
@@ -684,8 +684,6 @@ Pyramid::KnnSearch(const DatasetPtr& query,
     const bool collect_rabitq_lower_bounds = search_param.enable_rabitq_one_bit_search and
                                              use_reorder_ and
                                              base_codes_->SupportSplitCodeStorage();
-    std::string hierarchy_name =
-        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     DistanceRecordVector rabitq_lower_bound_candidates(allocator_);
     std::mutex rabitq_lower_bound_mutex;
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
@@ -714,7 +712,7 @@ Pyramid::KnnSearch(const DatasetPtr& query,
                           k,
                           reorder_candidate_limit,
                           ctx,
-                          hierarchy_name,
+                          parsed_param,
                           collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
     result->Statistics(stats.Dump());
     return FilterDatasetByThreshold(result, threshold, allocator_, k);
@@ -733,8 +731,8 @@ Pyramid::RangeSearch(const DatasetPtr& query,
 
     auto parsed_param = PyramidSearchParameters::FromJson(parameters);
     ctx.rabitq_error_rate = parsed_param.rabitq_error_rate;
-    CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
-                   "multi-hierarchy search (union/intersection) is not yet implemented");
+    CHECK_ARGUMENT(parsed_param.hierarchy_op != PyramidSearchParameters::HierarchyOp::UNION,
+                   "multi-hierarchy union search is not yet implemented");
     InnerSearchParam search_param;
     search_param.ef = parsed_param.ef_search;
     search_param.radius = radius * RADIUS_EPSILON;
@@ -758,8 +756,6 @@ Pyramid::RangeSearch(const DatasetPtr& query,
     const bool collect_rabitq_lower_bounds = search_param.enable_rabitq_one_bit_search and
                                              use_reorder_ and
                                              base_codes_->SupportSplitCodeStorage();
-    std::string hierarchy_name =
-        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     DistanceRecordVector rabitq_lower_bound_candidates(allocator_);
     std::mutex rabitq_lower_bound_mutex;
     SearchFunc search_func = [&](const IndexNode* node, const VisitedListPtr& vl) {
@@ -788,7 +784,7 @@ Pyramid::RangeSearch(const DatasetPtr& query,
                           search_param.topk,
                           std::nullopt,
                           ctx,
-                          hierarchy_name,
+                          parsed_param,
                           collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
     result->Statistics(stats.Dump());
     return result;
@@ -827,8 +823,8 @@ Pyramid::SearchWithRequest(const SearchRequest& request) const {
         search_param = this->create_knn_search_param(
             parsed_param, request.topk_, request_filter, request.threshold_);
     } else {
-        CHECK_ARGUMENT(parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::SINGLE,
-                       "multi-hierarchy search (union/intersection) is not yet implemented");
+        CHECK_ARGUMENT(parsed_param.hierarchy_op != PyramidSearchParameters::HierarchyOp::UNION,
+                       "multi-hierarchy union search is not yet implemented");
         search_param.ef = parsed_param.ef_search;
         search_param.radius = request.radius_ * RADIUS_EPSILON;
         search_param.search_mode = RANGE_SEARCH;
@@ -915,8 +911,6 @@ Pyramid::SearchWithRequest(const SearchRequest& request) const {
         return node_result;
     };
 
-    std::string hierarchy_name =
-        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     const auto final_topk = is_knn ? request.topk_ : search_param.topk;
     const auto reorder_candidate_limit =
         is_knn ? get_reorder_candidate_limit(
@@ -929,7 +923,7 @@ Pyramid::SearchWithRequest(const SearchRequest& request) const {
                           final_topk,
                           reorder_candidate_limit,
                           ctx,
-                          hierarchy_name,
+                          parsed_param,
                           collect_rabitq_lower_bounds ? &rabitq_lower_bound_candidates : nullptr);
     if (is_knn) {
         result = FilterDatasetByThreshold(result, request.threshold_, ctx.alloc, request.topk_);
@@ -966,15 +960,19 @@ Pyramid::search_impl(const DatasetPtr& query,
                      int64_t final_topk,
                      std::optional<int64_t> reorder_candidate_limit,
                      QueryContext& ctx,
-                     const std::string& hierarchy_name,
+                     const PyramidSearchParameters& parsed_param,
                      const DistanceRecordVector* rabitq_lower_bound_candidates) const {
+    const std::string hierarchy_name =
+        parsed_param.hierarchies.empty() ? "" : parsed_param.hierarchies[0];
     auto h_iter = hierarchies_.find(hierarchy_name);
     CHECK_ARGUMENT(h_iter != hierarchies_.end(),
                    fmt::format("unknown hierarchy name: '{}'", hierarchy_name));
     const auto& h = *h_iter->second;
 
     const auto* query_path = query->GetPaths(hierarchy_name);
-    if (query_path == nullptr) {
+    const bool intersection =
+        parsed_param.hierarchy_op == PyramidSearchParameters::HierarchyOp::INTERSECTION;
+    if (query_path == nullptr and not intersection) {
         query_path = query->GetPaths();
     }
     // NOLINTNEXTLINE(readability-simplify-boolean-expr)
@@ -985,6 +983,24 @@ Pyramid::search_impl(const DatasetPtr& query,
     DistHeapPtr search_result = std::make_shared<StandardHeap<true, false>>(ctx.alloc, -1);
 
     std::shared_lock<std::shared_mutex> lock(resize_mutex_);
+    if (intersection) {
+        auto combined = std::make_shared<CombinedFilter>();
+        combined->AppendFilter(search_param.is_inner_id_allowed);
+        // Validate every selector, including the driving hierarchy, before searching.
+        for (uint64_t i = 0; i < parsed_param.hierarchies.size(); ++i) {
+            const auto& name = parsed_param.hierarchies[i];
+            auto iter = hierarchies_.find(name);
+            CHECK_ARGUMENT(iter != hierarchies_.end(),
+                           fmt::format("unknown hierarchy name: '{}'", name));
+            const auto* paths = query->GetPaths(name);
+            CHECK_ARGUMENT(paths != nullptr,
+                           fmt::format("query_path is required for hierarchy '{}'", name));
+            if (i != 0) {
+                combined->AppendFilter(create_hierarchy_filter(*iter->second, paths[0]));
+            }
+        }
+        search_param.is_inner_id_allowed = combined;
+    }
     VisitedListGuard vl_guard(pool_.get());
     const VisitedListPtr& vl = vl_guard.get();
     if (query_path != nullptr) {
@@ -993,6 +1009,20 @@ Pyramid::search_impl(const DatasetPtr& query,
             h, search_func, vl, search_result, current_path, search_param, ctx.reasoning_ctx);
     } else {
         h.root->Search(search_func, vl, search_result, search_param.ef, ctx.reasoning_ctx);
+    }
+
+    if (intersection) {
+        // Overlapping OR paths (including parallel searches) may emit the same id repeatedly.
+        // Deduplicate before factor/topk limits so repeats cannot displace valid matches.
+        UnorderedSet<InnerIdType> seen(ctx.alloc);
+        auto unique_result = std::make_shared<StandardHeap<true, false>>(ctx.alloc, -1);
+        const auto* candidates = search_result->GetData();
+        for (uint64_t i = 0; i < search_result->Size(); ++i) {
+            if (seen.insert(candidates[i].second).second) {
+                unique_result->Push(candidates[i].first, candidates[i].second);
+            }
+        }
+        search_result = unique_result;
     }
 
     if (use_reorder_) {
@@ -2297,6 +2327,67 @@ Pyramid::add_to_hierarchy(Hierarchy& h,
                                  ? nullptr
                                  : data_vectors + dim_ * input_index;
         add_to_path(h, paths[input_index], inner_id, vector, sampled_level);
+    });
+}
+
+bool
+Pyramid::matches_scope(const IndexNode* node, InnerIdType id) const {
+    std::shared_lock lock(node->mutex_);
+    if (node->status_ == IndexNode::Status::FLAT) {
+        return std::find(node->ids_.begin(), node->ids_.end(), id) != node->ids_.end();
+    }
+    if (node->status_ == IndexNode::Status::GRAPH) {
+        const auto contains = [&](InnerIdType candidate) {
+            // A singleton root has no edges (and compressed storage has no row for it).
+            if (node->graph_->TotalCount() != 0 and candidate == node->entry_point_) {
+                return true;
+            }
+            const auto storage = node->graph_param_->graph_storage_type_;
+            if (storage != GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_FLAT and
+                storage != GraphStorageTypes::GRAPH_STORAGE_TYPE_VALUE_COMPRESSED) {
+                return node->graph_->CheckIdExists(candidate);
+            }
+            if (candidate >= node->graph_->TotalCount()) {
+                return false;
+            }
+            // Dense root capacity can include holes from partial hierarchy inserts. NSW keeps
+            // at least one neighbor after connecting a non-singleton; MARK_REMOVE only changes
+            // the label filter. Protect compressed row ownership as well as dense row counts.
+            SharedLock point_lock(points_mutex_, candidate);
+            return node->graph_->GetNeighborSize(candidate) != 0;
+        };
+        if (contains(id)) {
+            return true;
+        }
+        // Duplicate vectors can belong to a scope without having their own graph row.
+        const auto duplicates = node->graph_->GetDuplicateIds(id);
+        return std::any_of(duplicates.begin(), duplicates.end(), contains);
+    }
+    // Unbuilt levels are represented by their searchable descendants, as in IndexNode::Search.
+    return std::any_of(node->children_.begin(), node->children_.end(), [&](const auto& child) {
+        return matches_scope(child.second.get(), id);
+    });
+}
+
+FilterPtr
+Pyramid::create_hierarchy_filter(const Hierarchy& hierarchy, const std::string& path) const {
+    Vector<const IndexNode*> scopes(allocator_);
+    for (const auto& one_path : parse_path(path)) {
+        auto* node = hierarchy.root.get();
+        for (const auto& segment : one_path) {
+            node = node->GetChild(segment, false);
+            if (node == nullptr) {
+                break;
+            }
+        }
+        if (node != nullptr) {
+            scopes.push_back(node);
+        }
+    }
+    return std::make_shared<WhiteListFilter>([this, scopes = std::move(scopes)](int64_t id) {
+        return std::any_of(scopes.begin(), scopes.end(), [this, id](const IndexNode* node) {
+            return matches_scope(node, static_cast<InnerIdType>(id));
+        });
     });
 }
 

--- a/src/algorithm/pyramid/pyramid.h
+++ b/src/algorithm/pyramid/pyramid.h
@@ -359,6 +359,12 @@ private:
                 const float* vector,
                 int sampled_root_level);
 
+    bool
+    matches_scope(const IndexNode* node, InnerIdType id) const;
+
+    FilterPtr
+    create_hierarchy_filter(const Hierarchy& hierarchy, const std::string& path) const;
+
     /// Search a single hierarchy along a path prefix, accumulating candidates.
     void
     search_hierarchy(const Hierarchy& h,
@@ -381,7 +387,7 @@ private:
                 int64_t final_topk,
                 std::optional<int64_t> reorder_candidate_limit,
                 QueryContext& ctx,
-                const std::string& hierarchy_name,
+                const PyramidSearchParameters& parsed_param,
                 const DistanceRecordVector* rabitq_lower_bound_candidates = nullptr) const;
 
     InnerSearchParam

--- a/tests/test_pyramid.cpp
+++ b/tests/test_pyramid.cpp
@@ -1943,7 +1943,7 @@ TEST_CASE("Multi-Hierarchy: Search without hierarchies param in multi-mode error
     REQUIRE_FALSE(result.has_value());
 }
 
-TEST_CASE("Multi-Hierarchy: Multi-hierarchy union/intersection rejected",
+TEST_CASE("Multi-Hierarchy: Intersection requires all named paths",
           "[ft][pyramid][multi_hierarchy]") {
     MultiHierarchyFixture f;
     auto index = vsag::Factory::CreateIndex("pyramid", f.build_param("nsw"));

--- a/tests/test_pyramid_intersection.cpp
+++ b/tests/test_pyramid_intersection.cpp
@@ -1,0 +1,398 @@
+// Copyright 2024-present the vsag project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <future>
+#include <nlohmann/json.hpp>
+#include <sstream>
+
+#include "vsag/vsag.h"
+
+namespace {
+
+struct IntersectionFixture {
+    static constexpr int64_t DIM = 16;
+    std::vector<int64_t> ids{100, 101, 102, 103, 104, 105};
+    std::vector<float> vectors = std::vector<float>(6 * DIM, 0.0F);
+    std::vector<std::string> site{"a/one", "b/one", "a/one", "b/two", "a/two", "c"};
+    std::vector<std::string> category{"x/one", "y/one", "y/two", "x/two", "y/two", "z"};
+    std::vector<std::string> region{"south", "south", "south", "north", "north", "north"};
+    std::vector<float> query_vector = std::vector<float>(DIM, 0.0F);
+    std::string site_query{"a"};
+    std::string category_query{"y"};
+    std::string region_query{"north"};
+
+    IntersectionFixture() {
+        for (uint64_t i = 0; i < ids.size(); ++i) {
+            vectors[i * DIM] = static_cast<float>(i + 1);
+        }
+    }
+
+    vsag::DatasetPtr
+    base(uint64_t begin = 0, uint64_t count = 6) {
+        return vsag::Dataset::Make()
+            ->NumElements(static_cast<int64_t>(count))
+            ->Dim(DIM)
+            ->Ids(ids.data() + begin)
+            ->Float32Vectors(vectors.data() + begin * DIM)
+            ->Paths("site", site.data() + begin)
+            ->Paths("category", category.data() + begin)
+            ->Paths("region", region.data() + begin)
+            ->Owner(false);
+    }
+
+    vsag::DatasetPtr
+    query() {
+        return vsag::Dataset::Make()
+            ->NumElements(1)
+            ->Dim(DIM)
+            ->Float32Vectors(query_vector.data())
+            ->Paths("site", &site_query)
+            ->Paths("category", &category_query)
+            ->Paths("region", &region_query)
+            ->Owner(false);
+    }
+
+    static nlohmann::json
+    params(const std::string& graph = "nsw", int min_size = 100, bool reorder = false) {
+        return {{"dtype", "float32"},
+                {"metric_type", "l2"},
+                {"dim", DIM},
+                {"index_param",
+                 {{"graph_type", graph},
+                  {"max_degree", 16},
+                  {"ef_construction", 100},
+                  {"index_min_size", min_size},
+                  {"use_reorder", reorder},
+                  {"base_quantization_type", reorder ? "sq8" : "fp32"},
+                  {"precise_quantization_type", "fp32"},
+                  {"hierarchies",
+                   {{{"name", "site"}, {"no_build_levels", {0}}},
+                    {{"name", "category"}, {"no_build_levels", {0, 1}}},
+                    {{"name", "region"}, {"no_build_levels", {0}}}}}}}};
+    }
+
+    static std::string
+    search_params(int ef = 10) {
+        return nlohmann::json{{"pyramid",
+                               {{"ef_search", ef},
+                                {"factor", 1.5},
+                                {"hierarchies", {"site", "category"}},
+                                {"hierarchy_op", "intersection"}}}}
+            .dump();
+    }
+
+    static void
+    check(const tl::expected<vsag::DatasetPtr, vsag::Error>& result,
+          const std::vector<int64_t>& expected) {
+        if (not result.has_value()) {
+            FAIL(result.error().message);
+        }
+        REQUIRE(result.value()->GetDim() == static_cast<int64_t>(expected.size()));
+        for (uint64_t i = 0; i < expected.size(); ++i) {
+            REQUIRE(result.value()->GetIds()[i] == expected[i]);
+        }
+    }
+
+    void
+    check_entries(const vsag::IndexPtr& index,
+                  const std::vector<int64_t>& expected,
+                  const std::string& parameters = search_params(),
+                  const vsag::FilterPtr& filter = nullptr,
+                  int64_t limit = 6) {
+        CAPTURE(site_query, category_query, region_query, parameters, limit, expected);
+        auto q = query();
+        check(index->KnnSearch(q, limit, parameters, filter), expected);
+        check(index->RangeSearch(q, 100.0F, parameters, filter, limit), expected);
+        vsag::SearchRequest request;
+        request.query_ = q;
+        request.params_str_ = parameters;
+        request.topk_ = limit;
+        request.filter_ = filter;
+        request.enable_filter_ = filter != nullptr;
+        check(index->SearchWithRequest(request), expected);
+        request.mode_ = vsag::SearchMode::RANGE_SEARCH;
+        request.radius_ = 100.0F;
+        request.limited_size_ = limit;
+        check(index->SearchWithRequest(request), expected);
+    }
+};
+
+class ExcludeLabel : public vsag::Filter {
+public:
+    bool
+    CheckValid(int64_t id) const override {
+        return id != 102;
+    }
+};
+
+}  // namespace
+
+TEST_CASE("Pyramid intersection applies scopes before candidate limits",
+          "[ft][pyramid][intersection]") {
+    const auto graph = GENERATE("nsw", "odescent");
+    const auto min_size = GENERATE(0, 100);
+    const auto reorder = GENERATE(false, true);
+    CAPTURE(graph, min_size, reorder);
+    IntersectionFixture f;
+    auto created = vsag::Factory::CreateIndex("pyramid", f.params(graph, min_size, reorder).dump());
+    REQUIRE(created.has_value());
+    auto index = created.value();
+    REQUIRE(index->Build(f.base()).has_value());
+
+    // Independent Top-1 results are 100 and 101; intersecting them loses the valid best match 102.
+    f.check(index->KnnSearch(f.query(), 1, R"({"pyramid":{"ef_search":1,"hierarchies":["site"]}})"),
+            {100});
+    f.check(
+        index->KnnSearch(f.query(), 1, R"({"pyramid":{"ef_search":1,"hierarchies":["category"]}})"),
+        {101});
+    f.check_entries(index, {102}, f.search_params(1), nullptr, 1);
+    f.check_entries(index, {102, 104});
+    f.check(index->RangeSearch(f.query(), 10.0F, f.search_params()), {102});
+    vsag::SearchRequest threshold_request;
+    threshold_request.query_ = f.query();
+    threshold_request.topk_ = 6;
+    threshold_request.params_str_ = f.search_params();
+    threshold_request.threshold_ = 10.0F;
+    f.check(index->SearchWithRequest(threshold_request), {102});
+    f.check_entries(index, {104}, f.search_params(), std::make_shared<ExcludeLabel>());
+
+    // OR on both sides, including duplicate/overlapping prefixes and nonexistent alternatives.
+    f.site_query = "a/one|b/two|a/one|missing";
+    f.category_query = "y|x/two|y/two";
+    f.check_entries(index, {102, 103});
+    f.site_query = "c";
+    f.category_query = "y";
+    f.check_entries(index, {});
+    f.site_query = "missing";
+    f.check_entries(index, {});
+    f.site_query = "";
+    f.check_entries(index, {});
+    f.site_query = "a";
+    f.category_query = "";
+    f.check_entries(index, {});
+    f.category_query = "y";
+
+    auto three = nlohmann::json::parse(f.search_params());
+    three["pyramid"]["hierarchies"] = {"site", "category", "region"};
+    f.check_entries(index, {104}, three.dump());
+    three["pyramid"]["hierarchies"] = {"region", "category", "site"};
+    f.check_entries(index, {104}, three.dump());
+
+    // Scope membership is restored independently of store_paths.
+    std::stringstream stream;
+    REQUIRE(index->Serialize(stream).has_value());
+    auto restored =
+        vsag::Factory::CreateIndex("pyramid", f.params(graph, min_size, reorder).dump());
+    REQUIRE(restored.has_value());
+    REQUIRE(restored.value()->Deserialize(stream).has_value());
+    f.check_entries(restored.value(), {102, 104});
+    std::stringstream streaming;
+    REQUIRE(index->SerializeStreaming(streaming).has_value());
+    auto streamed =
+        vsag::Factory::CreateIndex("pyramid", f.params(graph, min_size, reorder).dump());
+    REQUIRE(streamed.has_value());
+    REQUIRE(streamed.value()->DeserializeStreaming(streaming).has_value());
+    f.check_entries(streamed.value(), {102, 104});
+    // MarkRemove does not change physical graph membership; its filter must still apply.
+    for (const auto& target : {index, restored.value()}) {
+        auto removed = target->Remove(std::vector<int64_t>{102}, vsag::RemoveMode::MARK_REMOVE);
+        REQUIRE(removed.has_value());
+        REQUIRE(removed.value() == 1);
+        f.check_entries(target, {104});
+    }
+}
+
+TEST_CASE("Pyramid intersection validates every named path", "[ft][pyramid][intersection]") {
+    IntersectionFixture f;
+    auto index = vsag::Factory::CreateIndex("pyramid", f.params().dump()).value();
+    REQUIRE(index->Build(f.base()).has_value());
+    const auto invalid = GENERATE("missing_path", "unknown", "union", "missing_first");
+    auto q = f.query();
+    auto params = nlohmann::json::parse(f.search_params());
+    if (std::string(invalid) == "missing_path" || std::string(invalid) == "missing_first") {
+        q = vsag::Dataset::Make()
+                ->NumElements(1)
+                ->Dim(f.DIM)
+                ->Float32Vectors(f.query_vector.data())
+                ->Paths(&f.category_query)
+                ->Owner(false);
+        if (std::string(invalid) == "missing_path") {
+            q->Paths("site", &f.site_query);
+        } else {
+            q->Paths("category", &f.category_query);
+        }
+    } else if (std::string(invalid) == "unknown") {
+        // An empty first scope must not hide an invalid later selector.
+        f.site_query = "missing";
+        params["pyramid"]["hierarchies"] = {"site", "unknown"};
+    } else {
+        params["pyramid"]["hierarchy_op"] = "union";
+    }
+    const auto sp = params.dump();
+    const auto require_invalid = [](const auto& result) {
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_ARGUMENT);
+    };
+    require_invalid(index->KnnSearch(q, 1, sp));
+    require_invalid(index->RangeSearch(q, 100.0F, sp));
+    vsag::SearchRequest request;
+    request.query_ = q;
+    request.topk_ = 1;
+    request.params_str_ = sp;
+    require_invalid(index->SearchWithRequest(request));
+    request.mode_ = vsag::SearchMode::RANGE_SEARCH;
+    request.radius_ = 100.0F;
+    require_invalid(index->SearchWithRequest(request));
+}
+
+TEST_CASE("Pyramid intersection follows Add and FLAT promotion", "[ft][pyramid][intersection]") {
+    IntersectionFixture f;
+    auto param = f.params("nsw", 3);
+    auto index = vsag::Factory::CreateIndex("pyramid", param.dump()).value();
+    REQUIRE(index->Build(f.base(0, 2)).has_value());
+    f.check_entries(index, {});
+    REQUIRE(index->Add(f.base(2, 3)).has_value());
+    f.check_entries(index, {102, 104});
+    // A label inserted into only one hierarchy must not satisfy the other scope.
+    auto partial = vsag::Dataset::Make()
+                       ->NumElements(1)
+                       ->Dim(f.DIM)
+                       ->Ids(f.ids.data() + 5)
+                       ->Float32Vectors(f.vectors.data() + 5 * f.DIM)
+                       ->Paths("site", &f.site_query)
+                       ->Owner(false);
+    REQUIRE(index->Add(partial).has_value());
+    f.check_entries(index, {102, 104});
+    auto serialized = index->Serialize();
+    REQUIRE(serialized.has_value());
+    auto restored = vsag::Factory::CreateIndex("pyramid", param.dump()).value();
+    REQUIRE(restored->Deserialize(serialized.value()).has_value());
+    f.check_entries(restored, {102, 104});
+}
+
+TEST_CASE("Pyramid intersection supports root scopes and partial hierarchy membership",
+          "[ft][pyramid][intersection]") {
+    const auto storage = GENERATE("flat", "compressed");
+    CAPTURE(storage);
+    IntersectionFixture f;
+    auto param = f.params("nsw", 0);
+    param["index_param"]["hierarchies"][1] = {{"name", "category"},
+                                              {"root_graph_type", "multi_layer"},
+                                              {"no_build_levels", nlohmann::json::array()}};
+    param["index_param"]["graph_storage_type"] = storage;
+    auto made = vsag::Factory::CreateIndex("pyramid", param.dump());
+    REQUIRE(made.has_value());
+    auto index = made.value();
+    auto partial = vsag::Dataset::Make()
+                       ->NumElements(2)
+                       ->Dim(f.DIM)
+                       ->Ids(f.ids.data())
+                       ->Float32Vectors(f.vectors.data())
+                       ->Paths("site", f.site.data())
+                       ->Owner(false);
+    REQUIRE(index->Build(partial).has_value());
+    REQUIRE(index->Add(f.base(2, 1)).has_value());
+    f.category_query = "/";
+    // The singleton category root is a real zero-degree member, despite earlier ID holes.
+    f.check_entries(index, {102});
+    REQUIRE(index->Remove(std::vector<int64_t>{102}).value() == 1);
+    f.check_entries(index, {});
+    REQUIRE(index->Add(f.base(3, 3)).has_value());
+    f.check_entries(index, {104});
+    auto serialized = index->Serialize();
+    REQUIRE(serialized.has_value());
+    auto restored = vsag::Factory::CreateIndex("pyramid", param.dump()).value();
+    REQUIRE(restored->Deserialize(serialized.value()).has_value());
+    // Existing serialization does not retain MarkRemove flags; reapply the deletion explicitly.
+    REQUIRE(restored->Remove(std::vector<int64_t>{102}).value() == 1);
+    f.check_entries(restored, {104});
+}
+
+TEST_CASE("Pyramid intersection includes graph duplicates", "[ft][pyramid][intersection]") {
+    IntersectionFixture f;
+    f.vectors[2 * f.DIM] = f.vectors[f.DIM];
+    f.site_query = "a/one";
+    f.category_query = "y/one";
+    f.category[2] = "y/one";
+    auto param = f.params("nsw", 0);
+    param["index_param"]["support_duplicate"] = true;
+    auto index = vsag::Factory::CreateIndex("pyramid", param.dump()).value();
+    REQUIRE(index->Build(f.base()).has_value());
+    // 102 has no physical row in category/y/one: it is a duplicate of 101.
+    f.check_entries(index, {102});
+    auto serialized = index->Serialize();
+    REQUIRE(serialized.has_value());
+    auto restored = vsag::Factory::CreateIndex("pyramid", param.dump()).value();
+    REQUIRE(restored->Deserialize(serialized.value()).has_value());
+    f.check_entries(restored, {102});
+}
+
+TEST_CASE("Pyramid intersection filters RaBitQ reorder and request bitsets",
+          "[ft][pyramid][intersection]") {
+    IntersectionFixture f;
+    auto param = f.params("nsw", 0, true);
+    param["index_param"]["base_quantization_type"] = "rabitq";
+    param["index_param"]["precise_quantization_type"] = "rabitq";
+    param["index_param"]["rabitq_bits_per_dim_base"] = 3;
+    param["index_param"]["rabitq_bits_per_dim_precise"] = 5;
+    auto index = vsag::Factory::CreateIndex("pyramid", param.dump()).value();
+    REQUIRE(index->Build(f.base()).has_value());
+    f.check_entries(index, {102, 104});
+    vsag::SearchRequest request;
+    request.query_ = f.query();
+    request.params_str_ = f.search_params();
+    request.topk_ = 1;
+    request.enable_bitset_filter_ = true;
+    request.bitset_filter_ = vsag::Bitset::Make();
+    request.bitset_filter_->Set(102);
+    f.check(index->SearchWithRequest(request), {104});
+    request.mode_ = vsag::SearchMode::RANGE_SEARCH;
+    request.radius_ = 100;
+    f.check(index->SearchWithRequest(request), {104});
+}
+
+TEST_CASE("Pyramid intersection supports concurrent opposite selectors and parallel OR",
+          "[ft][pyramid][intersection]") {
+    IntersectionFixture f;
+    auto pool = vsag::Engine::CreateThreadPool(4).value();
+    auto allocator = vsag::Engine::CreateDefaultAllocator();
+    vsag::Resource resource(allocator, pool);
+    vsag::Engine engine(&resource);
+    auto index = engine.CreateIndex("pyramid", f.params("nsw", 0).dump()).value();
+    REQUIRE(index->Build(f.base()).has_value());
+    f.site_query = "a|a/one|a/two";
+    auto forward = nlohmann::json::parse(f.search_params());
+    forward["pyramid"]["parallel_search_thread_count"] = 2;
+    auto reverse = forward;
+    reverse["pyramid"]["hierarchies"] = {"category", "site"};
+    f.check_entries(index, {102, 104}, forward.dump());
+    f.check_entries(index, {102, 104}, reverse.dump());
+    auto q = f.query();
+    auto search = [&](const std::string& parameters) {
+        for (int i = 0; i < 30; ++i) {
+            const auto result = index->KnnSearch(q, 2, parameters);
+            if (not result.has_value() || result.value()->GetDim() != 2 ||
+                result.value()->GetIds()[0] != 102 || result.value()->GetIds()[1] != 104) {
+                return false;
+            }
+        }
+        return true;
+    };
+    auto a = std::async(std::launch::async, search, forward.dump());
+    auto b = std::async(std::launch::async, search, reverse.dump());
+    REQUIRE(a.get());
+    REQUIRE(b.get());
+}


### PR DESCRIPTION
## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

Closes #2849

## What Changed

Pyramid previously rejected searches selecting multiple named hierarchies. It now supports `hierarchy_op: "intersection"` in KnnSearch, RangeSearch, and both SearchWithRequest modes. For example, `(host1 OR host2) AND (finance/bank OR finance/insurance)` reads the paths associated with each named hierarchy.

The first hierarchy drives the existing search. Other hierarchy path scopes form internal membership filters composed with external and deletion filters, before node candidate limits, final truncation, and reorder. Overlapping OR results are deduplicated before the final limits. Membership uses existing FLAT IDs, graph rows, duplicate trackers, and descendants of unbuilt levels; no new persistent state is introduced. Each selected hierarchy requires its own named query paths. Single-hierarchy fallback behavior is preserved; union remains unsupported.

## Test Evidence

- [x] `make fmt` (clang-format 15)
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other: focused production clang-tidy 15, struct-name lint, coverage-enabled build, relevant Pyramid unit and functional tests

Test details:

```text
make cov COMPILE_JOBS=12                                      exit 0
cmake --build build --target functests unittests --parallel 12 exit 0
VSAG_TEST_SEED=424242 OPENBLAS_NUM_THREADS=1 build/tests/functests   '[multi_hierarchy],[intersection],[paths]' --rng-seed 424242
  Passed: 46 cases, 1728 assertions; exit 0
VSAG_TEST_SEED=424242 OPENBLAS_NUM_THREADS=1 build/tests/unittests   '*Pyramid*' --rng-seed 424242
  Passed: 52 cases, 600 assertions; exit 0
make fmt                                                     exit 0
python3 scripts/linters/check-struct-names.py                  exit 0
bash scripts/linters/run-clang-tidy-15.sh -p build   -source-filter '.*/src/algorithm/pyramid/pyramid[.]cpp$' -j 4
  Matched and checked exactly 1 production source; exit 0
git diff --check                                             exit 0
```

New cases cover independent Top-1 intersection losing the valid best result, OR/AND and three hierarchies, invalid/missing paths, empty scopes, external and bitset filters, radius/threshold, FP32 and SQ8/reorder, split RaBitQ/reorder, NSW/ODescent, FLAT promotion, partial hierarchy inserts, graph duplicates, regular/streaming restore, and concurrent opposite selectors with parallel OR searches. Root tests cover flat/compressed storage, ID holes, a zero-degree singleton, marking it deleted, and inserting more records.

Validation covers the related Pyramid tests and formatting/static checks listed above. The full test suite and complete coverage collection were not run. Old gcda files were cleared before the final focused runs; no coverage percentage is claimed.

A separate single-hierarchy reproduction confirms that existing LabelTable serialization does not persist MARK_REMOVE state (one visible result before restore, two after restore). No deletion-persistence change is included. Restore tests verify scope membership, and deletion composition is checked independently on original/restored indexes.

## Compatibility Impact

- API/ABI compatibility: no public header or object layout change.
- Serialization: unchanged; `store_paths` is not required.
- Behavior: multi-hierarchy intersection is now accepted; existing single-hierarchy behavior is retained.

## Performance and Concurrency Impact

- Every candidate can incur extra hierarchy membership checks: small FLAT scans, graph probes, duplicate lookups, and traversal through unbuilt levels. Overlapping OR results also incur deduplication memory/time. No benchmark or zero-overhead claim is made. The first hierarchy and normal ANN search parameters still affect recall and latency.
- Scope checks take node shared locks; root row access also takes the existing points lock. BasicSearcher releases its traversal points lock before invoking filters. Selector uniqueness prevents locking the driving node again, and the existing resize shared lock protects node lifetime. Parallel OR and concurrent reversed selectors are tested; no TSAN run is claimed.
- Dense/compressed root membership uses the existing NSW connectivity invariant, explicitly recognizing the zero-degree entry and duplicate members; physical capacity alone is never accepted as membership. ODescent multi-layer roots and physical removal are already unsupported.

## Documentation Impact

- [ ] No docs update needed
- [x] Updated docs:
  - [x] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [x] Other: English and Chinese Pyramid index guides

## Risk and Rollback

- Risk level: medium (candidate filtering and root membership assumptions).
- Rollback plan: revert this commit; stored indexes require no conversion.

## Checklist

- [x] I have linked the relevant issue
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions
