### PR TITLE
refactor(hgraph): deserialize streaming blocks forward-only

### DIFF
--- a/docs/docs/en/src/advanced/new_serialization.md
+++ b/docs/docs/en/src/advanced/new_serialization.md
@@ -165,8 +165,15 @@ HGraph writes these streaming blocks in order:
 `DeserializeStreaming` restores the full in-memory index. `Load` loads HGraph blocks into memory by
 default. Load parameters can set `precise_io_type` to override the IO type for `precise_codes`. If
 they also provide `precise_reader`, and that reader size matches the `high_precision_codes` payload
-size, `Load` validates the external reader payload checksum and then binds reorder codes to that
-reader.
+size, `Load` binds reorder codes to that reader and validates its payload checksum before returning
+the index.
+
+HGraph parses known block payloads directly with forward reads and skips, without payload-sized
+buffers or temporary files. Skipped bytes are included in incremental checksum validation; any
+unconsumed suffix is drained with an 8 KiB buffer after component deserialization succeeds.
+Checksum validation may finish after component state has changed. If `DeserializeStreaming`
+fails, discard the target index; it must not be queried or reused. Other index types still use
+their existing block readers.
 
 ## IVF Blocks
 

--- a/docs/docs/zh/src/advanced/new_serialization.md
+++ b/docs/docs/zh/src/advanced/new_serialization.md
@@ -147,7 +147,12 @@ HGraph 按顺序写入以下 streaming blocks：
 `DeserializeStreaming` 会恢复完整的内存索引。`Load` 默认把 HGraph blocks 加载到内存中；如果
 load parameters 中设置 `precise_io_type`，可以覆盖 `precise_codes` 的 IO 类型。如果同时提供
 `precise_reader`，并且该 reader 大小与 `high_precision_codes` payload 大小一致，`Load` 会校验该外部
-reader 的 payload checksum，然后将 reorder codes 绑定到该 reader。
+reader 的 payload checksum，并在返回索引前完成校验；reorder codes 的绑定可能先于校验完成。
+
+HGraph 直接使用向前读取和跳过操作解析已知 block payload，不使用与 payload 等大的缓冲区或
+临时文件。跳过的字节也参与增量 checksum 校验；组件反序列化成功后，使用 8 KiB 缓冲区消费
+未读取的尾部。校验完成时组件状态可能已被修改，因此 `DeserializeStreaming` 失败后必须丢弃
+目标索引，不得查询或复用。其他索引类型暂时保留现有 block reader。
 
 ## IVF Blocks
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -1,0 +1,52 @@
+# Streaming block reader microbenchmark
+
+This Linux-only diagnostic compares the legacy materializing TLV reader and the forward-only reader used by HGraph. It does **not** measure complete HGraph loading or search performance.
+
+Build the library first, then compile against the same library build:
+
+```sh
+g++ -std=c++17 -O2 -Iinclude -Isrc \
+  -Ibuild/_deps/fmt-src/include -Ibuild/_deps/nlohmann_json-src/include \
+  -Ibuild/_deps/tsl-src/include scripts/benchmarks/streaming_block_reader.cpp \
+  -Lbuild/src -Wl,-rpath,"$PWD/build/src" -lvsag -o /tmp/streaming-block-benchmark
+for mode in legacy forward legacy forward legacy forward; do
+  /tmp/streaming-block-benchmark "$mode"
+done
+```
+
+The input is a generated 129 MiB zero-filled payload, above the configured 128 MiB block limit. The callback consumes every byte through an 8 KiB buffer. Each sample runs in a fresh process; input generation and expected-checksum calculation happen before timing. `getrusage` measures the increase in peak RSS (KiB) and output blocks (512-byte units). A zero RSS delta means no new process high-water mark was observed, not zero allocation. Output blocks measure OS-accounted storage writes, not logical write calls; results depend on the temporary-filesystem backend.
+
+## Local observation, 2026-09-10
+
+Base commit `b144589fc1` with the HGraph forward-reader worktree changes; Linux x86-64, AMD EPYC 9T24, Debug library, no coverage instrumentation. Other test/build work ran concurrently, so timings are indicative only.
+
+| Adapter | Seconds, three runs | Peak RSS increase | Output bytes per run |
+| --- | --- | --- | --- |
+| Legacy | 4.51888, 4.53509, 4.53647 | 133816–133876 KiB | 135266304 |
+| Forward | 4.44432, 4.42120, 4.43077 | 0 KiB observed | 0 |
+
+Both paths read exactly 135266304 bytes from the generated source. The evidence supports removal of payload staging and temporary writes; it is not an end-to-end speedup claim. The legacy helper remains because other indexes still depend on it.
+
+## Real HGraph streaming-load comparison
+
+`hgraph_streaming_load.cpp` creates a streaming artifact with 1024 vectors (dimension 4) and 131073 bytes of extra information per vector. `legacy_streaming_block_shim.cpp` is a Linux `LD_PRELOAD` adapter which routes calls to the new helper through the still-existing legacy helper. Thus both modes use identical component parsers and the same artifact, isolating the effect of block materialization. This is not a comparison against a complete historical checkout. The shim logs payload lengths so its activation is observable; it is only for this benchmark, never for production.
+
+```sh
+g++ -std=c++17 -O2 -Iinclude scripts/benchmarks/hgraph_streaming_load.cpp \
+  -Lbuild/src -Wl,-rpath,"$PWD/build/src" -lvsag -o /tmp/hgraph-streaming-benchmark
+g++ -std=c++17 -O2 -fPIC -shared -Iinclude -Isrc \
+  -Ibuild/_deps/fmt-src/include -Ibuild/_deps/nlohmann_json-src/include \
+  -Ibuild/_deps/tsl-src/include scripts/benchmarks/legacy_streaming_block_shim.cpp \
+  -Lbuild/src -lvsag -o /tmp/legacy-streaming-block-shim.so
+benchmark_dir=$(mktemp -d /tmp/vsag-streaming-benchmark.XXXXXX)
+export GCOV_PREFIX="$benchmark_dir/profiles"
+export OPENBLAS_NUM_THREADS=1
+/tmp/hgraph-streaming-benchmark create "$benchmark_dir/hgraph.stream"
+for iteration in 1 2 3; do
+  LD_PRELOAD=/tmp/legacy-streaming-block-shim.so \
+    /tmp/hgraph-streaming-benchmark load "$benchmark_dir/hgraph.stream"
+  /tmp/hgraph-streaming-benchmark load "$benchmark_dir/hgraph.stream"
+done
+```
+
+The local artifact was 134329419 bytes; its extra-info block was 134218776 bytes, exceeding the 134217728-byte limit. Every successful load restored 1024 elements. With the Debug **coverage-instrumented** library (unlike the microbenchmark above), observed old-helper loads took 4.33437, 4.33281 and 4.33939 seconds, increased peak RSS by 663360–663364 KiB and wrote 134221824 bytes each. Forward loads took 4.25345, 4.26048 and 4.24500 seconds, increased peak RSS by 532456–532460 KiB and wrote zero bytes. RSS here includes the restored index and ordinary component buffers; the approximately 128 MiB difference isolates the removed staging buffer. Profiling output is redirected outside the unit-test coverage tree and is written after the measured interval. These warm-cache, concurrent-work measurements demonstrate resource savings, not a production latency guarantee.

--- a/scripts/benchmarks/hgraph_streaming_load.cpp
+++ b/scripts/benchmarks/hgraph_streaming_load.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026-present the vsag project
+// Linux-only benchmark support; see README.md for scope and invocation.
+#include <sys/resource.h>
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include "vsag/vsag.h"
+
+int
+main(int argc, char** argv) {
+    if (argc != 3)
+        return 2;
+    vsag::Options::Instance().set_block_size_limit(128ULL * 1024 * 1024);
+    if (std::string(argv[1]) == "create") {
+        constexpr int64_t count = 1024, dim = 4, extra_size = 131073;
+        auto index = vsag::Factory::CreateIndex("hgraph", R"({"dtype":"float32",
+          "metric_type":"l2","dim":4,"extra_info_size":131073,"index_param":{
+          "base_quantization_type":"fp32","max_degree":16,"ef_construction":32,
+          "build_thread_count":1}})");
+        if (!index) {
+            std::cerr << index.error().message;
+            return 1;
+        }
+        std::vector<int64_t> ids(count);
+        std::iota(ids.begin(), ids.end(), 0);
+        std::vector<float> vectors(count * dim);
+        for (uint64_t i = 0; i < vectors.size(); ++i) vectors[i] = float(i % 103);
+        std::vector<char> extra(count * extra_size, 'x');
+        auto base = vsag::Dataset::Make();
+        base->NumElements(count)
+            ->Dim(dim)
+            ->Ids(ids.data())
+            ->Float32Vectors(vectors.data())
+            ->ExtraInfos(extra.data())
+            ->Owner(false);
+        auto built = index.value()->Build(base);
+        if (!built) {
+            std::cerr << built.error().message;
+            return 1;
+        }
+        std::ofstream output(argv[2], std::ios::binary);
+        auto written = index.value()->SerializeStreaming(output);
+        if (!written) {
+            std::cerr << written.error().message;
+            return 1;
+        }
+        std::cout << "artifact_bytes=" << output.tellp() << '\n';
+        return 0;
+    }
+    std::ifstream input(argv[2], std::ios::binary);
+    rusage before{}, after{};
+    getrusage(RUSAGE_SELF, &before);
+    auto start = std::chrono::steady_clock::now();
+    auto index = vsag::Index::Load(input, "{}");
+    auto seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+    getrusage(RUSAGE_SELF, &after);
+    if (!index) {
+        std::cerr << index.error().message;
+        return 1;
+    }
+    std::cout << "load_seconds=" << seconds << " elements=" << index.value()->GetNumElements()
+              << " peak_rss_delta_kib=" << after.ru_maxrss - before.ru_maxrss
+              << " output_bytes=" << (after.ru_oublock - before.ru_oublock) * 512 << '\n';
+}

