### PR TITLE
refactor(attr): route region predicates through immutable executor factories

### DIFF
--- a/docs/docs/en/src/advanced/attribute_filter.md
+++ b/docs/docs/en/src/advanced/attribute_filter.md
@@ -88,7 +88,9 @@ accepts a vector according to its type value:
 
 Missing values yield empty matches; other type values have no accepting branch. Missing
 fields or incompatible types are errors. Non-FastBitset attribute storage is not supported
-by this specialized executor. It can be combined with ordinary AND/OR/NOT predicates.
+by this specialized executor. It can be combined with ordinary AND/OR predicates.
+The parser accepts `!(...)`, but execution of a `NotExpression` remains unsupported
+(`INTERNAL_ERROR`, `Unsupported expression type`); this is not changed by factory dispatch.
 
 The type field must be signed and represent -1. Region and residence fields may use signed
 or unsigned integer types; query values must fit their field type and signed 64-bit input
@@ -97,6 +99,30 @@ range. Out-of-range values are rejected rather than truncated.
 `FUNCTION(name,"arg1|arg2","type1|type2")` is retained for parser/AST compatibility with
 `ads` only. It does **not** register callbacks or provide search-time function execution;
 passing such an expression to the executor is unsupported.
+
+### Internal executor factories
+
+Region expressions use the immutable named `ExecutorFactoryRegistry` by default, with no
+request flag. `Executor::MakeInstance` delegates to the internal builtin adapter in
+`src/attr/executor/builtin_executor.cpp`, which maps the existing typed region AST to the
+compile-linked `region_filter` factory. Registration glue is separate from the reusable
+registry implementation; the factory constructs the same `RegionFilterExecutor` with the
+same schema, range, and FastBitset checks and bitmap algorithm.
+
+This is an **internal, compile-linked extension point**, not a user-injectable registry,
+public plugin SDK, dynamic-library loader, or runtime registration/unregistration API.
+Adding a builtin requires source changes and rebuilding VSAG; it does not add grammar or
+make generic `FUNCTION(...)` executable. Existing search entrypoint signatures are unchanged.
+
+The builtin registry is initialized once and read-only afterwards. Each factory call creates
+an independent executor with its own mutable scratch/result bitmaps; the expression and
+attribute index are retained by shared ownership, while the allocator must outlive the
+executor. Shared expressions and the index must not be mutated concurrently with evaluation.
+Call `Init()` before use and `Clear()` before each composed `Run(bucket_id)`, as search does;
+logical AND/OR may modify a child's result bitmap in place, never borrowed index postings.
+Lookup occurs once per region executor construction, not in `Run` or per-candidate
+`CheckValid`. IVF creates an executor tree per parallel search worker, and each region leaf
+resolves separately, so this is not necessarily one lookup per request.
 
 ### Introducing fields during updates
 
@@ -254,7 +280,8 @@ common needs of structured filtering.
 | NOT         | `!(expr)`              |
 | Grouping    | `(...)`                |
 
