### PR TITLE
fix(test): stabilize IVF centroid scan ordering fixture

### DIFF
--- a/src/algorithm/ivf/ivf_nearest_partition_test.cpp
+++ b/src/algorithm/ivf/ivf_nearest_partition_test.cpp
@@ -173,21 +173,39 @@ TEST_CASE("IVF Nearest Partition Centroid Scan Test", "[ut][IVFNearestPartition]
         REQUIRE(untrained_restored->ClassifyDatas(nullptr, 1, buckets_per_data, nullptr) ==
                 untrained_result);
 
-        auto vectors = fixtures::generate_vectors(data_count, dim, true, 95);
+        // KMeans sees exactly bucket_count distinct points, so initialization only permutes
+        // the centroids. Powers of two on separate axes keep L2 arithmetic exact and cosine
+        // centroids unit length. Random centroids can produce near-ties that BLAS and the
+        // independent SIMD distance oracle round differently.
+        std::vector<float> vectors(data_count * dim, 0.0F);
+        for (int64_t i = 0; i < data_count; ++i) {
+            const auto axis = i % bucket_count;
+            vectors[i * dim + axis] = static_cast<float>(1 << (axis % 4));
+        }
         auto dataset = Dataset::Make();
         dataset->Float32Vectors(vectors.data())->Dim(dim)->NumElements(data_count)->Owner(false);
         partition->Train(dataset);
         REQUIRE(partition->route_index_ptr_ == nullptr);
 
+        // Exercise different norms, signs and query directions, including exact ties. These
+        // queries are separate from the training points and retain exact bucket-ID checks.
+        std::vector<float> queries(data_count * dim, 0.0F);
+        for (int64_t i = 1; i < data_count; ++i) {
+            const auto scale = static_cast<float>(1 + i / bucket_count);
+            for (int64_t j = 0; j < buckets_per_data; ++j) {
+                queries[i * dim + (i + j) % bucket_count] =
+                    scale * static_cast<float>(j + 1) * (i % 2 == 0 ? 0.25F : -0.25F);
+            }
+        }
         auto actual =
-            partition->ClassifyDatas(vectors.data(), data_count, buckets_per_data, nullptr);
+            partition->ClassifyDatas(queries.data(), data_count, buckets_per_data, nullptr);
         REQUIRE(actual.size() == static_cast<uint64_t>(data_count * buckets_per_data));
 
         Vector<float> centroid(dim, allocator.get());
         Vector<float> normalized_query(dim, allocator.get());
         Vector<std::pair<float, BucketIdType>> expected(bucket_count, allocator.get());
         for (int64_t i = 0; i < data_count; ++i) {
-            const auto* query = vectors.data() + i * dim;
+            const auto* query = queries.data() + i * dim;
             if (metric == MetricType::METRIC_TYPE_COSINE) {
                 Normalize(query, normalized_query.data(), dim);
                 query = normalized_query.data();
@@ -204,6 +222,7 @@ TEST_CASE("IVF Nearest Partition Centroid Scan Test", "[ut][IVFNearestPartition]
             }
             std::sort(expected.begin(), expected.end());
             for (BucketIdType j = 0; j < buckets_per_data; ++j) {
+                CAPTURE(static_cast<int>(metric), i, j);
                 REQUIRE(actual[i * buckets_per_data + j] == expected[j].second);
             }
         }
@@ -214,7 +233,7 @@ TEST_CASE("IVF Nearest Partition Centroid Scan Test", "[ut][IVFNearestPartition]
             std::make_unique<IVFNearestPartition>(bucket_count, common_param, graph_config_param);
         test_serializion(*partition, *restored);
         REQUIRE(restored->route_index_ptr_ == nullptr);
-        REQUIRE(restored->ClassifyDatas(vectors.data(), data_count, buckets_per_data, nullptr) ==
+        REQUIRE(restored->ClassifyDatas(queries.data(), data_count, buckets_per_data, nullptr) ==
                 actual);
     }
 }


### PR DESCRIPTION
## What changed

The centroid-scan regression compares exact bucket order from BLAS routing with independently computed SIMD distances. Its seeded input still undergoes unseeded KMeans training, which can produce near-ties that the two kernels round differently. A captured current-main failure returns bucket 4 before 8: BLAS gives both distance `0.17414480447769165`, while AVX512 gives `0.1741449236869812` and `0.17414474487304688`. Replaying the saved trained layout and query batch reproduces the assertion without retraining; SSE also distinguishes this pair.

Use repeated, distinct axis-aligned training points with power-of-two magnitudes, plus separate signed queries with varying norms. KMeans initialization can permute these centroids without changing their geometry. L2 arithmetic remains exact, and cosine centroids normalize to unit axes. Keep every exact bucket-ID assertion, including ties, all three metrics, and serialization checks. Add failure context for metric/query/rank. No production routing or I/O semantics change.

Fixes: #2881
Fixes: #2911

Both trackers report this same unchanged test and assertion on SSE/AArch64. The independent HGraph signature in #2911 was already fixed by merged #2877 (`44e5b072`); the reported failing commit predates that merge. #2918 separately handles the accepted-task draining failure in #2916 and is not duplicated here.

## Validation

- Fresh Release build with libaio disabled; build parallelism capped at 24.
- Original fixture failed on run 16; saved-layout API replay reproduces `4 == 8` deterministically. Scalar/SSE/AVX512 kernel comparisons isolate FP32 rounding and tie-breaking.
- Updated centroid regression: 30 consecutive passes, 3,093 assertions each.
- All nearest-partition tests: 5 cases, 5,106 assertions passed.
- Same compiled centroid regression in a focused runner with SSE and scalar FP32/normalization dispatch: 3,093 assertions passed per configuration. These are focused kernel checks, not full platform builds.
- HGraph no-libaio mapper regression: 13 assertions passed.
- `git diff --check` passed. Exact clang-format/tidy 15 unavailable locally; normal CI remains enabled.

Risk is limited to a test fixture. API, serialization format, production behavior, and documentation are unchanged.

## Review and CI follow-up

All five inline review threads were checked against the fixed fixture constants and zero-safe normalization implementation, answered, and resolved without code changes. The TSan failure matches the historical race in #2705; [the full-stack comparison](https://github.com/antgroup/vsag/issues/2705#issuecomment-5618010353) is recorded there. Only the failed TSan test job was requested for one rerun. #2915 now links this PR as the shared IVF assertion fix.