--- a/scripts/benchmarks/legacy_streaming_block_shim.cpp
+++ b/scripts/benchmarks/legacy_streaming_block_shim.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026-present the vsag project
+// Linux-only benchmark support; see README.md for scope and invocation.
+#include <iostream>
+
+#include "storage/tlv_section.h"
+namespace vsag {
+void
+ReadForwardBlockPayload(StreamReader& reader,
+                        const StreamBlockHeader& header,
+                        const std::function<void(StreamReader&)>& deserialize) {
+    std::cerr << "legacy_adapter_payload_bytes=" << header.value_len << '\n';
+    ReadSeekableBlockPayload(reader, header, deserialize);
+}
+}  // namespace vsag

--- a/scripts/benchmarks/streaming_block_reader.cpp
+++ b/scripts/benchmarks/streaming_block_reader.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026-present the vsag project
+// Linux-only adapter microbenchmark; see README.md for scope and invocation.
+#include <sys/resource.h>
+
+#include <array>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+
+#include "storage/serialization.h"
+#include "storage/tlv_section.h"
+#include "vsag/options.h"
+
+int
+main(int argc, char** argv) {
+    if (argc != 2)
+        return 2;
+    constexpr uint64_t size = 129ULL * 1024 * 1024;
+    vsag::Options::Instance().set_block_size_limit(128ULL * 1024 * 1024);
+    std::array<char, 8192> chunk{};
+    uint32_t crc = vsag::StreamHeader::InitialChecksum();
+    for (uint64_t offset = 0; offset < size; offset += chunk.size()) {
+        crc = vsag::StreamHeader::UpdateChecksum(crc, {chunk.data(), chunk.size()});
+    }
+    vsag::StreamBlockHeader header;
+    header.value_len = size;
+    header.payload_checksum = vsag::StreamHeader::FinalizeChecksum(crc);
+    uint64_t source_bytes = 0;
+    vsag::ReadFuncStreamReader source(
+        [&](uint64_t, uint64_t count, void* destination) {
+            std::memset(destination, 0, count);
+            source_bytes += count;
+        },
+        0,
+        size);
+    auto consume = [&](vsag::StreamReader& block) {
+        for (uint64_t offset = 0; offset < size; offset += chunk.size()) {
+            block.Read(chunk.data(), chunk.size());
+        }
+    };
+    rusage before{}, after{};
+    getrusage(RUSAGE_SELF, &before);
+    const auto start = std::chrono::steady_clock::now();
+    if (std::string(argv[1]) == "legacy") {
+        vsag::ReadSeekableBlockPayload(source, header, consume);
+    } else {
+        vsag::ReadForwardBlockPayload(source, header, consume);
+    }
+    const auto seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - start);
+    getrusage(RUSAGE_SELF, &after);
+    std::cout << argv[1] << " seconds=" << seconds.count()
+              << " rss_peak_delta_kib=" << after.ru_maxrss - before.ru_maxrss
+              << " block_output_bytes=" << (after.ru_oublock - before.ru_oublock) * 512
+              << " source_bytes=" << source_bytes << '\n';
+}

--- a/src/algorithm/hgraph/hgraph_serialize.cpp
+++ b/src/algorithm/hgraph/hgraph_serialize.cpp
@@ -15,7 +15,6 @@
 #include <fmt/format.h>
 
 #include <algorithm>
-#include <array>
 #include <limits>
 
 #include "common.h"
@@ -48,85 +47,6 @@ dump_basic_info_for_log(const JsonType& basic_info) {
     }
     return log_basic_info.Dump(4);
 }
-
-class PayloadChecksumStreamReader : public StreamReader {
-public:
-    PayloadChecksumStreamReader(StreamReader& reader, const StreamBlockHeader& header)
-        : StreamReader(header.value_len),
-          reader_(reader),
-          expected_checksum_(header.payload_checksum) {
-    }
-
-    void
-    Read(char* data, uint64_t size) override {
-        const auto cursor = reader_.GetCursor();
-        if (cursor > length_ || size > length_ - cursor) {
-            throw VsagException(ErrorType::READ_ERROR,
-                                "checksum stream reader exceeds payload boundary");
-        }
-        if (cursor > checksum_cursor_) {
-            checksum_range(checksum_cursor_, cursor - checksum_cursor_);
-        }
-
-        reader_.Read(data, size);
-        if (cursor + size > checksum_cursor_) {
-            const auto checksum_offset = checksum_cursor_ > cursor ? checksum_cursor_ - cursor : 0;
-            const auto checksum_size = size - checksum_offset;
-            crc_ = StreamHeader::UpdateChecksum(
-                crc_, std::string_view(data + checksum_offset, checksum_size));
-            checksum_cursor_ += checksum_size;
-        }
-    }
-
-    void
-    Seek(uint64_t cursor) override {
-        if (cursor > length_) {
-            throw VsagException(ErrorType::READ_ERROR,
-                                "checksum stream reader seek exceeds payload boundary");
-        }
-        reader_.Seek(cursor);
-    }
-
-    [[nodiscard]] uint64_t
-    GetCursor() const override {
-        return reader_.GetCursor();
-    }
-
-    void
-    Validate() {
-        if (checksum_cursor_ < length_) {
-            checksum_range(checksum_cursor_, length_ - checksum_cursor_);
-        }
-        if (StreamHeader::FinalizeChecksum(crc_) != expected_checksum_) {
-            throw VsagException(ErrorType::INVALID_BINARY,
-                                "streaming block payload checksum mismatch");
-        }
-    }
-
-private:
-    void
-    checksum_range(uint64_t offset, uint64_t size) {
-        constexpr uint64_t k_buffer_size = 8192;
-        std::array<char, k_buffer_size> buffer{};
-        const auto original_cursor = reader_.GetCursor();
-        reader_.Seek(offset);
-        uint64_t remaining = size;
-        while (remaining > 0) {
-            const auto read_size = std::min<uint64_t>(remaining, k_buffer_size);
-            reader_.Read(buffer.data(), read_size);
-            crc_ = StreamHeader::UpdateChecksum(crc_, std::string_view(buffer.data(), read_size));
-            remaining -= read_size;
-        }
-        checksum_cursor_ += size;
-        reader_.Seek(original_cursor);
-    }
-
-private:
-    StreamReader& reader_;
-    uint32_t expected_checksum_{0};
-    uint32_t crc_{StreamHeader::InitialChecksum()};
-    uint64_t checksum_cursor_{0};
-};
 
 }  // namespace
 
