### PR TITLE
[skip ci] docs: update EnhanceGraph publication references to TKDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ Thrive together in VSAG community with users and developers from all around the 
    **Mingyu Yang**, Wentao Li, **Jiabao Jin, Xiaoyao Zhong, Xiangyu Wang, Zhitao Shen**, **Wei Jia,** Wei Wang \
    [PDF](https://arxiv.org/pdf/2404.16322) | [DOI](https://doi.org/10.1109/ICDE65448.2025.00087)  
 
-7. EnhanceGraph: A Continuously Enhanced Graph-based Index for High-dimensional Approximate Nearest Neighbor Search [_arxiv_, 2025]  
+7. EnhanceGraph: A Continuously Enhanced Graph-based Index for High-dimensional Approximate Nearest Neighbor Search [_TKDE_] \
    **Xiaoyao Zhong, Jiabao Jin**, Peng Cheng, **Mingyu Yang**, Lei Chen, Haoyang Li, **Zhitao Shen**, Xuemin Lin, Heng Tao Shen, Jingkuan Song  
-   [PDF](https://arxiv.org/pdf/2506.13144)
+   [PDF](https://ieeexplore.ieee.org/document/11663430)
 
 ## Reference
 VSAG referenced the following works during its implementation:

--- a/docs/docs/en/src/resources/research_papers.md
+++ b/docs/docs/en/src/resources/research_papers.md
@@ -32,7 +32,7 @@ HNSWlib.
 > Integrated into VSAG; enabled through the [`Tune`](../advanced/optimizer.md) API (historically
 > called the "ELP Optimizer" and implemented behind the `use_elp_optimizer` key).
 
-## 3. EnhanceGraph: A Continuously Enhanced Graph-based Index for High-dimensional Approximate Nearest Neighbor Search [[arxiv]](https://arxiv.org/abs/2506.13144)
+## 3. EnhanceGraph: A Continuously Enhanced Graph-based Index for High-dimensional Approximate Nearest Neighbor Search [[TKDE]](https://ieeexplore.ieee.org/document/11663430)
 
 Driven by rapid progress in deep learning, high-dimensional ANNS has received growing attention.
 We observe that graph-based indexes generate large amounts of search and construction logs over

--- a/docs/docs/zh/src/resources/research_papers.md
+++ b/docs/docs/zh/src/resources/research_papers.md
@@ -13,7 +13,7 @@
 > 该功能已集成于 VSAG 库中，通过统一的 [`Tune`](../advanced/optimizer.md) 接口启用（历史上称为
 > "ELP Optimizer"，底层实现键为 `use_elp_optimizer`）。
 
-## 3. EnhanceGraph: A Continuously Enhanced Graph-based Index for High-dimensional Approximate Nearest Neighbor Search [[arxiv]](https://arxiv.org/abs/2506.13144)
+## 3. EnhanceGraph: A Continuously Enhanced Graph-based Index for High-dimensional Approximate Nearest Neighbor Search [[TKDE]](https://ieeexplore.ieee.org/document/11663430)
 
 摘要（翻译）：随着深度学习技术的飞速发展，高维向量空间中的近似最近邻搜索近年来受到了广泛关注。我们观察到，在基于图的索引的整个生命周期中，会产生大量的搜索日志与构建日志。然而，由于现有索引具有静态特性，这两类有价值的日志并未得到充分利用。本文提出了EnhanceGraph框架，该框架将这两类日志整合到一种名为“共轭图”（conjugate graph）的新型结构中，并利用该共轭图来提升搜索质量。通过对基于图的索引的局限性进行理论分析与观察，我们提出了若干优化方法。针对搜索日志，共轭图存储从局部最优解到全局最优解的边，以增强路由至最近邻的能力；针对构建日志，共轭图存储从邻近图（proximity graph）中被剪除的边，以增强对k最近邻的检索能力。我们在多个公开及真实的工业数据集上的实验结果表明，EnhanceGraph在不牺牲搜索效率的前提下，显著提升了搜索精度，其中召回率（recall）的最大提升幅度达到了从41.74%至93.42%。此外，我们的EnhanceGraph算法已被集成到蚂蚁集团的开源向量库VSAG中。
 


### PR DESCRIPTION
Update the EnhanceGraph publication references to TKDE in the README and the English and Chinese research-paper pages.

- Replace the venue link in both existing EnhanceGraph subsection headings with [TKDE](https://ieeexplore.ieee.org/document/11663430).
- Replace the README entry’s arXiv venue/year with TKDE and point its existing PDF link to the same IEEE record, preserving the PDF label.
- Preserve the title, authors, abstracts, and unrelated papers. No publication year, volume, pages, or DOI is added.

Validation: exact link-placement and bilingual consistency checks passed; `git diff --check` passed. Only the three scoped Markdown files change. Documentation only; no builds were run. The commit retains `[skip ci]`.
