### PR TITLE
fix(api): handle serial GetDataByIds execution

### DIFF
--- a/src/algorithm/inner_index_interface.cpp
+++ b/src/algorithm/inner_index_interface.cpp
@@ -829,14 +829,26 @@ InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
             inner_ids.emplace_back(this->label_table_->GetIdByLabel(ids[i]));
         }
     }
-    auto thread_count = static_cast<int64_t>(this->build_thread_count_);
-    auto item_per_thread = (count + thread_count - 1) / thread_count;
+    if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U) {
+        CHECK_ARGUMENT(this->has_raw_vector_, "has_raw_vector_ is false");
+    }
+    if ((selected_data_flag & DATA_FLAG_ATTRIBUTE) != 0U) {
+        CHECK_ARGUMENT(this->has_attribute_, "has_attribute_ is false");
+    }
+    if ((selected_data_flag & DATA_FLAG_EXTRA_INFO) != 0U) {
+        CHECK_ARGUMENT(this->extra_info_size_ > 0, "extra_info_size_ is 0");
+    }
     auto dataset = Dataset::Make();
     dataset->NumElements(count)->Dim(dim_)->Owner(true, allocator_);
+    if (count == 0) {
+        return dataset;
+    }
+
+    const auto thread_count = static_cast<int64_t>(std::max<uint64_t>(
+        uint64_t{1}, std::min<uint64_t>(this->build_thread_count_, static_cast<uint64_t>(count))));
+    const auto item_per_thread =
+        count / thread_count + static_cast<int64_t>(count % thread_count != 0);
     if ((selected_data_flag & DATA_FLAG_FLOAT32_VECTOR) != 0U) {
-        if (not this->has_raw_vector_) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT, "has_raw_vector_ is false");
-        }
         auto* fp32_data = reinterpret_cast<float*>(
             this->allocator_->Allocate(count * this->dim_ * sizeof(float)));
         dataset->Float32Vectors(fp32_data);
@@ -845,11 +857,12 @@ InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
                 this->GetVectorByInnerId(inner_ids[i], fp32_data + i * this->dim_);
             }
         };
-        if (this->thread_pool_ != nullptr) {
+        if (this->thread_pool_ != nullptr and thread_count > 1) {
             std::vector<std::future<void>> futures;
+            futures.reserve(thread_count);
             for (int64_t i = 0; i < thread_count; ++i) {
-                int64_t begin = i * item_per_thread;
-                int64_t end = std::min(begin + item_per_thread, count);
+                const auto begin = i * item_per_thread;
+                const auto end = std::min(begin + item_per_thread, count);
                 futures.emplace_back(this->thread_pool_->GeneralEnqueue(get_vec_func, begin, end));
             }
             for (auto& future : futures) {
@@ -861,9 +874,6 @@ InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
     }
 
     if ((selected_data_flag & DATA_FLAG_ATTRIBUTE) != 0U) {
-        if (not this->has_attribute_) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT, "has_attribute_ is false");
-        }
         auto* attribute_data = new AttributeSet[count];
         dataset->AttributeSets(attribute_data);
         auto get_attr_func = [&](int64_t begin, int64_t end) {
@@ -871,11 +881,12 @@ InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
                 this->GetAttributeSetByInnerId(inner_ids[i], attribute_data + i);
             }
         };