-`NOT` is only available in the prefixed form `!(...)`.
+The parser recognizes `NOT` only in the prefixed form `!(...)`; its execution is
+currently unsupported (see [Region filter](#region-filter)).
 
 ### Comparison operators
 
@@ -323,8 +350,8 @@ category = "electronics"
 # numeric range, multi-valued field
 price >= 100 AND price <= 1000 AND tag IN ["promo", "new"]
 
-# negation
-!(status = "archived") AND multi_notin(region, "us-east|us-west", "|")
+# exclusion without the unsupported NOT expression
+status != "archived" AND multi_notin(region, "us-east|us-west", "|")
 
 # arithmetic on the left side of the comparison
 (end_ts - start_ts) > 3600 AND charge_type = 5

--- a/docs/docs/zh/src/advanced/attribute_filter.md
+++ b/docs/docs/zh/src/advanced/attribute_filter.md
@@ -76,11 +76,26 @@ region_filter(region_type, region_list, residence_tag_list, "10|20", "30", "40")
 | 5 | R AND NOT H |
 
 未出现的值对应空匹配；其他类型值没有接受分支。字段不存在或类型不兼容会报错。
-该专用 executor 不支持非 FastBitset 属性存储，可以与普通 AND/OR/NOT 条件组合。
+该专用 executor 不支持非 FastBitset 属性存储，可以与普通 AND/OR 条件组合。
+解析器接受 `!(...)`，但 `NotExpression` 的执行仍不受支持（`INTERNAL_ERROR`，`Unsupported expression type`）；工厂分发不改变这一既有行为。
 
 类型字段必须是能表示 -1 的有符号整数。地域和常住地字段可使用有符号或无符号整数；查询值必须同时满足字段类型和有符号 64 位输入范围，越界时报错而不是截断。
 
 `FUNCTION(name,"arg1|arg2","type1|type2")` 仅为兼容 `ads` 保留语法和 AST，**不提供**回调注册或搜索时函数执行能力；将此类表达式传给 executor 不受支持。
+
+### 内部 executor 工厂
+
+Region 表达式默认通过不可变的命名 `ExecutorFactoryRegistry` 创建 executor，无需请求开关。
+`Executor::MakeInstance` 委托给 `src/attr/executor/builtin_executor.cpp` 中的内置适配器，将现有的强类型 region AST 映射到编译链接的 `region_filter` 工厂。
+注册胶水与可复用的 registry 实现分离；工厂仍创建同一个 `RegionFilterExecutor`，schema、范围、FastBitset 校验和位图算法均不改变。
+
+这是**内部、编译链接的扩展点**，不是可由用户注入的 registry、公开插件 SDK、动态库加载器或运行时注册/注销 API。
+新增内置实现需要修改源码并重新编译 VSAG；它不扩展语法，也不会让通用 `FUNCTION(...)` 可执行。现有搜索入口签名不变。
+
+内置 registry 只初始化一次，此后只读。每次工厂调用创建独立 executor，拥有自己的可变临时位图和结果位图；表达式与属性索引通过共享所有权保留，allocator 则必须比 executor 活得更久。
+共享表达式和索引不能在求值期间被并发修改。使用前调用 `Init()`，每次组合表达式 `Run(bucket_id)` 前调用 `Clear()`，与搜索调用方式一致；逻辑 AND/OR 可能就地修改子节点的结果位图，但不修改借用的索引 posting。
+命名查找只发生在每个 region executor 创建时，不发生在 `Run` 或逐候选 `CheckValid` 内。
+IVF 为每个并行搜索 worker 创建 executor 树，每个 region 叶子分别解析工厂，因此不能笼统地说每个请求只查找一次。
 
 ### 更新时引入字段
 
@@ -227,7 +242,7 @@ for (int64_t i = 0; i < result->GetDim(); ++i) {
 | NOT   | `!(expr)`             |
 | 分组  | `(...)`               |
 
-`NOT` 仅支持前缀写法 `!(...)`。
+解析器仅识别前缀写法 `!(...)` 的 `NOT`；目前不支持执行，详见 [Region filter](#region-filter)。
 
 ### 比较运算符
 
@@ -291,8 +306,8 @@ category = "electronics"
 # 数值范围 + 多值字段
 price >= 100 AND price <= 1000 AND tag IN ["promo", "new"]
 
-# 取反
-!(status = "archived") AND multi_notin(region, "us-east|us-west", "|")
+# 排除，不使用尚不支持执行的 NOT 表达式
+status != "archived" AND multi_notin(region, "us-east|us-west", "|")
 
 # 比较左侧的算术运算
 (end_ts - start_ts) > 3600 AND charge_type = 5

--- a/src/attr/executor/builtin_executor.cpp
+++ b/src/attr/executor/builtin_executor.cpp
@@ -1,0 +1,37 @@
+// Copyright 2024-present the vsag project
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0
+#include "builtin_executor.h"
+
+#include "executor_factory_registry.h"
+#include "region_filter_executor.h"
+
+namespace vsag {
+namespace {
+ExecutorPtr
+make_region(Allocator* allocator,
+            const ExprPtr& expression,
+            const AttrInvertedInterfacePtr& attr_index) {
+    return std::make_shared<RegionFilterExecutor>(allocator, expression, attr_index);
+}
+}  // namespace
+
+const ExecutorFactoryRegistry&
+ExecutorFactoryRegistry::Builtins() {
+    static const ExecutorFactoryRegistry registry{{"region_filter", make_region}};
+    return registry;
+}
+
+ExecutorPtr
+CreateBuiltinExecutor(Allocator* allocator,
+                      const ExprPtr& expression,
+                      const AttrInvertedInterfacePtr& attr_index) {
+    // Keep the existing grammar and typed arguments; generic FUNCTION remains unsupported.
+    if (std::dynamic_pointer_cast<RegionFilterExpression>(expression)) {
+        return ExecutorFactoryRegistry::Builtins().Create(
+            "region_filter", allocator, expression, attr_index);
+    }
+    return nullptr;
+}
+}  // namespace vsag

--- a/src/attr/executor/builtin_executor.h
+++ b/src/attr/executor/builtin_executor.h
@@ -1,0 +1,16 @@
+// Copyright 2024-present the vsag project
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0
+#pragma once
+
+#include "executor.h"
+
+namespace vsag {
+// Internal typed-AST compatibility adapter. Returns nullptr for unregistered expression types.
+// Registrations are compile-linked; this is not an external callback or runtime plugin API.
+ExecutorPtr
+CreateBuiltinExecutor(Allocator* allocator,
+                      const ExprPtr& expression,
+                      const AttrInvertedInterfacePtr& attr_index);
+}  // namespace vsag

--- a/src/attr/executor/executor.cpp
+++ b/src/attr/executor/executor.cpp
@@ -15,10 +15,10 @@
 
 #include "executor.h"
 
+#include "builtin_executor.h"
 #include "comparison_executor.h"
 #include "integer_list_executor.h"
 #include "logical_executor.h"
-#include "region_filter_executor.h"
 #include "string_list_executor.h"
 namespace vsag {
 
@@ -49,8 +49,8 @@ Executor::MakeInstance(Allocator* allocator,
     if (std::dynamic_pointer_cast<LogicalExpression>(expression)) {
         return std::make_shared<LogicalExecutor>(allocator, expression, attr_index);
     }
-    if (std::dynamic_pointer_cast<RegionFilterExpression>(expression)) {
-        return std::make_shared<RegionFilterExecutor>(allocator, expression, attr_index);
+    if (auto executor = CreateBuiltinExecutor(allocator, expression, attr_index)) {
+        return executor;
     }
     if (std::dynamic_pointer_cast<FunctionExpression>(expression)) {
         throw VsagException(

--- a/src/attr/executor/executor_factory_registry.cpp
+++ b/src/attr/executor/executor_factory_registry.cpp
@@ -1,0 +1,35 @@
+// Copyright 2024-present the vsag project
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0
+#include "executor_factory_registry.h"
+
+namespace vsag {
+
+ExecutorFactoryRegistry::ExecutorFactoryRegistry(std::initializer_list<Entry> entries)
+    : factories_([&entries] {
+          std::unordered_map<std::string, Factory> factories;
+          for (const auto& entry : entries) {
+              if (entry.first.empty() || entry.second == nullptr ||
+                  !factories.emplace(entry.first, entry.second).second) {
+                  throw VsagException(ErrorType::INVALID_ARGUMENT,
+                                      "invalid or duplicate executor factory registration");
+              }
+          }
+          return factories;
+      }()) {
+}
+
+ExecutorPtr
+ExecutorFactoryRegistry::Create(const std::string& name,
+                                Allocator* allocator,
+                                const ExprPtr& expression,
+                                const AttrInvertedInterfacePtr& attr_index) const {
+    auto factory = factories_.find(name);
+    if (factory == factories_.end()) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "unknown executor factory: " + name);
+    }
+    return factory->second(allocator, expression, attr_index);
+}
+}  // namespace vsag

--- a/src/attr/executor/executor_factory_registry.h
+++ b/src/attr/executor/executor_factory_registry.h
@@ -1,0 +1,36 @@
+// Copyright 2024-present the vsag project
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0
+#pragma once
+
+#include <initializer_list>
+#include <string>
+#include <unordered_map>
+
+#include "executor.h"
+
+namespace vsag {
+// Internal immutable named factories. Each invocation creates an independently owned executor.
+// The allocator must outlive its executors; each executor retains its expression and index.
+// There is no runtime registration or public registry injection into search.
+class ExecutorFactoryRegistry {
+public:
+    using Factory = ExecutorPtr (*)(Allocator*, const ExprPtr&, const AttrInvertedInterfacePtr&);
+    using Entry = std::pair<std::string, Factory>;
+
+    explicit ExecutorFactoryRegistry(std::initializer_list<Entry> entries);
+
+    ExecutorPtr
+    Create(const std::string& name,
+           Allocator* allocator,
+           const ExprPtr& expression,
+           const AttrInvertedInterfacePtr& attr_index) const;
+
+    static const ExecutorFactoryRegistry&
+    Builtins();
+
+private:
+    const std::unordered_map<std::string, Factory> factories_;
+};
+}  // namespace vsag

--- a/src/attr/executor/executor_factory_registry_test.cpp
+++ b/src/attr/executor/executor_factory_registry_test.cpp
@@ -1,0 +1,137 @@
+// Copyright 2024-present the vsag project
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy at http://www.apache.org/licenses/LICENSE-2.0
+#include "executor_factory_registry.h"
+
+#include <future>
+
+#include "attr/argparse.h"
+#include "impl/allocator/safe_allocator.h"
+#include "region_filter_executor.h"
+#include "unittest.h"
+
+using namespace vsag;
+
+TEST_CASE("Immutable region factory errors", "[ut][RegionFactory]") {
+    auto alloc = SafeAllocator::FactoryDefaultAllocator();
+    auto index = AttributeInvertedInterface::MakeInstance(alloc.get(), true);
+    // Existing parser accepts NOT, but executor dispatch does not implement it.
+    auto negated = AstParse(R"(!(region_filter(kind,geo,home,"1","1","2")))");
+    REQUIRE(negated->GetExprType() == ExpressionType::kNotExpression);
+    try {
+        Executor::MakeInstance(alloc.get(), negated, index);
+        FAIL("top-level NOT remains unsupported");
+    } catch (const VsagException& error) {
+        REQUIRE(error.error_.type == ErrorType::INTERNAL_ERROR);
+        REQUIRE(std::string(error.what()) == "Unsupported expression type");
+    }
+    REQUIRE_THROWS_AS(Executor::MakeInstance(alloc.get(), nullptr, index), VsagException);
+    const auto& registry = ExecutorFactoryRegistry::Builtins();
+    REQUIRE_THROWS_AS(registry.Create("unknown", alloc.get(), nullptr, index), VsagException);
+    REQUIRE_THROWS_AS(registry.Create("region_filter", alloc.get(), nullptr, index), VsagException);
+    REQUIRE_THROWS_AS(registry.Create("region_filter", alloc.get(), AstParse("a = 1"), index),
+                      VsagException);
+    auto factory = +[](Allocator* allocator,
+                       const ExprPtr& expr,
+                       const AttrInvertedInterfacePtr& attrs) -> ExecutorPtr {
+        return std::make_shared<RegionFilterExecutor>(allocator, expr, attrs);
+    };
+    REQUIRE_THROWS_AS((ExecutorFactoryRegistry{{"x", factory}, {"x", factory}}), VsagException);
+    REQUIRE_THROWS_AS((ExecutorFactoryRegistry{{"", factory}}), VsagException);
+    REQUIRE_THROWS_AS((ExecutorFactoryRegistry{{"x", nullptr}}), VsagException);
+    const ExecutorFactoryRegistry empty{};
+    REQUIRE_THROWS_AS(empty.Create("region_filter", alloc.get(), nullptr, index), VsagException);
+}
+
+TEST_CASE("Region factory combinations and independent lifecycle", "[ut][RegionFactory]") {
+    auto alloc = SafeAllocator::FactoryDefaultAllocator();
+    auto index = AttributeInvertedInterface::MakeInstance(alloc.get(), true);
+    for (int64_t id = 0; id < 64; ++id) {
+        AttributeValue<int16_t> kind;
+        AttributeValue<int64_t> geo;
+        AttributeValue<int64_t> home;
+        kind.name_ = "kind";
+        kind.GetValue() = {2};
+        geo.name_ = "geo";
+        geo.GetValue() = {id % 2};
+        home.name_ = "home";
+        home.GetValue() = {id % 3};
+        index->Insert(AttributeSet{{&kind, &geo, &home}}, id, 0);
+    }
+    using Oracle = bool (*)(int64_t);
+    const std::pair<const char*, Oracle> cases[] = {
+        {R"(region_filter(kind,geo,home,"1","1","2"))", [](int64_t id) { return id % 2 == 1; }},
+        {R"(region_filter(kind,geo,home,"1","1","2") AND home = 1)",
+         [](int64_t id) { return id % 2 == 1 && id % 3 == 1; }},
+        {R"(region_filter(kind,geo,home,"1","1","2") OR home = 1)",
+         [](int64_t id) { return id % 2 == 1 || id % 3 == 1; }},
+        {R"(home = 1 AND region_filter(kind,geo,home,"1","1","2"))",
+         [](int64_t id) { return id % 2 == 1 && id % 3 == 1; }},
+        {R"(home = 1 OR region_filter(kind,geo,home,"1","1","2"))",
+         [](int64_t id) { return id % 2 == 1 || id % 3 == 1; }},
+        {R"(region_filter(kind,geo,home,"1","1","2") AND region_filter(kind,geo,home,"0","1","2"))",
+         [](int64_t) { return false; }}};
+    for (const auto& item : cases) {
+        auto expr = AstParse(item.first, &index->field_type_map_);
+        auto registered = Executor::MakeInstance(alloc.get(), expr, index);
+        registered->Init();
+        registered->Init();
+        for (int repeat = 0; repeat < 4; ++repeat) {
+            registered->Clear();
+            const auto* result = registered->Run(0);
+            for (int64_t id = 0; id < 64; ++id) {
+                REQUIRE(result->CheckValid(id) == item.second(id));
+            }
+            registered->Clear();
+            REQUIRE_FALSE(registered->Run(9)->CheckValid(int64_t{0}));
+            registered->Clear();
+            registered->Clear();
+        }
+    }
+    auto expr = AstParse(R"(region_filter(kind,geo,home,"1","1","2"))");
+    // Instrument a factory only in this correctness test, never in timed production code.
+    static int factory_calls = 0;
+    factory_calls = 0;
+    const ExecutorFactoryRegistry counted{
+        {"region_filter",
+         +[](Allocator* allocator, const ExprPtr& expression, const AttrInvertedInterfacePtr& attrs)
+             -> ExecutorPtr {
+             ++factory_calls;
+             return std::make_shared<RegionFilterExecutor>(allocator, expression, attrs);
+         }}};
+    auto counted_executor = counted.Create("region_filter", alloc.get(), expr, index);
+    counted_executor->Init();
+    for (int i = 0; i < 100; ++i) {
+        counted_executor->Run(i % 2);
+    }
+    REQUIRE(factory_calls == 1);
+    counted_executor.reset();
+    auto survivor = Executor::MakeInstance(alloc.get(), expr, index);
+    survivor->Init();
+    auto other = Executor::MakeInstance(alloc.get(), expr, index);
+    other->Init();
+    survivor->Run(0);
+    other->Run(9);
+    REQUIRE(survivor->filter_->CheckValid(int64_t{1}));
+    REQUIRE(survivor->bitset_ != other->bitset_);
+    other.reset();
+    expr.reset();
+    index.reset();
+    REQUIRE(survivor->Run(0)->CheckValid(int64_t{1}));
+    auto work = [survivor] {
+        auto executor =
+            Executor::MakeInstance(survivor->allocator_, survivor->expr_, survivor->attr_index_);
+        executor->Init();
+        for (int i = 0; i < 100; ++i) {
+            if (!executor->Run(0)->CheckValid(int64_t{1})) {
+                return false;
+            }
+        }
+        return true;
+    };
+    auto a = std::async(std::launch::async, work);
+    auto b = std::async(std::launch::async, work);
+    REQUIRE(a.get());
+    REQUIRE(b.get());
+}

--- a/src/attr/executor/region_filter_executor_test.cpp
+++ b/src/attr/executor/region_filter_executor_test.cpp
@@ -25,10 +25,10 @@ namespace {
 
 template <typename Type, typename List>
 void
-InsertTypedAttributes(const AttrInvertedInterfacePtr& index,
-                      Type type_value,
-                      std::vector<List> region_values,
-                      std::vector<List> residence_values) {
+insert_typed_attributes(const AttrInvertedInterfacePtr& index,
+                        Type type_value,
+                        std::vector<List> region_values,
+                        std::vector<List> residence_values) {
     AttributeValue<Type> type;
     type.name_ = "kind";
     type.GetValue() = {type_value};
@@ -138,7 +138,10 @@ TEST_CASE("RegionFilterExecutor truth table and expression fields", "[ut][Region
     }
 
     auto expression = AstParse(R"(region_filter(kind,geo,home,"10|404","20|405","30|406"))");
-    auto executor = Executor::MakeInstance(allocator.get(), expression, attr_index);
+    ExecutorPtr executor =
+        GENERATE(false, true)
+            ? Executor::MakeInstance(allocator.get(), expression, attr_index)
+            : std::make_shared<RegionFilterExecutor>(allocator.get(), expression, attr_index);
     REQUIRE(std::dynamic_pointer_cast<RegionFilterExecutor>(executor) != nullptr);
     executor->Init();
     auto* filter = executor->Run(3);
@@ -162,7 +165,10 @@ TEST_CASE("RegionFilterExecutor validates inputs and lifecycle", "[ut][RegionFil
     attr_index->Insert(row.set, 0, 0);
 
     auto expression = AstParse(R"(region_filter(kind,geo,home,"10","20","30"))");
-    auto executor = Executor::MakeInstance(allocator.get(), expression, attr_index);
+    ExecutorPtr executor =
+        GENERATE(false, true)
+            ? Executor::MakeInstance(allocator.get(), expression, attr_index)
+            : std::make_shared<RegionFilterExecutor>(allocator.get(), expression, attr_index);
     REQUIRE_THROWS_AS(executor->Run(), VsagException);
 
     try {
@@ -214,7 +220,7 @@ TEST_CASE("RegionFilterExecutor checks integer field boundaries", "[ut][RegionFi
 
     SECTION("signed boundaries are accepted") {
         auto index = AttributeInvertedInterface::MakeInstance(allocator.get(), true);
-        InsertTypedAttributes<int8_t, int8_t>(index, -1, {-128, 127}, {-128, 127});
+        insert_typed_attributes<int8_t, int8_t>(index, -1, {-128, 127}, {-128, 127});
         auto expression =
             AstParse(R"(region_filter(kind,geo,home,"-128|127","-128|127","-128|127"))");
         auto executor = std::make_shared<RegionFilterExecutor>(allocator.get(), expression, index);
@@ -224,7 +230,7 @@ TEST_CASE("RegionFilterExecutor checks integer field boundaries", "[ut][RegionFi
 
     SECTION("signed overflow is rejected") {
         auto index = AttributeInvertedInterface::MakeInstance(allocator.get(), true);
-        InsertTypedAttributes<int8_t, int8_t>(index, 1, {0}, {0});
+        insert_typed_attributes<int8_t, int8_t>(index, 1, {0}, {0});
         auto expression = AstParse(R"(region_filter(kind,geo,home,"128","0","0"))");
         REQUIRE_THROWS_AS(
             std::make_shared<RegionFilterExecutor>(allocator.get(), expression, index),
@@ -237,7 +243,7 @@ TEST_CASE("RegionFilterExecutor checks integer field boundaries", "[ut][RegionFi
 
     SECTION("unsigned list boundaries are checked") {
         auto index = AttributeInvertedInterface::MakeInstance(allocator.get(), true);
-        InsertTypedAttributes<int16_t, uint8_t>(index, 2, {0, 255}, {0, 255});
+        insert_typed_attributes<int16_t, uint8_t>(index, 2, {0, 255}, {0, 255});
         auto expression = AstParse(R"(region_filter(kind,geo,home,"0|255","0|255","255"))");
         auto executor = std::make_shared<RegionFilterExecutor>(allocator.get(), expression, index);
         executor->Init();
@@ -255,7 +261,7 @@ TEST_CASE("RegionFilterExecutor checks integer field boundaries", "[ut][RegionFi
 
     SECTION("unsigned type field is rejected because it cannot represent minus one") {
         auto index = AttributeInvertedInterface::MakeInstance(allocator.get(), true);
-        InsertTypedAttributes<uint8_t, int16_t>(index, 1, {10}, {20});
+        insert_typed_attributes<uint8_t, int16_t>(index, 1, {10}, {20});
         auto expression = AstParse(R"(region_filter(kind,geo,home,"10","20","30"))");
         REQUIRE_THROWS_AS(
             std::make_shared<RegionFilterExecutor>(allocator.get(), expression, index),


### PR DESCRIPTION
## Change Type

- [x] Improvement/Refactor

## Linked Issue

Internal refactor (`kind/improvement`); a linked issue is not required. Related-issue search for region filter registry found no matches.

## What Changed

- Introduce an immutable named executor-factory registry and isolate compile-linked builtin registration from core executor dispatch.
- Route the existing region predicate through its registered factory while retaining the specialized bitmap executor.
- Keep existing query syntax and unsupported generic FUNCTION behavior. This is an internal extension seam, not a public plugin SDK or dynamic-library ABI.
- Exclude the experimental request toggle, benchmark target and POC artifacts from the production change.
- Add focused registry/dispatch/lifecycle coverage and explain scope in English and Chinese attribute-filter docs.

## Test Evidence

- Release build with tests enabled, isolated dependencies, GCC 11.4.0.
- `make fmt` with clang-format 15.0.7.
- Focused clang-tidy 15 for changed production and test translation units.
- Attribute executor/parser/manager suite: **31,013 assertions in 27 test cases**, seed 424242 (final `tests-verified.log`). Dedicated region/registry run: **1,683 assertions in 5 cases**.
- `git diff --check`.

No full-repository `make test`, `make lint`, sanitizer run or coverage measurement is claimed.

## Compatibility Impact

- No intended public API or query-semantic changes; final diff to verify removal of all POC-only public fields.
- Region's existing storage/type restrictions remain unchanged.
- Generic FUNCTION and top-level NOT execution are not added by this change.

## Performance and Concurrency Impact

The prior A/B POC compared real executor construction and actual IVF/BruteForce searches on a shared Xeon host. The revised POC observed approximately 20–56 ns additional construction/Init/destruction cost (1.88–3.02%); search paired median differences ranged from roughly -0.53% to +0.75% in that synthetic matrix. These are historical POC measurements, not a benchmark of this final refactored PR. They do not establish zero overhead, a universal sub-percent bound, or production-tail equivalence. Host load and independently randomized IVF training limit cross-process comparisons.

Factory resolution is in executor construction, not Run(bucket_id) or candidate checks. Registry definitions are immutable; query executors own independent mutable state. No runtime unload/hot replacement is introduced.

## Documentation Impact

- English and Chinese canonical attribute filtering documentation updated (exact paths to confirm in final diff).

## Risk and Rollback

- Risk: internal dispatch/registration correctness; focused tests exercise malformed registration, region behavior, composition and state isolation.
- Rollback: revert this refactor; no index-storage format migration intended.

## Checklist

- [x] Final diff, API compatibility and doc scope reviewed
- [x] Focused tests and exact formatting/lint evidence recorded
- One Conventional Commit with ordered human DCO and AI-assistance trailers.
- Fork-first submission; `kind/improvement` and `version/1.1` labels.
