### PR TITLE
fix(python): align SINDI tests with partial statistics

### DIFF
--- a/tests/python/test_sindi.py
+++ b/tests/python/test_sindi.py
@@ -12,25 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pybind statistics tests for the maintained sparse SINDI index."""
+"""Pybind statistics tests for the maintained sparse SINDI indexes."""
 
 import json
 
 import numpy as np
 import pyvsag
+import pytest
 
 
-def test_sindi_knn_search_with_statistics():
+def assert_distance_statistics(statistics):
+    total = statistics["distance_evaluations"]
+    phases = statistics["distance_evaluations_by_phase"]
+    backends = statistics["distance_evaluations_by_backend"]
+    assert isinstance(statistics["complete"], bool)
+    assert set(phases) == {"routing", "approximate", "rerank"}
+    for count in [total, *phases.values(), *backends.values()]:
+        assert type(count) is int
+        assert 0 <= count < 2**64
+    assert total == sum(phases.values()) == sum(backends.values())
+    assert phases["routing"] == phases["approximate"] == 0
+    assert backends["unknown"] == 0
+    assert backends["sparse_fp32"] == total
+
+
+@pytest.mark.parametrize("index_name", ["sindi", "sindi_v2"])
+@pytest.mark.parametrize("use_reorder", [False, True])
+def test_sindi_knn_search_with_statistics(index_name, use_reorder):
     """Expose one statistics JSON result per sparse CSR query."""
     index = pyvsag.Index(
-        "sindi",
+        index_name,
         json.dumps(
             {
                 "dim": 16,
                 "dtype": "sparse",
                 "metric_type": "ip",
                 "index_param": {
-                    "use_reorder": True,
+                    "use_reorder": use_reorder,
                     "doc_prune_ratio": 0.0,
                     "window_size": 10000,
                     "term_id_limit": 16,
@@ -48,7 +66,7 @@ def test_sindi_knn_search_with_statistics():
     query_values = np.array([1.0, 0.5, 0.9, 0.6], dtype=np.float32)
     search_parameters = json.dumps(
         {
-            "sindi": {
+            index_name: {
                 "n_candidate": 3,
                 "query_prune_ratio": 0.0,
                 "term_prune_ratio": 0.0,
@@ -64,8 +82,34 @@ def test_sindi_knn_search_with_statistics():
     )
     assert ids.shape == legacy_ids.shape == (2, 2)
     assert distances.shape == legacy_distances.shape == (2, 2)
+    np.testing.assert_array_equal(ids, legacy_ids)
+    np.testing.assert_allclose(distances, legacy_distances)
+    np.testing.assert_array_equal(ids, [[0, 1], [2, 0]])
+    np.testing.assert_allclose(distances, [[-0.25, 0.2], [-0.17, 0.55]], atol=1e-6)
     assert len(statistics_json) == 2
-    for value in statistics_json:
+    for value, candidate_count in zip(statistics_json, [3, 2]):
+        assert isinstance(value, str)
         statistics = json.loads(value)
-        assert statistics["distance_evaluations"] > 0
-        assert statistics["complete"] is True
+        assert_distance_statistics(statistics)
+        # PR #2873 intentionally leaves partial statistics to keep posting scans fast.
+        assert statistics["complete"] is False
+        assert statistics["distance_evaluations_by_phase"]["rerank"] == (
+            candidate_count if use_reorder else 0
+        )
+
+    # An absent term performs no approximate work and can still be complete.
+    ids, distances, statistics_json = index.knn_search_with_statistics(
+        np.array([0, 1], dtype=np.uint32),
+        np.array([15], dtype=np.uint32),
+        np.array([1.0], dtype=np.float32),
+        2,
+        search_parameters,
+    )
+    assert ids.shape == distances.shape == (1, 2)
+    assert len(statistics_json) == 1
+    statistics = json.loads(statistics_json[0])
+    assert_distance_statistics(statistics)
+    assert statistics["distance_evaluations"] == 0
+    assert statistics["complete"] is True
+    np.testing.assert_array_equal(ids, [[-1, -1]])
+    np.testing.assert_array_equal(distances, [[-1.0, -1.0]])


### PR DESCRIPTION
## Change Type

- [x] Bug fix

## Linked Issue

Fixes: #2907

## What Changed

PR #2873 intentionally stopped tracking approximate evaluations in SINDI/SINDI_V2 posting scans for performance. Searches that do this untracked work return `complete=false`, while measured rerank statistics remain available. The Python test still required `complete=true`, causing shared CI failures affecting #2856, #2899, and #2914.

Align the Python expectations with that partial-statistics contract. Cover both sparse index variants with and without reranking, verify result values and legacy tuple equivalence, retain exact rerank counts and phase/backend/type consistency checks, and verify an absent-term query remains complete with zero evaluations. A short comment records the intentional semantics.

## Test Evidence

- [x] Other: fresh Release Python binding built from this checkout with `make release VSAG_ENABLE_PYBINDS=ON COMPILE_JOBS=48` and an isolated Python 3.11 environment.
- Original test reproduced the `False is True` failure using that fresh binding.
- `python -m pytest tests/python/test_sindi.py -q`: **4 passed**.
- `python -m pytest tests/python -q`: **113 passed**, 3 existing collection warnings.
- `git diff --check`: passed.

Local validation used Python 3.11.16, NumPy 1.26.4, and pytest 9.1.1. NumPy 2.4.6 initially crashed during native module import before test execution; NumPy 1.26.4 worked with the repository's pybind11 2.11.1. Exact clang-format/tidy 15 are unavailable locally; normal PR CI remains enabled for required checks.

## Compatibility Impact

No API/ABI or production behavior changes. This updates test expectations to match the already documented English and Chinese contract.

## Performance and Concurrency Impact

None. No hot-path tracking or counters are restored; candidate deduplication and reranking remain unchanged.

## Documentation Impact

- [x] No docs update needed: #2873 already updated both API translations.

## Risk and Rollback

Low risk; test-only change. Revert this commit if needed.

## Checklist

- [x] Linked the relevant issue.
- [x] Updated regression coverage.
- [x] Considered API compatibility and documentation impact.
- [x] One Conventional Commit with human DCO sign-off and AI assistance attribution.