-        if (this->thread_pool_ != nullptr) {
+        if (this->thread_pool_ != nullptr and thread_count > 1) {
             std::vector<std::future<void>> futures;
+            futures.reserve(thread_count);
             for (int64_t i = 0; i < thread_count; ++i) {
-                int64_t begin = i * item_per_thread;
-                int64_t end = std::min(begin + item_per_thread, count);
+                const auto begin = i * item_per_thread;
+                const auto end = std::min(begin + item_per_thread, count);
                 futures.emplace_back(this->thread_pool_->GeneralEnqueue(get_attr_func, begin, end));
             }
             for (auto& future : futures) {
@@ -887,9 +898,6 @@ InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
     }
 
     if ((selected_data_flag & DATA_FLAG_EXTRA_INFO) != 0U) {
-        if (extra_info_size_ == 0) {
-            throw VsagException(ErrorType::INVALID_ARGUMENT, "extra_info_size_ is 0");
-        }
         auto* extra_info =
             reinterpret_cast<char*>(this->allocator_->Allocate(count * extra_info_size_));
         dataset->ExtraInfos(extra_info)->ExtraInfoSize(static_cast<int64_t>(extra_info_size_));
@@ -899,11 +907,12 @@ InnerIndexInterface::get_data_by_ids_with_flag(const int64_t* ids,
                                                      extra_info + i * extra_info_size_);
             }
         };
-        if (this->thread_pool_ != nullptr) {
+        if (this->thread_pool_ != nullptr and thread_count > 1) {
             std::vector<std::future<void>> futures;
+            futures.reserve(thread_count);
             for (int64_t i = 0; i < thread_count; ++i) {
-                int64_t begin = i * item_per_thread;
-                int64_t end = std::min(begin + item_per_thread, count);
+                const auto begin = i * item_per_thread;
+                const auto end = std::min(begin + item_per_thread, count);
                 futures.emplace_back(
                     this->thread_pool_->GeneralEnqueue(get_extra_info_func, begin, end));
             }

--- a/src/algorithm/inner_index_interface_test.cpp
+++ b/src/algorithm/inner_index_interface_test.cpp
@@ -15,9 +15,12 @@
 
 #include "inner_index_interface.h"
 
+#include <algorithm>
+#include <future>
 #include <memory>
 #include <sstream>
 #include <utility>
+#include <vector>
 
 #include "algorithm/bruteforce/bruteforce.h"
 #include "algorithm/hgraph/hgraph.h"
@@ -76,6 +79,10 @@ class EmptyInnerIndex : public InnerIndexInterface {
 public:
     EmptyInnerIndex() = default;
 
+    EmptyInnerIndex(const InnerIndexParameterPtr& index_param, const IndexCommonParam& common_param)
+        : InnerIndexInterface(index_param, common_param) {
+    }
+
     std::string
     GetName() const override {
         return "EmptyInnerIndex";
@@ -124,6 +131,110 @@ public:
     GetNumElements() const override {
         return 0;
     }
+};
+
+class DataReadingInnerIndex : public EmptyInnerIndex {
+public:
+    class TestExtraInfo : public ExtraInfoInterface {
+    public:
+        void
+        InsertExtraInfo(const char*, InnerIdType) override {
+        }
+
+        void
+        BatchInsertExtraInfo(const char*, InnerIdType, InnerIdType*) override {
+        }
+
+        void
+        Prefetch(InnerIdType) override {
+        }
+
+        void
+        Resize(InnerIdType) override {
+        }
+
+        void
+        Release(const char*) const override {
+        }
+
+        const char*
+        GetExtraInfoById(InnerIdType, bool& need_release) const override {
+            need_release = false;
+            return nullptr;
+        }
+
+        bool
+        GetExtraInfoById(InnerIdType inner_id, char* extra_info) const override {
+            extra_info[0] = static_cast<char>(inner_id);
+            extra_info[1] = static_cast<char>(inner_id + 10);
+            return true;
+        }
+
+        [[nodiscard]] bool
+        InMemory() const override {
+            return true;
+        }
+    };
+
+    DataReadingInnerIndex(const InnerIndexParameterPtr& index_param,
+                          const IndexCommonParam& common_param,
+                          uint64_t count)
+        : EmptyInnerIndex(index_param, common_param) {
+        this->has_raw_vector_ = true;
+        this->has_attribute_ = true;
+        this->extra_info_size_ = 2;
+        this->extra_infos_ = std::make_shared<TestExtraInfo>();
+        for (InnerIdType inner_id = 0; inner_id != count; ++inner_id) {
+            this->label_table_->Insert(inner_id, static_cast<LabelType>(100 + inner_id));
+        }
+    }
+
+    void
+    GetVectorByInnerId(InnerIdType inner_id, float* data) const override {
+        data[0] = static_cast<float>(inner_id);
+        data[1] = static_cast<float>(inner_id) + 0.5F;
+    }
+
+    void
+    GetAttributeSetByInnerId(InnerIdType inner_id, AttributeSet* attr) const override {
+        auto* value = new AttributeValue<int64_t>();
+        value->name_ = "inner_id";
+        value->GetValue().push_back(static_cast<int64_t>(inner_id));
+        attr->attrs_.push_back(value);
+    }
+};
+
+class CountingThreadPool : public ThreadPool {
+public:
+    void
+    WaitUntilEmpty() override {
+    }
+
+    void
+    SetQueueSizeLimit(uint64_t) override {
+    }
+
+    void
+    SetPoolSize(uint64_t) override {
+    }
+
+    std::future<void>
+    Enqueue(std::function<void(void)> task) override {
+        ++submission_count_;
+        std::promise<void> promise;
+        auto future = promise.get_future();
+        task();
+        promise.set_value();
+        return future;
+    }
+
+    [[nodiscard]] uint64_t
+    SubmissionCount() const {
+        return submission_count_;
+    }
+
+private:
+    uint64_t submission_count_{0};
 };
 
 class ReadingInnerIndex : public EmptyInnerIndex {
@@ -288,4 +399,71 @@ TEST_CASE("InnerIndexInterface rejects malformed binary set", "[ut][InnerIndexIn
 
         RequireReadError([&index, &binary]() { index->Deserialize(binary); });
     }
+}
+
+TEST_CASE("GetDataByIds handles serial build thread counts", "[ut][InnerIndexInterface]") {
+    constexpr uint64_t count = 3;
+    auto index_param = std::make_shared<InnerIndexParameter>();
+    index_param->build_thread_count = GENERATE(uint64_t{0}, uint64_t{1}, uint64_t{2}, uint64_t{8});
+
+    IndexCommonParam common_param;
+    common_param.dim_ = 2;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    auto pool = std::make_shared<CountingThreadPool>();
+    common_param.thread_pool_ = std::make_shared<SafeThreadPool>(pool);
+
+    auto index = std::make_shared<DataReadingInnerIndex>(index_param, common_param, count);
+    const std::vector<int64_t> ids{102, 100, 101};
+
+    auto result = index->GetDataByIds(ids.data(), static_cast<int64_t>(ids.size()));
+
+    REQUIRE(result->GetNumElements() == static_cast<int64_t>(ids.size()));
+    REQUIRE(result->GetDim() == common_param.dim_);
+    const std::vector<float> expected_vectors{2.0F, 2.5F, 0.0F, 0.5F, 1.0F, 1.5F};
+    REQUIRE(std::equal(ids.begin(), ids.end(), result->GetIds()));
+    REQUIRE(
+        std::equal(expected_vectors.begin(), expected_vectors.end(), result->GetFloat32Vectors()));
+    const std::vector<char> expected_extra_info{2, 12, 0, 10, 1, 11};
+    REQUIRE(std::equal(
+        expected_extra_info.begin(), expected_extra_info.end(), result->GetExtraInfos()));
+    for (uint64_t i = 0; i < count; ++i) {
+        const auto& attrs = result->GetAttributeSets()[i].attrs_;
+        REQUIRE(attrs.size() == 1);
+        auto* value = dynamic_cast<AttributeValue<int64_t>*>(attrs[0]);
+        REQUIRE(value != nullptr);
+        REQUIRE(value->name_ == "inner_id");
+        REQUIRE(value->GetValue() == std::vector<int64_t>{ids[i] - 100});
+    }
+    const auto expected_submissions =
+        index_param->build_thread_count > 1
+            ? 3 * std::min<uint64_t>(index_param->build_thread_count, count)
+            : uint64_t{0};
+    REQUIRE(pool->SubmissionCount() == expected_submissions);
+}
+
+TEST_CASE("GetDataByIds does not schedule empty work", "[ut][InnerIndexInterface]") {
+    auto index_param = std::make_shared<InnerIndexParameter>();
+    index_param->build_thread_count = 8;
+
+    IndexCommonParam common_param;
+    common_param.dim_ = 2;
+    common_param.allocator_ = SafeAllocator::FactoryDefaultAllocator();
+    common_param.metric_ = MetricType::METRIC_TYPE_L2SQR;
+    auto pool = std::make_shared<CountingThreadPool>();
+    common_param.thread_pool_ = std::make_shared<SafeThreadPool>(pool);
+
+    auto index = std::make_shared<DataReadingInnerIndex>(index_param, common_param, 0);
+    auto result = index->GetDataByIds(nullptr, 0);
+
+    REQUIRE(result->GetNumElements() == 0);
+    REQUIRE(result->GetIds() == nullptr);
+    REQUIRE(result->GetFloat32Vectors() == nullptr);
+    REQUIRE(result->GetAttributeSets() == nullptr);
+    REQUIRE(result->GetExtraInfos() == nullptr);
+    REQUIRE(pool->SubmissionCount() == 0);
+
+    auto unsupported = std::make_shared<EmptyInnerIndex>(index_param, common_param);
+    REQUIRE_THROWS_AS(unsupported->GetDataByIdsWithFlag(nullptr, 0, DATA_FLAG_FLOAT32_VECTOR),
+                      VsagException);
 }


### PR DESCRIPTION
## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Refactor
- [ ] Documentation
- [ ] CI/Build/Infra

## Linked Issue

- Fixes: #2936

## What Changed

- Clamp retrieval workers to at least one and at most the requested ID count.
- Run retrieval on the caller thread when `build_thread_count` is zero or one, even when the Resource supplies a thread pool.
- Add deterministic regression coverage for zero, one, two, and over-provisioned build thread counts plus empty requests.

## Test Evidence

- [x] `make fmt`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make cov`, run tests, and collect coverage
- [x] Other (described below)

Test details:

```text
PATH=/opt/homebrew/opt/llvm@15/bin:$PATH make fmt
Using clang-format version 15 (required: 15)
Code formatting completed with /opt/homebrew/opt/llvm@15/bin/clang-format

/opt/homebrew/opt/llvm@15/bin/clang-tidy -p build src/algorithm/inner_index_interface.cpp
45345 warnings generated.
Suppressed 45345 warnings (45345 in non-user code).
# exit 0; no project-code diagnostics

cmake --build build-system --target unittests --parallel 6
# built target unittests

./build-system/tests/unittests "[InnerIndexInterface]" --rng-seed 424242 --reporter compact
All tests passed (66 assertions in 5 test cases)

cmake --build build-system --target functests --parallel 6
# built target functests

# Broader non-daily unit run before the final focused rerun:
# 578 test cases and 21,595,926 assertions passed. The run was manually
# interrupted after 39 minutes in the unrelated pre-existing
# "PQFSQuantizer Encode and Decode" case, which had made no progress.
```

## Compatibility Impact

- API/ABI compatibility: none
- Behavior changes: `GetDataByIds` now populates selected data when `build_thread_count` is zero; empty and serial calls preserve their Dataset contract.

## Performance and Concurrency Impact

- Performance impact: improved for small requests because parallel work is capped by the requested ID count.
- Concurrency/thread-safety impact: zero/one-worker retrieval runs synchronously; multi-worker retrieval retains the existing future-based synchronization.

## Documentation Impact

- [x] No docs update needed
- [ ] Updated docs:
  - [ ] `README.md`
  - [ ] `DEVELOPMENT.md`
  - [ ] `CONTRIBUTING.md`
  - [ ] Other:

## Risk and Rollback

- Risk level: low
- Rollback plan: revert commit `90423ada111d6cd10ace823e11473061368b1d92`.

## Checklist

- [x] I have linked the relevant issue (required for `kind/bug` and `kind/feature`; see "Linked Issue" above)
- [x] I have added/updated tests for new behavior or bug fixes
- [x] I have considered API compatibility impact
- [x] I have updated docs if behavior/workflow changed
- [x] My commit messages follow project conventions (Conventional Commits, optional `[skip ci]` prefix)