@@ -709,7 +629,7 @@ HGraph::read_streaming_body(StreamReader& reader,
 
         switch (static_cast<StreamSerializationTag>(block_header.tag)) {
             case StreamSerializationTag::LABEL_TABLE:
-                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                ReadForwardBlockPayload(block_reader, block_header, [this](StreamReader& block) {
                     this->deserialize_label_info_streaming(block);
                 });
                 loaded_label_table = true;
@@ -720,19 +640,19 @@ HGraph::read_streaming_body(StreamReader& reader,
                         ErrorType::INVALID_BINARY,
                         "HGraph streaming serialization has an unexpected code slot map block");
                 }
-                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                ReadForwardBlockPayload(block_reader, block_header, [this](StreamReader& block) {
                     this->code_slot_map_->Deserialize(block);
                 });
                 loaded_code_slot_map = true;
                 break;
             case StreamSerializationTag::BASE_CODES:
-                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                ReadForwardBlockPayload(block_reader, block_header, [this](StreamReader& block) {
                     this->basic_flatten_codes_->Deserialize(block);
                 });
                 loaded_base_codes = true;
                 break;
             case StreamSerializationTag::BOTTOM_GRAPH:
-                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                ReadForwardBlockPayload(block_reader, block_header, [this](StreamReader& block) {
                     this->bottom_graph_->Deserialize(block);
                 });
                 loaded_bottom_graph = true;
@@ -761,11 +681,12 @@ HGraph::read_streaming_body(StreamReader& reader,
                         block_reader.SkipRemaining();
                         this->SetPreciseCodesIO(reader_ptr);
                         ReadFuncStreamReader external_reader(read_func, 0, reader_ptr->Size());
-                        PayloadChecksumStreamReader checksum_reader(external_reader, block_header);
-                        this->high_precise_codes_->Deserialize(checksum_reader);
-                        checksum_reader.Validate();
+                        ReadForwardBlockPayload(
+                            external_reader, block_header, [this](StreamReader& block) {
+                                this->high_precise_codes_->Deserialize(block);
+                            });
                     } else {
-                        ReadSeekableBlockPayload(
+                        ReadForwardBlockPayload(
                             block_reader, block_header, [this](StreamReader& block) {
                                 this->high_precise_codes_->Deserialize(block);
                             });
@@ -774,7 +695,7 @@ HGraph::read_streaming_body(StreamReader& reader,
                 }
                 break;
             case StreamSerializationTag::ROUTE_GRAPHS:
-                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                ReadForwardBlockPayload(block_reader, block_header, [this](StreamReader& block) {
                     for (auto& route_graph : this->route_graphs_) {
                         route_graph->Deserialize(block);
                     }
@@ -783,7 +704,7 @@ HGraph::read_streaming_body(StreamReader& reader,
                 break;
             case StreamSerializationTag::EXTRA_INFO:
                 if (this->extra_info_size_ > 0 && this->extra_infos_ != nullptr) {
-                    ReadSeekableBlockPayload(
+                    ReadForwardBlockPayload(
                         block_reader, block_header, [this](StreamReader& block) {
                             this->extra_infos_->Deserialize(block);
                         });
@@ -792,7 +713,7 @@ HGraph::read_streaming_body(StreamReader& reader,
                 break;
             case StreamSerializationTag::ATTRIBUTE_FILTER:
                 if (this->use_attribute_filter_ && this->attr_filter_index_ != nullptr) {
-                    ReadSeekableBlockPayload(
+                    ReadForwardBlockPayload(
                         block_reader, block_header, [this](StreamReader& block) {
                             this->attr_filter_index_->Deserialize(block);
                         });
@@ -801,7 +722,7 @@ HGraph::read_streaming_body(StreamReader& reader,
                 break;
             case StreamSerializationTag::RAW_VECTOR:
                 if (create_new_raw_vector_) {
-                    ReadSeekableBlockPayload(
+                    ReadForwardBlockPayload(
                         block_reader, block_header, [this](StreamReader& block) {
                             this->raw_vector_->Deserialize(block);
                         });
@@ -814,7 +735,7 @@ HGraph::read_streaming_body(StreamReader& reader,
                         ErrorType::INVALID_ARGUMENT,
                         "serialized HGraph uses conjugate graph but the target does not");
                 }
-                ReadSeekableBlockPayload(block_reader, block_header, [this](StreamReader& block) {
+                ReadForwardBlockPayload(block_reader, block_header, [this](StreamReader& block) {
                     std::unique_lock graph_lock(this->conjugate_graph_mutex_);
                     auto result = this->conjugate_graph_->Deserialize(block);
                     if (not result) {

--- a/src/algorithm/hgraph/hgraph_streaming_test.cpp
+++ b/src/algorithm/hgraph/hgraph_streaming_test.cpp
@@ -1,0 +1,100 @@
+// Copyright 2026-present the vsag project
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstring>
+#include <sstream>
+#include <vector>
+
+#include "storage/streaming_serialization_test_utils.h"
+#include "unittest.h"
+#include "vsag/vsag.h"
+
+namespace vsag {
+
+TEST_CASE("HGraph forward block entry points", "[ut][hgraph][streaming_serialization]") {
+    const bool reorder = GENERATE(false, true);
+    const bool deduplicate = GENERATE(false, true);
+    const auto param = JsonType::Parse(R"({
+        "dtype":"float32", "metric_type":"l2", "dim":16, "extra_info_size":8,
+        "index_param": {
+            "base_quantization_type":"sq8", "precise_quantization_type":"fp32",
+            "use_attribute_filter":true, "store_raw_vector":true,
+            "persist_source_id":true, "use_conjugate_graph":true,
+            "build_thread_count":1, "max_degree":8, "ef_construction":32
+        }
+    })");
+    auto parameters = param;
+    parameters["index_param"]["use_reorder"].SetBool(reorder);
+    parameters["index_param"]["support_duplicate"].SetBool(deduplicate);
+    parameters["index_param"]["deduplicate_storage"].SetBool(deduplicate);
+    const auto parameter_string = parameters.Dump();
+    constexpr int64_t count = 16;
+    std::vector<int64_t> ids(count);
+    std::vector<float> vectors(count * 16);
+    std::vector<char> extra(count * 8, 'x');
+    std::vector<std::string> sources(count);
+    std::vector<AttributeSet> attributes(count);
+    std::vector<AttributeValue<std::string>> values(count);
+    for (uint64_t i = 0; i < count; ++i) {
+        ids[i] = static_cast<int64_t>(i);
+        sources[i] = std::to_string(i);
+        values[i].name_ = "group";
+        values[i].GetValue() = {"allowed"};
+        attributes[i].attrs_.push_back(&values[i]);
+        for (uint64_t d = 0; d < 16; ++d) {
+            vectors[i * 16 + d] = static_cast<float>(i + d);
+        }
+    }
+    auto base = Dataset::Make();
+    base->NumElements(count)
+        ->Dim(16)
+        ->Ids(ids.data())
+        ->Float32Vectors(vectors.data())
+        ->ExtraInfos(extra.data())
+        ->SourceID(sources.data())
+        ->AttributeSets(attributes.data())
+        ->Owner(false);
+    auto created = Factory::CreateIndex("hgraph", parameter_string);
+    REQUIRE(created.has_value());
+    REQUIRE(created.value()->Build(base).has_value());
+    std::stringstream output;
+    REQUIRE(created.value()->SerializeStreaming(output).has_value());
+    const auto bytes = output.str();
+    auto restored = Factory::CreateIndex("hgraph", parameter_string);
+    REQUIRE(restored.has_value());
+    std::istringstream input(bytes);
+    REQUIRE(restored.value()->DeserializeStreaming(input).has_value());
+    REQUIRE(restored.value()->GetNumElements() == count);
+
+    LoadParameters load_parameters;
+    if (reorder) {
+        const auto block =
+            test::FindStreamingBlock(bytes, StreamSerializationTag::HIGH_PRECISION_CODES);
+        auto payload =
+            std::make_shared<std::string>(bytes.substr(block.payload_offset, block.payload_size));
+        auto external = Factory::CreateReadFuncReader(
+            [payload](uint64_t offset, uint64_t length, void* dest) {
+                std::memcpy(dest, payload->data() + offset, length);
+            },
+            payload->size());
+        load_parameters.Set("precise_io_type", "reader_io").SetReader("precise_reader", external);
+    }
+    std::istringstream load_input(bytes);
+    auto loaded = Index::Load(load_input, load_parameters);
+    REQUIRE(loaded.has_value());
+    auto query = Dataset::Make();
+    query->NumElements(1)->Dim(16)->Float32Vectors(vectors.data())->Owner(false);
+    const auto search_parameters = R"({"hgraph":{"ef_search":32}})";
+    auto expected = created.value()->KnnSearch(query, 5, search_parameters);
+    REQUIRE(expected.has_value());
+    for (const auto& candidate : {restored.value(), loaded.value()}) {
+        auto result = candidate->KnnSearch(query, 5, search_parameters);
+        REQUIRE(result.has_value());
+        REQUIRE(result.value()->GetDim() == expected.value()->GetDim());
+        for (int64_t i = 0; i < result.value()->GetDim(); ++i) {
+            REQUIRE(result.value()->GetIds()[i] == expected.value()->GetIds()[i]);
+        }
+    }
+}
+
+}  // namespace vsag

--- a/src/datacell/flatten_datacell_test.cpp
+++ b/src/datacell/flatten_datacell_test.cpp
@@ -905,6 +905,23 @@ TEST_CASE("RaBitQSplitDataCell fused model-only serialization",
     split->TrainFusedCodec(vectors.data(), count, cluster_count);
 
     const auto legacy_payload = serialize_flatten(flatten);
+    // The current split format remains supported without fused storage. Invalid IO fields must
+    // fail instead of rewinding to the unpublished format that omitted the field.
+    auto ordinary_restored = FlattenInterface::MakeInstance(param, common_param);
+    REQUIRE_NOTHROW(deserialize_flatten(ordinary_restored, legacy_payload));
+    const uint64_t io_offset = 2 * sizeof(InnerIdType) + sizeof(uint32_t);
+    for (uint64_t invalid_length : {uint64_t{65}, std::numeric_limits<uint64_t>::max()}) {
+        auto invalid = legacy_payload;
+        std::memcpy(invalid.data() + io_offset, &invalid_length, sizeof(invalid_length));
+        auto rejected = FlattenInterface::MakeInstance(param, common_param);
+        REQUIRE_THROWS_AS(deserialize_flatten(rejected, invalid), VsagException);
+    }
+    auto invalid_type = legacy_payload;
+    const uint64_t invalid_type_length = 3;
+    std::memcpy(invalid_type.data() + io_offset, &invalid_type_length, sizeof(invalid_type_length));
+    std::memcpy(invalid_type.data() + io_offset + sizeof(uint64_t), "bad", invalid_type_length);
+    auto rejected_type = FlattenInterface::MakeInstance(param, common_param);
+    REQUIRE_THROWS_AS(deserialize_flatten(rejected_type, invalid_type), VsagException);
     const uint64_t memory_with_split_codes = flatten->GetMemoryUsage();
     const uint64_t code_payload_size =
         static_cast<uint64_t>(count) * (split->OneBitCodeSize() + split->SupplementCodeSize());
@@ -980,6 +997,9 @@ TEST_CASE("RaBitQSplitDataCell fused model-only serialization",
         REQUIRE(std::abs(expected_distances[id] - model_distances[id]) <= 1e-6F);
     }
 
+    // Review pending (#2582): the legacy split-to-fused fallback is disabled for forward-only
+    // loading. Preserve the old compatibility assertions until its removal is confirmed.
+    /*
     auto [legacy_flatten, legacy_split, legacy_graph] = make_attached_pair();
     deserialize_flatten(legacy_flatten, legacy_payload);
     deserialize_graph(legacy_graph, graph_payload);
@@ -1000,6 +1020,9 @@ TEST_CASE("RaBitQSplitDataCell fused model-only serialization",
     for (InnerIdType id = 0; id < count; ++id) {
         REQUIRE(std::abs(expected_distances[id] - legacy_distances[id]) <= 1e-6F);
     }
+    */
+    auto rejected = make_attached_pair();
+    REQUIRE_THROWS_AS(deserialize_flatten(std::get<0>(rejected), legacy_payload), VsagException);
 }
 
 TEST_CASE("RaBitQSplitDataCell supports MRLE transform quantizer",

--- a/src/datacell/rabitq_split_datacell.h
+++ b/src/datacell/rabitq_split_datacell.h
@@ -1649,7 +1649,9 @@ public:
     Deserialize(LvalueOrRvalue<StreamReader> reader) override {
         FlattenInterface::Deserialize(reader);
         if (this->fused_code_storage_ != nullptr) {
-            const uint64_t payload_cursor = reader->GetCursor();
+            // Review pending (#2582): disable the legacy split-payload fallback below so fused
+            // deserialization does not require rewinding. Keep the old code for removal review.
+            // const uint64_t payload_cursor = reader->GetCursor();
             uint64_t magic = 0;
             StreamReader::ReadObj(reader, magic);
             if (magic == kFusedModelMagic) {
@@ -1672,6 +1674,11 @@ public:
                                "serialized fused RaBitQ code sizes do not match the node layout");
                 return;
             }
+            // Review pending (#2582): accepting legacy split payloads in fused mode requires
+            // rewind/seek compatibility. Disable this path for forward-only loading; this also
+            // affects ordinary Deserialize(), not just streaming. Retain until review confirms
+            // whether these old artifacts may be rejected permanently.
+            /*
             reader->Seek(payload_cursor);
             this->DeserializeSupplementIOType(reader);
             auto skip_serialized_layout = [](StreamReader& stream) {
@@ -1692,6 +1699,9 @@ public:
                         this->supplement_code_size_,
                 "legacy split RaBitQ code sizes do not match the fused node layout");
             return;
+            */
+            throw VsagException(ErrorType::INVALID_BINARY,
+                                "legacy split payload is unsupported for fused RaBitQ storage");
         }
         this->DeserializeSupplementIOType(reader);
         this->x_bit_layout_->Deserialize(reader);
@@ -1918,7 +1928,10 @@ private:
     void
     DeserializeSupplementIOType(StreamReader& reader) {
         this->supplement_io_type_.clear();
-        const uint64_t cursor = reader.GetCursor();
+        // Review pending (#2582): disable missing-field compatibility for old snapshots to avoid
+        // rewinding. The current supplement_io_type field (including an empty string) is required
+        // by both ordinary and streaming Deserialize(). Keep fallback code for removal review.
+        // const uint64_t cursor = reader.GetCursor();
         uint64_t length = 0;
         StreamReader::ReadObj(reader, length);
 
@@ -1927,9 +1940,13 @@ private:
         }
 
         constexpr uint64_t kMaxIOTypeLength = 64;
-        if (length > kMaxIOTypeLength or reader.GetCursor() + length > reader.Length()) {
-            reader.Seek(cursor);
-            return;
+        if (length > kMaxIOTypeLength or reader.GetCursor() > reader.Length() or
+            length > reader.Length() - reader.GetCursor()) {
+            // Review pending (#2582): do not reinterpret an invalid length as a missing field.
+            // reader.Seek(cursor);
+            // return;
+            throw VsagException(ErrorType::INVALID_BINARY,
+                                "invalid RaBitQ supplement IO type length");
         }
 
         std::string io_type(length, '\0');
@@ -1939,7 +1956,9 @@ private:
             return;
         }
 
-        reader.Seek(cursor);
+        // Review pending (#2582): do not reinterpret an unknown IO type as a missing field.
+        // reader.Seek(cursor);
+        throw VsagException(ErrorType::INVALID_BINARY, "unknown RaBitQ supplement IO type");
     }
 
     void

--- a/src/impl/conjugate_graph.cpp
+++ b/src/impl/conjugate_graph.cpp
@@ -213,27 +213,25 @@ tl::expected<void, Error>
 ConjugateGraph::Deserialize(StreamReader& in_stream) {
     try {
         uint32_t offset = 0;
-        uint32_t footer_offset = 0;
         uint64_t neighbor_size = 0;
         int64_t from_tag_id = 0;
         int64_t to_tag_id = 0;
 
         conjugate_graph_.clear();
 
-        auto cur_pos = in_stream.GetCursor();
-
         read_var_from_stream(in_stream, &offset, &memory_usage_);
-        if (memory_usage_ <= FOOTER_SIZE) {
+        if (memory_usage_ < sizeof(memory_usage_) + FOOTER_SIZE) {
             throw VsagException(ErrorType::INVALID_BINARY,
                                 fmt::format("Incorrect header: memory_usage_({})", memory_usage_));
         }
-        footer_offset = memory_usage_ - FOOTER_SIZE;
-        in_stream.Seek(cur_pos + footer_offset);
-        footer_.Deserialize(in_stream);
-
-        offset = sizeof(memory_usage_);
-        in_stream.Seek(cur_pos + offset);
-        while (offset != memory_usage_ - FOOTER_SIZE) {
+        const uint32_t footer_offset = memory_usage_ - FOOTER_SIZE;
+        // The existing format stores the footer after all adjacency entries. Read it last so
+        // this component also works inside a forward-only streaming block.
+        while (offset < footer_offset) {
+            if (footer_offset - offset < sizeof(from_tag_id) + sizeof(neighbor_size)) {
+                throw VsagException(ErrorType::INVALID_BINARY,
+                                    "conjugate graph entry header overlaps footer");
+            }
             read_var_from_stream(in_stream, &offset, &from_tag_id);
             if (conjugate_graph_.count(from_tag_id) == 0) {
                 conjugate_graph_.emplace(from_tag_id,
@@ -241,11 +239,16 @@ ConjugateGraph::Deserialize(StreamReader& in_stream) {
             }
 
             read_var_from_stream(in_stream, &offset, &neighbor_size);
-            for (int i = 0; i < neighbor_size; i++) {
+            if (neighbor_size > (footer_offset - offset) / sizeof(to_tag_id)) {
+                throw VsagException(ErrorType::INVALID_BINARY,
+                                    "conjugate graph neighbors overlap footer");
+            }
+            for (uint64_t i = 0; i < neighbor_size; i++) {
                 read_var_from_stream(in_stream, &offset, &to_tag_id);
                 conjugate_graph_[from_tag_id]->insert(to_tag_id);
             }
         }
+        footer_.Deserialize(in_stream);
 
         return {};
     } catch (const std::runtime_error& e) {

--- a/src/impl/conjugate_graph_test.cpp
+++ b/src/impl/conjugate_graph_test.cpp
@@ -17,11 +17,84 @@
 
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <nlohmann/json.hpp>
+#include <sstream>
 
 #include "impl/allocator/safe_allocator.h"
 #include "storage/stream_reader.h"
 #include "unittest.h"
+
+TEST_CASE("ConjugateGraph forward-only deserialization", "[ut][ConjugateGraph]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::ConjugateGraph source(allocator.get());
+    const bool empty = GENERATE(false, true);
+    if (not empty) {
+        REQUIRE(source.AddNeighbor(1, 2).value());
+        REQUIRE(source.AddNeighbor(1, 3).value());
+        REQUIRE(source.AddNeighbor(4, 5).value());
+    }
+    std::ostringstream output;
+    REQUIRE(source.Serialize(output).has_value());
+    const auto payload = output.str();
+    std::ostringstream streaming_output;
+    vsag::IOStreamWriter writer(streaming_output);
+    source.Serialize(writer);
+    REQUIRE(streaming_output.str() == payload);
+    // Start at a nonzero offset and leave a suffix to verify exact payload consumption.
+    std::istringstream input("prefix" + payload + "suffix");
+    vsag::ForwardStreamReader reader(input);
+    char marker[6];
+    reader.Read(marker, sizeof(marker));
+    vsag::ConjugateGraph restored(allocator.get());
+    REQUIRE(restored.Deserialize(reader).has_value());
+    REQUIRE(reader.GetCursor() == sizeof(marker) + payload.size());
+    REQUIRE(restored.GetMemoryUsage() == source.GetMemoryUsage());
+    if (not empty) {
+        REQUIRE_FALSE(restored.AddNeighbor(1, 2).value());
+        REQUIRE_FALSE(restored.AddNeighbor(1, 3).value());
+        REQUIRE_FALSE(restored.AddNeighbor(4, 5).value());
+    }
+    reader.Read(marker, sizeof(marker));
+    REQUIRE(std::string(marker, sizeof(marker)) == "suffix");
+}
+
+TEST_CASE("ConjugateGraph rejects malformed forward-only payloads", "[ut][ConjugateGraph]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    vsag::ConjugateGraph source(allocator.get());
+    REQUIRE(source.AddNeighbor(1, 2).value());
+    std::ostringstream output;
+    REQUIRE(source.Serialize(output).has_value());
+    auto payload = output.str();
+    auto expected_error = vsag::ErrorType::INVALID_BINARY;
+    SECTION("header smaller than minimum payload") {
+        uint32_t size = vsag::FOOTER_SIZE + 1;
+        std::memcpy(payload.data(), &size, sizeof(size));
+    }
+    SECTION("entry header overlaps footer") {
+        uint32_t size = vsag::FOOTER_SIZE + sizeof(uint32_t) + 1;
+        std::memcpy(payload.data(), &size, sizeof(size));
+    }
+    SECTION("neighbor count overflows payload") {
+        uint64_t count = std::numeric_limits<uint64_t>::max();
+        std::memcpy(payload.data() + sizeof(uint32_t) + sizeof(int64_t), &count, sizeof(count));
+    }
+    SECTION("truncated footer") {
+        payload.pop_back();
+        expected_error = vsag::ErrorType::READ_ERROR;
+    }
+    SECTION("invalid footer") {
+        uint32_t size = vsag::FOOTER_SIZE;
+        std::memcpy(payload.data() + payload.size() - vsag::FOOTER_SIZE, &size, sizeof(size));
+    }
+    std::istringstream input(payload);
+    vsag::ForwardStreamReader reader(input);
+    vsag::ConjugateGraph restored(allocator.get());
+    const auto result = restored.Deserialize(reader);
+    REQUIRE_FALSE(result.has_value());
+    REQUIRE(result.error().type == expected_error);
+    REQUIRE(restored.GetMemoryUsage() == sizeof(uint32_t) + vsag::FOOTER_SIZE);
+}
 
 TEST_CASE("ConjugateGraph Build, Add and Memory Usage", "[ut][ConjugateGraph]") {
     auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();

--- a/src/io/core/byte_io.h
+++ b/src/io/core/byte_io.h
@@ -183,9 +183,9 @@ public:
         StreamReader::ReadObj(reader, size);
         const uint64_t serialized_start = reader.GetCursor();
         if constexpr (SkipDeserialize) {
-            const uint64_t serialized_end = CheckedEnd(serialized_start, size);
+            (void)CheckedEnd(serialized_start, size);
             uint64_t old_size = Size();
-            reader.Seek(serialized_end);
+            reader.Skip(size);
             backend_.BindSerializedRange(serialized_start, size);
             start_ = serialized_start;
             has_deserialized_ = true;

--- a/src/io/reader_io/reader_io_contract_test.cpp
+++ b/src/io/reader_io/reader_io_contract_test.cpp
@@ -75,6 +75,42 @@ MakeReaderParam(std::vector<uint8_t> data, bool enable_cache = false) {
 
 }  // namespace
 
+TEST_CASE("ReaderIO binds ranges from forward-only input", "[ut][ReaderIO]") {
+    auto allocator = SafeAllocator::FactoryDefaultAllocator();
+    auto payload = MakeReaderData(20000, 9);
+    std::stringstream stream;
+    IOStreamWriter writer(stream);
+    writer.Write("prefix", 6);
+    StreamWriter::WriteObj(writer, static_cast<uint64_t>(payload.size()));
+    writer.Write(reinterpret_cast<const char*>(payload.data()), payload.size());
+    writer.Write("suffix", 6);
+    auto serialized = stream.str();
+    const bool truncated = GENERATE(false, true);
+    if (truncated) {
+        serialized.resize(6 + sizeof(uint64_t) + payload.size() - 1);
+    }
+    std::istringstream input(serialized);
+    ForwardStreamReader reader(input);
+    reader.Skip(6);
+    ReaderIO io(allocator.get());
+    if (truncated) {
+        REQUIRE_THROWS_AS(io.Deserialize(reader), VsagException);
+        REQUIRE_FALSE(io.HasDeserialized());
+        REQUIRE(io.Size() == 0);
+        return;
+    }
+    io.Deserialize(reader);
+    REQUIRE(io.Size() == payload.size());
+    REQUIRE(reader.GetCursor() == 6 + sizeof(uint64_t) + payload.size());
+    io.InitIO(MakeReaderParam(std::vector<uint8_t>(serialized.begin(), serialized.end())));
+    std::vector<uint8_t> actual(payload.size());
+    REQUIRE(io.ReadAt(0, actual.size(), actual.data()));
+    REQUIRE(actual == payload);
+    char suffix[6];
+    reader.Read(suffix, sizeof(suffix));
+    REQUIRE(std::string(suffix, sizeof(suffix)) == "suffix");
+}
+
 TEST_CASE("ReaderIO rejects an invalid generic parameter", "[ut][ReaderIO]") {
     auto allocator = SafeAllocator::FactoryDefaultAllocator();
     IndexCommonParam common_param;

--- a/src/storage/stream_reader.cpp
+++ b/src/storage/stream_reader.cpp
@@ -32,6 +32,11 @@
 namespace vsag {
 
 void
+StreamReader::Skip(uint64_t size) {
+    SkipForward(*this, size);
+}
+
+void
 SkipForward(StreamReader& reader, uint64_t size) {
     constexpr uint64_t buffer_size = 8192;
     std::array<char, buffer_size> buffer{};
@@ -63,6 +68,15 @@ ReadFuncStreamReader::Read(char* data, uint64_t size) {
 void
 ReadFuncStreamReader::Seek(uint64_t cursor) {
     cursor_ = cursor;
+}
+
+void
+ReadFuncStreamReader::Skip(uint64_t size) {
+    if (cursor_ > length_ || size > length_ - cursor_) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "ReadFuncStreamReader: skip exceeds stream boundary");
+    }
+    cursor_ += size;
 }
 
 uint64_t
@@ -215,6 +229,23 @@ BufferStreamReader::Seek(uint64_t cursor) {
     cursor_ = cursor;
 }
 
+void
+BufferStreamReader::Skip(uint64_t size) {
+    const uint64_t buffered = valid_size_ - buffer_cursor_;
+    if (size <= buffered) {
+        buffer_cursor_ += size;
+        return;
+    }
+    const uint64_t remaining = size - buffered;
+    if (cursor_ > max_size_ || remaining > max_size_ - cursor_) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "BufferStreamReader: skip exceeds stream boundary");
+    }
+    reader_impl_->Skip(remaining);
+    buffer_cursor_ = valid_size_;
+    cursor_ += remaining;
+}
+
 uint64_t
 BufferStreamReader::GetCursor() const {
     return reader_impl_->GetCursor() - (valid_size_ - buffer_cursor_);
@@ -259,6 +290,16 @@ SliceStreamReader::Seek(uint64_t cursor) {
     }
     reader_impl_->Seek(begin_ + cursor);
     cursor_ = cursor;
+}
+
+void
+SliceStreamReader::Skip(uint64_t size) {
+    if (cursor_ > length_ || size > length_ - cursor_) {
+        throw VsagException(ErrorType::READ_ERROR,
+                            "SliceStreamReader: skip exceeds slice boundary");
+    }
+    reader_impl_->Skip(size);
+    cursor_ += size;
 }
 
 uint64_t

--- a/src/storage/stream_reader.h
+++ b/src/storage/stream_reader.h
@@ -67,6 +67,11 @@ public:
     virtual void
     Read(char* data, uint64_t size) = 0;
 
+    // Advance by consuming bytes with a fixed-size buffer by default. Wrappers that validate
+    // consumed bytes must not bypass Read(); random-access sources may optimize cursor advances.
+    virtual void
+    Skip(uint64_t size);
+
     virtual void
     Seek(uint64_t cursor) = 0;
 
@@ -117,6 +122,9 @@ SkipForward(StreamReader& reader, uint64_t size);
 
 class ReadFuncStreamReader : public StreamReader {
 public:
+    void
+    Skip(uint64_t size) override;
+
     void
     Read(char* data, uint64_t size) override;
 
@@ -182,6 +190,9 @@ private:
 
 class BufferStreamReader : public StreamReader {
 public:
+    void
+    Skip(uint64_t size) override;
+
     [[nodiscard]] uint64_t
     Length() override;
 
@@ -212,6 +223,9 @@ private:
 
 class SliceStreamReader : public StreamReader {
 public:
+    void
+    Skip(uint64_t size) override;
+
     [[nodiscard]] uint64_t
     Length() override;
 

--- a/src/storage/stream_reader_test.cpp
+++ b/src/storage/stream_reader_test.cpp
@@ -17,8 +17,93 @@
 #include "stream_reader.h"
 
 #include <cstdint>
+#include <limits>
+#include <sstream>
 
+#include "impl/allocator/safe_allocator.h"
 #include "unittest.h"
+#include "vsag_exception.h"
+
+TEST_CASE("StreamReader Skip consumes forward input", "[ut][stream_reader]") {
+    std::istringstream input(std::string(20000, 'x') + "tail");
+    vsag::ForwardStreamReader reader(input);
+    reader.Skip(0);
+    REQUIRE(reader.GetCursor() == 0);
+    reader.Skip(20000);
+    REQUIRE(reader.GetCursor() == 20000);
+    char tail[4];
+    reader.Read(tail, sizeof(tail));
+    REQUIRE(std::string(tail, sizeof(tail)) == "tail");
+    REQUIRE_THROWS_AS(reader.Skip(1), vsag::VsagException);
+}
+
+TEST_CASE("StreamReader Skip respects bounds without reading random-access data",
+          "[ut][stream_reader]") {
+    uint64_t read_count = 0;
+    vsag::ReadFuncStreamReader reader(
+        [&](uint64_t, uint64_t size, void* dest) {
+            ++read_count;
+            std::memset(dest, 'x', size);
+        },
+        0,
+        100);
+    auto slice = reader.Slice(50);
+    slice.Skip(20);
+    REQUIRE(slice.GetCursor() == 20);
+    REQUIRE(reader.GetCursor() == 20);
+    REQUIRE_THROWS_AS(slice.Skip(31), vsag::VsagException);
+    REQUIRE(slice.GetCursor() == 20);
+    slice.Skip(30);
+    reader.Skip(50);
+    reader.Skip(0);
+    REQUIRE(read_count == 0);
+    REQUIRE(reader.GetCursor() == 100);
+    REQUIRE_THROWS_AS(reader.Skip(1), vsag::VsagException);
+    REQUIRE_THROWS_AS(reader.Skip(std::numeric_limits<uint64_t>::max()), vsag::VsagException);
+    REQUIRE(reader.GetCursor() == 100);
+}
+
+TEST_CASE("BufferStreamReader Skip preserves buffered cursor and delegates unread bytes",
+          "[ut][stream_reader]") {
+    auto allocator = vsag::SafeAllocator::FactoryDefaultAllocator();
+    const std::string data = "0123456789";
+    uint64_t read_count = 0;
+    vsag::ReadFuncStreamReader source(
+        [&](uint64_t offset, uint64_t size, void* dest) {
+            ++read_count;
+            std::memcpy(dest, data.data() + offset, size);
+        },
+        0,
+        data.size());
+    vsag::BufferStreamReader reader(&source, data.size(), allocator.get());
+    reader.Skip(3);
+    REQUIRE(read_count == 0);
+    REQUIRE(reader.GetCursor() == 3);
+    char value = 0;
+    reader.Read(&value, 1);
+    REQUIRE(value == '3');
+    reader.Skip(2);
+    REQUIRE(reader.GetCursor() == 6);
+    reader.Read(&value, 1);
+    REQUIRE(value == '6');
+    REQUIRE_THROWS_AS(reader.Skip(4), vsag::VsagException);
+    REQUIRE(reader.GetCursor() == 7);
+    reader.Skip(3);
+    reader.Skip(0);
+    REQUIRE(reader.GetCursor() == data.size());
+    REQUIRE(read_count == 1);
+}
+
+TEST_CASE("BoundedForwardReader Skip consumes only its payload", "[ut][stream_reader]") {
+    std::istringstream input("payloadsuffix");
+    vsag::ForwardStreamReader source(input);
+    vsag::BoundedForwardReader reader(&source, 7);
+    REQUIRE_THROWS_AS(reader.Skip(8), vsag::VsagException);
+    REQUIRE(source.GetCursor() == 0);
+    reader.Skip(7);
+    REQUIRE(reader.GetCursor() == 7);
+    REQUIRE(source.GetCursor() == 7);
+}
 
 // fill buffer with below and return a wrappered StreamReader object:
 // ['1' '1' ... repeats 1024 times]

--- a/src/storage/streaming_serialization_test.cpp
+++ b/src/storage/streaming_serialization_test.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
+#include <catch2/matchers/catch_matchers.hpp>
 #include <cstring>
 #include <limits>
 #include <memory>
@@ -61,6 +63,123 @@ private:
 };
 
 }  // namespace
+
+TEST_CASE("Forward block reader validates consumed and drained bytes",
+          "[ut][streaming_serialization]") {
+    const uint64_t size = GENERATE(0, 3, 20000);
+    const uint64_t consume = GENERATE(0, 1, 2);
+    const std::string payload(size, 'x');
+    std::istringstream input("prefix" + payload + "suffix");
+    vsag::ForwardStreamReader reader(input);
+    reader.Skip(6);
+    vsag::StreamBlockHeader header;
+    header.value_len = size;
+    header.payload_checksum = vsag::StreamHeader::CalculateChecksum(payload);
+    vsag::ReadForwardBlockPayload(reader, header, [&](vsag::StreamReader& block) {
+        REQUIRE(block.GetCursor() == 0);
+        REQUIRE(block.Length() == size);
+        block.Read(nullptr, 0);
+        if (consume == 1) {
+            block.Skip(size / 2);
+        } else if (consume == 2) {
+            std::string actual(size, '\0');
+            block.Read(actual.data(), size);
+            REQUIRE(actual == payload);
+        }
+    });
+    REQUIRE(reader.GetCursor() == 6 + size);
+    char suffix[6];
+    reader.Read(suffix, sizeof(suffix));
+    REQUIRE(std::string(suffix, sizeof(suffix)) == "suffix");
+}
+
+TEST_CASE("Forward block reader rejects invalid input without unwinding drains",
+          "[ut][streaming_serialization]") {
+    std::istringstream input("abc");
+    vsag::ForwardStreamReader reader(input);
+    vsag::StreamBlockHeader header;
+    header.value_len = 3;
+    header.payload_checksum = vsag::StreamHeader::CalculateChecksum("abc");
+    SECTION("seek is forbidden even at the current position") {
+        REQUIRE_THROWS(vsag::ReadForwardBlockPayload(
+            reader, header, [](vsag::StreamReader& block) { block.Seek(0); }));
+        REQUIRE(reader.GetCursor() == 0);
+    }
+    SECTION("overflow-sized read is rejected before touching the source") {
+        REQUIRE_THROWS(vsag::ReadForwardBlockPayload(reader, header, [](vsag::StreamReader& block) {
+            char value;
+            block.Read(&value, std::numeric_limits<uint64_t>::max());
+        }));
+        REQUIRE(reader.GetCursor() == 0);
+    }
+    SECTION("callback exception does not drain") {
+        REQUIRE_THROWS_WITH(
+            vsag::ReadForwardBlockPayload(reader,
+                                          header,
+                                          [](vsag::StreamReader& block) {
+                                              block.Skip(1);
+                                              throw std::runtime_error("callback failed");
+                                          }),
+            "callback failed");
+        REQUIRE(reader.GetCursor() == 1);
+    }
+    SECTION("checksum failure occurs after component mutation") {
+        ++header.payload_checksum;
+        bool mutated = false;
+        REQUIRE_THROWS(
+            vsag::ReadForwardBlockPayload(reader, header, [&](vsag::StreamReader& block) {
+                block.Skip(2);
+                mutated = true;
+            }));
+        REQUIRE(mutated);  // The partially restored target must be discarded.
+        REQUIRE(reader.GetCursor() == 3);
+    }
+    SECTION("truncated drain") {
+        header.value_len = 4;
+        REQUIRE_THROWS(vsag::ReadForwardBlockPayload(reader, header, [](vsag::StreamReader&) {}));
+    }
+    SECTION("truncated callback read") {
+        header.value_len = 4;
+        REQUIRE_THROWS(vsag::ReadForwardBlockPayload(
+            reader, header, [](vsag::StreamReader& block) { block.Skip(4); }));
+    }
+    SECTION("chunked sentinel is unsupported") {
+        header.value_len = std::numeric_limits<uint64_t>::max();
+        REQUIRE_THROWS(vsag::ReadForwardBlockPayload(
+            reader, header, [](vsag::StreamReader&) { FAIL("must not invoke callback"); }));
+        REQUIRE(reader.GetCursor() == 0);
+    }
+}
+
+TEST_CASE("Forward block reader drains a large generated payload with bounded reads",
+          "[ut][streaming_serialization]") {
+    const uint64_t size = vsag::Options::Instance().block_size_limit() + 1;
+    std::array<char, 8192> bytes{};
+    uint32_t checksum = vsag::StreamHeader::InitialChecksum();
+    for (uint64_t offset = 0; offset < size;) {
+        const uint64_t count = std::min<uint64_t>(bytes.size(), size - offset);
+        checksum = vsag::StreamHeader::UpdateChecksum(checksum, {bytes.data(), count});
+        offset += count;
+    }
+    uint64_t consumed = 0;
+    vsag::ReadFuncStreamReader reader(
+        [&](uint64_t offset, uint64_t count, void* destination) {
+            REQUIRE(offset == consumed);
+            REQUIRE(count <= bytes.size());
+            std::memset(destination, 0, count);
+            consumed += count;
+        },
+        0,
+        size);
+    vsag::StreamBlockHeader header;
+    header.value_len = size;
+    header.payload_checksum = vsag::StreamHeader::FinalizeChecksum(checksum);
+    vsag::ReadForwardBlockPayload(reader, header, [&](vsag::StreamReader& block) {
+        REQUIRE(consumed == 0);  // No payload materialization before the callback.
+        block.Skip(size / 2);
+    });
+    REQUIRE(consumed == size);
+}
 
 TEST_CASE("StreamHeader", "[ut][streaming_serialization]") {
     auto metadata = std::make_shared<vsag::Metadata>();

--- a/src/storage/tlv_section.cpp
+++ b/src/storage/tlv_section.cpp
@@ -39,6 +39,53 @@ namespace vsag {
 
 namespace {
 
+class ForwardChecksumReader : public StreamReader {
+public:
+    ForwardChecksumReader(StreamReader& source, uint64_t length)
+        : StreamReader(length), source_(source) {
+    }
+
+    void
+    Read(char* data, uint64_t size) override {
+        if (size > length_ - cursor_) {
+            throw VsagException(ErrorType::READ_ERROR,
+                                "forward block reader exceeds payload boundary");
+        }
+        if (size == 0) {
+            return;
+        }
+        source_.Read(data, size);
+        checksum_ = StreamHeader::UpdateChecksum(checksum_, std::string_view(data, size));
+        cursor_ += size;
+    }
+
+    void
+    Seek(uint64_t cursor) override {
+        (void)cursor;
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "forward block reader does not support seek");
+    }
+
+    [[nodiscard]] uint64_t
+    GetCursor() const override {
+        return cursor_;
+    }
+
+    void
+    Finish(uint32_t expected_checksum) {
+        this->Skip(length_ - cursor_);
+        if (StreamHeader::FinalizeChecksum(checksum_) != expected_checksum) {
+            throw VsagException(ErrorType::INVALID_BINARY,
+                                "streaming block payload checksum mismatch");
+        }
+    }
+
+private:
+    StreamReader& source_;
+    uint64_t cursor_{0};
+    uint32_t checksum_{StreamHeader::InitialChecksum()};
+};
+
 struct FileCloser {
     void
     operator()(std::FILE* file) const {
@@ -327,6 +374,19 @@ ReadSeekableBlockPayload(StreamReader& reader,
     ReadFuncStreamReader block_reader(read_func, 0, header.value_len);
     deserialize(block_reader);
     validate_seekable_block_cursor(block_reader, header);
+}
+
+void
+ReadForwardBlockPayload(StreamReader& reader,
+                        const StreamBlockHeader& header,
+                        const std::function<void(StreamReader&)>& deserialize) {
+    if (header.value_len == std::numeric_limits<uint64_t>::max()) {
+        throw VsagException(ErrorType::UNSUPPORTED_INDEX_OPERATION,
+                            "chunked streaming block payload is not implemented yet");
+    }
+    ForwardChecksumReader block(reader, header.value_len);
+    deserialize(block);
+    block.Finish(header.payload_checksum);
 }
 
 void

--- a/src/storage/tlv_section.h
+++ b/src/storage/tlv_section.h
@@ -70,6 +70,14 @@ ReadSeekableBlockPayload(StreamReader& reader,
                          const StreamBlockHeader& header,
                          const std::function<void(StreamReader&)>& deserialize);
 
+// Reads directly from the source with bounded memory and no random access. After deserialize
+// succeeds, drains the suffix and validates the checksum. On failure, the caller must discard
+// any partially restored component state; no draining is performed during exception unwinding.
+void
+ReadForwardBlockPayload(StreamReader& reader,
+                        const StreamBlockHeader& header,
+                        const std::function<void(StreamReader&)>& deserialize);
+
 void
 ReadExternalBlockPayload(const ReaderPtr& reader,
                          const StreamBlockHeader& header,

--- a/tests/test_hgraph.cpp
+++ b/tests/test_hgraph.cpp
@@ -25,6 +25,7 @@
 #include <thread>
 #include <vector>
 
+#include "fixtures/framework/test_reader.h"
 #include "functest.h"
 #include "impl/filter/iterator_filter.h"
 #include "inner_string_params.h"
@@ -2776,6 +2777,129 @@ TEST_CASE("HGraph streaming Load applies IO parameters", "[ft][serialize][hgraph
     std::stringstream invalid_load_stream(bytes);
     REQUIRE_FALSE(
         vsag::Index::Load(invalid_load_stream, R"({"precise_io_type":"invalid_io"})").has_value());
+}
+
+TEST_CASE("HGraph forward blocks preserve optional data", "[ft][hgraph][streaming]") {
+    using namespace fixtures;
+    constexpr int64_t count = 32;
+    constexpr int64_t dim = 16;
+    HGraphTestIndex::HGraphBuildParam build_param("l2", dim, "sq8");
+    build_param.thread_count = 1;
+    build_param.use_attr_filter = true;
+    build_param.store_raw_vector = true;
+    build_param.extra_info_size = sizeof(uint64_t);
+    auto json =
+        vsag::JsonType::Parse(HGraphTestIndex::GenerateHGraphBuildParametersString(build_param));
+    json[vsag::INDEX_PARAM]["persist_source_id"].SetBool(true);
+    const auto param = json.Dump();
+    auto dataset =
+        HGraphTestIndex::pool.GetDatasetAndCreate(dim, count, "l2", false, 0.8, sizeof(uint64_t));
+    std::vector<std::string> source_ids(count);
+    std::vector<vsag::AttributeSet> attribute_sets(count);
+    std::vector<vsag::AttributeValue<std::string>> attributes(count);
+    for (uint64_t i = 0; i < count; ++i) {
+        source_ids[i] = fmt::format("source_{}", i);
+        attributes[i].name_ = "group";
+        attributes[i].GetValue() = {i % 2 == 0 ? "allowed" : "excluded"};
+        attribute_sets[i].attrs_.push_back(&attributes[i]);
+    }
+    // Keep fixture-owned datasets unchanged: optional fields refer to local test storage.
+    auto base = vsag::Dataset::Make();
+    base->NumElements(count)
+        ->Dim(dim)
+        ->Ids(dataset->base_->GetIds())
+        ->Float32Vectors(dataset->base_->GetFloat32Vectors())
+        ->ExtraInfos(dataset->base_->GetExtraInfos())
+        ->SourceID(source_ids.data())
+        ->AttributeSets(attribute_sets.data())
+        ->Owner(false);
+    auto index = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    REQUIRE(index->Build(base).has_value());
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    const auto bytes = stream.str();
+    for (auto tag : {vsag::StreamSerializationTag::RAW_VECTOR,
+                     vsag::StreamSerializationTag::ATTRIBUTE_FILTER,
+                     vsag::StreamSerializationTag::EXTRA_INFO}) {
+        REQUIRE(vsag::test::FindStreamingBlock(bytes, tag).payload_size > 0);
+    }
+    const auto labels =
+        vsag::test::FindStreamingBlock(bytes, vsag::StreamSerializationTag::LABEL_TABLE);
+    const auto label_payload = bytes.substr(labels.payload_offset, labels.payload_size);
+    for (const auto& source_id : source_ids) {
+        REQUIRE(label_payload.find(source_id) != std::string::npos);
+    }
+    auto restored = TestIndex::TestFactory(HGraphTestIndex::name, param, true);
+    std::istringstream input(bytes);
+    REQUIRE(restored->DeserializeStreaming(input).has_value());
+    std::istringstream load_input(bytes);
+    auto loaded = vsag::Index::Load(load_input, "{}");
+    REQUIRE(loaded.has_value());
+    for (const auto& candidate : {restored, loaded.value()}) {
+        TestIndex::TestGetRawVectorByIds(candidate, dataset);
+        vsag::SearchRequest request;
+        request.query_ = get_one_query(dataset->query_, 0);
+        request.topk_ = 10;
+        request.params_str_ = fmt::format(search_param_tmp, 200, false);
+        request.enable_attribute_filter_ = true;
+        request.attribute_filter_str_ = R"(multi_in(group, "allowed", "|"))";
+        const auto expected = index->SearchWithRequest(request);
+        const auto actual = candidate->SearchWithRequest(request);
+        REQUIRE(expected.has_value());
+        REQUIRE(actual.has_value());
+        REQUIRE(actual.value()->GetDim() == expected.value()->GetDim());
+        for (int64_t i = 0; i < actual.value()->GetDim(); ++i) {
+            REQUIRE(actual.value()->GetIds()[i] == expected.value()->GetIds()[i]);
+        }
+        // Re-serialization exposes the persisted Source ID table and extra-info bytes.
+        std::stringstream roundtrip;
+        REQUIRE(candidate->SerializeStreaming(roundtrip).has_value());
+        const auto restored_bytes = roundtrip.str();
+        for (auto tag : {vsag::StreamSerializationTag::LABEL_TABLE,
+                         vsag::StreamSerializationTag::EXTRA_INFO}) {
+            const auto before = vsag::test::FindStreamingBlock(bytes, tag);
+            const auto after = vsag::test::FindStreamingBlock(restored_bytes, tag);
+            REQUIRE(restored_bytes.substr(after.payload_offset, after.payload_size) ==
+                    bytes.substr(before.payload_offset, before.payload_size));
+        }
+    }
+}
+
+TEST_CASE("HGraph forward blocks validate external precise reader",
+          "[ft][serialize][hgraph][streaming]") {
+    auto fixture = MakeHGraphStreamingFixture("sq8,fp32");
+    const auto block = vsag::test::FindStreamingBlock(
+        fixture.bytes, vsag::StreamSerializationTag::HIGH_PRECISION_CODES);
+    vsag::Binary binary;
+    binary.size = block.payload_size;
+    binary.data.reset(new int8_t[binary.size]);
+    std::memcpy(binary.data.get(), fixture.bytes.data() + block.payload_offset, binary.size);
+    const bool corrupt = GENERATE(false, true);
+    if (corrupt) {
+        binary.data[binary.size - 1] ^= 1;
+    }
+    vsag::LoadParameters parameters;
+    parameters.Set("precise_io_type", "reader_io")
+        .SetReader("precise_reader", std::make_shared<fixtures::TestReader>(binary));
+    std::istringstream input(fixture.bytes);
+    auto result = vsag::Index::Load(input, parameters);
+    if (corrupt) {
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_BINARY);
+        return;
+    }
+    REQUIRE(result.has_value());
+    auto query = fixtures::get_one_query(fixture.dataset->query_, 0);
+    const auto search_param = fmt::format(fixtures::search_param_tmp, 200, false);
+    auto expected = fixture.index->KnnSearch(query, 10, search_param);
+    auto actual = result.value()->KnnSearch(query, 10, search_param);
+    REQUIRE(expected.has_value());
+    REQUIRE(actual.has_value());
+    REQUIRE(actual.value()->GetDim() == expected.value()->GetDim());
+    for (int64_t i = 0; i < expected.value()->GetDim(); ++i) {
+        REQUIRE(actual.value()->GetIds()[i] == expected.value()->GetIds()[i]);
+        REQUIRE(actual.value()->GetDistances()[i] == expected.value()->GetDistances()[i]);
+    }
 }
 
 TEST_CASE("HGraph streaming serialization compatibility",

--- a/tests/test_hgraph_rabitq_split.cpp
+++ b/tests/test_hgraph_rabitq_split.cpp
@@ -249,6 +249,65 @@ TEST_CASE("HGraph RaBitQ Split Homogeneous IO", "[ft][rabitq_split][hgraph]") {
     TestIndex::TestKnnSearch(index, dataset, kSplitSearchParam, 0.1F, true);
 }
 
+TEST_CASE("HGraph non-fused RaBitQ Split streaming round trip", "[ft][hgraph][streaming]") {
+    using namespace fixtures;
+    const auto supplement = GENERATE(std::string(""), std::string("block_memory_io"));
+    auto json = vsag::JsonType::Parse(HGraphRaBitQSplitTestIndex::GenerateBuildParam(
+        "l2", 128, "block_memory_io", supplement, 3, 5, false));
+    json["index_param"]["rabitq_fused_datacell"].SetBool(false);
+    const auto param = json.Dump();
+    auto index = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, param, true);
+    auto dataset = HGraphRaBitQSplitTestIndex::pool.GetDatasetAndCreate(128, 128, "l2");
+    TestIndex::TestBuildIndex(index, dataset, true);
+    std::stringstream stream;
+    REQUIRE(index->SerializeStreaming(stream).has_value());
+    auto restored = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, param, true);
+    REQUIRE(restored->DeserializeStreaming(stream).has_value());
+    std::istringstream load_input(stream.str());
+    auto loaded = vsag::Index::Load(load_input, "{}");
+    REQUIRE(loaded.has_value());
+    auto query = get_one_query(dataset->query_, 0);
+    const auto expected = index->KnnSearch(query, 10, kSplitSearchParam);
+    REQUIRE(expected.has_value());
+    for (const auto& candidate : {restored, loaded.value()}) {
+        const auto actual = candidate->KnnSearch(query, 10, kSplitSearchParam);
+        REQUIRE(actual.has_value());
+        REQUIRE(actual.value()->GetDim() == expected.value()->GetDim());
+        for (int64_t i = 0; i < actual.value()->GetDim(); ++i) {
+            REQUIRE(actual.value()->GetIds()[i] == expected.value()->GetIds()[i]);
+            REQUIRE(actual.value()->GetDistances()[i] == expected.value()->GetDistances()[i]);
+        }
+    }
+    const auto original = stream.str();
+    const auto block =
+        vsag::test::FindStreamingBlock(original, vsag::StreamSerializationTag::BASE_CODES);
+    // FlattenInterface writes total_count, max_capacity, and code_size before the IO field.
+    const uint64_t io_offset =
+        block.payload_offset + 2 * sizeof(vsag::InnerIdType) + sizeof(uint32_t);
+    for (const auto invalid_length : {uint64_t{65}, std::numeric_limits<uint64_t>::max()}) {
+        auto corrupted = original;
+        vsag::test::WriteStreamingObj(corrupted, io_offset, invalid_length);
+        auto target = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, param, true);
+        std::istringstream input(corrupted);
+        const auto result = target->DeserializeStreaming(input);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_BINARY);
+        REQUIRE(result.error().message.find("IO type length") != std::string::npos);
+        // Do not reuse a target after failed streaming deserialization.
+    }
+    if (not supplement.empty()) {
+        auto corrupted = original;
+        corrupted[io_offset + sizeof(uint64_t)] = '?';
+        auto target = TestIndex::TestFactory(HGraphRaBitQSplitTestIndex::name, param, true);
+        std::istringstream input(corrupted);
+        const auto result = target->DeserializeStreaming(input);
+        REQUIRE_FALSE(result.has_value());
+        REQUIRE(result.error().type == vsag::ErrorType::INVALID_BINARY);
+        REQUIRE(result.error().message.find("unknown RaBitQ supplement IO type") !=
+                std::string::npos);
+    }
+}
+
 TEST_CASE("HGraph MRLE RaBitQ Split", "[ft][rabitq_split][hgraph][MRLE]") {
     using namespace fixtures;
     constexpr int64_t dim = 128;


### PR DESCRIPTION
## Change Type

- [x] Improvement/Refactor

## Linked Issue

Part of #2582 — HGraph only. Other indexes retain the existing buffered/temp-file helper; this PR does not close the whole issue.

## What Changed

- Add bounded forward-only TLV payload reading with incremental CRC validation, avoiding payload-sized staging and temporary files for HGraph.
- Route HGraph block callbacks and external precise readers through this path.
- Add forward Skip support, preserve ReaderIO range binding, and deserialize ConjugateGraph sequentially without changing its valid wire format.
- Add regression coverage for optional data, fused/non-fused RaBitQ, malformed payloads, checksums, and streaming entry points.
- Include reproducible resource benchmarks under scripts/benchmarks/.

## Compatibility Impact — human review requested

Two legacy RaBitQ compatibility paths are disabled but deliberately preserved as commented code with explanations above them:
1. Missing supplement_io_type fallback that probes and rewinds older snapshots.
2. Loading legacy split payloads into fused storage via probing and rewinding.

Please review these comments before deciding whether to remove them permanently. Corresponding old compatibility assertions are also retained as review comments. These behavior changes affect ordinary deserialization as well as streaming. Current-format fused model-only and ordinary split payloads remain supported.

StreamReader::Skip becomes virtual: downstream binary consumers should rebuild.
CRC validation occurs after callback mutations; discard the destination index if deserialization fails.

## Test Evidence

- Debug and coverage builds succeeded.
- Original 944 unit cases passed across eight shards after updating the obsolete compatibility expectation and rerunning its entire 118-case shard; the subsequently added HGraph unit case also passed (166 assertions). Total tested: 945 cases.
- Targeted unit run: 58 cases / 48,835 assertions passed.
- Final HGraph functional run: 14 cases / 3,183 assertions passed.
- clang-format 15.0.7 checks and git diff --check passed.
- Unit-only coverage: 32,445 / 44,473 lines = **73.0%**.
- Added/changed executable production lines: **82/82 covered**, including **27/27** in the new forward reader/helper.

**Outstanding acceptance limitation:** repository-wide unit line coverage is below the required 90%. A main-branch coverage baseline was not measured, so this gap is not attributed to this PR. Functional/benchmark profiles were kept outside the unit coverage tree. This is not an all-gates-passed claim; the PR is draft for compatibility review and coverage follow-up. Full lint was not run.

## Performance and Concurrency Impact

A real HGraph artifact of 134,329,419 bytes (1,024 vectors; extra-info block above 128 MiB) was loaded in fresh processes using the same coverage-instrumented Debug library and component parsers. A benchmark-only LD_PRELOAD shim selects the old helper for comparison.

- Peak RSS reduced by approximately 128 MiB.
- Temporary output reduced from 134,221,824 bytes per load to zero.
- Three load samples: old helper 4.33437 / 4.33281 / 4.33939 s; forward helper 4.25345 / 4.26048 / 4.24500 s.

These are local resource measurements, not production latency guarantees or a historical full-checkout comparison. See scripts/benchmarks/README.md for methodology and reproduction. No new concurrency guarantee is introduced.

## Documentation Impact

- [x] Updated English and Chinese website serialization documentation.
- [x] Added benchmark methodology and reproduction instructions.

## Risk and Rollback

- Medium risk: explicitly disabled legacy compatibility, shared Skip/component code, and failure-after-mutation semantics.
- Rollback: revert this commit to restore the previous reader and compatibility paths.

## Checklist

- [x] Linked the relevant issue without closing the remaining index work.
- [x] Added/updated tests.
- [x] Considered API/ABI and behavioral compatibility.
- [x] Updated documentation.
- [x] Conventional commit with human sign-off and AI assistance attribution.
- [ ] Repository-wide >=90% unit coverage.
- [ ] Human approval of the two disabled legacy compatibility paths.
